### PR TITLE
Add Postgres-backed registry with SSL-aware pool, health/test endpoints, and schema bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 PORT=3000
 NODE_ENV=production
 VERIFY_BASE_URL=https://verify.qrv.network
+DATABASE_URL=postgres://username:password@hostname:5432/database
+DATABASE_SSL_ENABLED=true
+DATABASE_SSL_REJECT_UNAUTHORIZED=false

--- a/README.md
+++ b/README.md
@@ -8,28 +8,32 @@ The service is designed to be deployed at `https://api.qrv.network` and to gener
 
 - Create QR-V verification records with secure crypto-generated IDs
 - Verify stored records through a public lookup endpoint
-- Health monitoring endpoint for uptime checks and deployment probes
+- PostgreSQL-backed registry persistence with managed-SSL support
+- Automatic schema bootstrap for `qr_objects`, `qr_certificates`, and `qr_audit_log`
+- Health monitoring and database probe endpoints for uptime checks and deployment diagnostics
 - Environment-based configuration with `.env`
-- In-memory registry for MVP deployment without database dependencies
 - ESM-based Node.js project structure with separated routes, controllers, services, and utilities
 
 ## Project Structure
 
 ```text
 qrv-api/
-├── server.js
-├── routes/
-│   ├── records.js
-│   └── verify.js
 ├── controllers/
 │   ├── recordsController.js
 │   └── verifyController.js
+├── routes/
+│   ├── records.js
+│   └── verify.js
+├── scripts/
+│   └── init-db.js
 ├── services/
+│   ├── databaseService.js
 │   └── registryService.js
 ├── utils/
 │   └── idGenerator.js
 ├── .env.example
 ├── package.json
+├── server.js
 └── README.md
 ```
 
@@ -37,12 +41,14 @@ qrv-api/
 
 - Node.js 18 or newer
 - npm 9 or newer
+- PostgreSQL 13 or newer
 
 ## Installation
 
 ```bash
 npm install
 cp .env.example .env
+npm run db:init
 npm run dev
 ```
 
@@ -50,6 +56,7 @@ For production:
 
 ```bash
 npm install --omit=dev
+npm run db:init
 npm start
 ```
 
@@ -61,19 +68,52 @@ Create a `.env` file based on `.env.example`.
 PORT=3000
 NODE_ENV=production
 VERIFY_BASE_URL=https://verify.qrv.network
+DATABASE_URL=postgres://username:password@hostname:5432/database
+DATABASE_SSL_ENABLED=true
+DATABASE_SSL_REJECT_UNAUTHORIZED=false
 ```
+
+### Database configuration notes
+
+- Set **one** canonical `DATABASE_URL` value for your Postgres instance.
+- Do **not** append SSL query parameters such as `sslmode` or `sslrootcert` to `DATABASE_URL`; the application strips them so the pool-level SSL config remains authoritative.
+- `DATABASE_SSL_REJECT_UNAUTHORIZED=false` is useful for managed Postgres providers that require SSL but present a certificate chain that is not locally trusted.
 
 ## API Endpoints
 
 ### GET `/health`
 
-Health check endpoint.
+Health check endpoint with database connectivity status.
+
+**Healthy response**
+
+```json
+{
+  "ok": true,
+  "database": "connected",
+  "time": "2026-03-19T00:00:00.000Z"
+}
+```
+
+**Database unavailable response**
+
+```json
+{
+  "ok": false,
+  "database": "unconfigured",
+  "reason": "DATABASE_URL is not configured."
+}
+```
+
+### GET `/test-db`
+
+Runs `SELECT NOW()` against the configured PostgreSQL database.
 
 **Response**
 
 ```json
 {
-  "ok": true
+  "time": "2026-03-19T00:00:00.000Z"
 }
 ```
 
@@ -129,12 +169,41 @@ Verifies whether a record exists.
 }
 ```
 
+**Registry unavailable response**
+
+```json
+{
+  "status": "UNAVAILABLE",
+  "reason": "Registry not reachable. Please try again later."
+}
+```
+
+## Database bootstrap and migrations
+
+Run the schema bootstrap script before the first deployment and whenever you need to ensure the required tables exist:
+
+```bash
+npm run db:init
+```
+
+The bootstrap creates these tables if they do not exist already:
+
+- `qr_objects`
+- `qr_certificates`
+- `qr_audit_log`
+
 ## Example cURL Requests
 
 ### Health Check
 
 ```bash
 curl -X GET http://localhost:3000/health
+```
+
+### Database Probe
+
+```bash
+curl -X GET http://localhost:3000/test-db
 ```
 
 ### Create Record
@@ -155,19 +224,23 @@ curl -X POST http://localhost:3000/records \
 curl -X GET http://localhost:3000/verify/QRV-a1b2c3d4e5f6
 ```
 
-## Deployment Instructions (Hostinger Node Setup)
+## Deployment Instructions (Hostinger / Vercel / managed Node)
 
-1. Create a new Node.js application in Hostinger hPanel.
+1. Create or open your Node.js application in your hosting control panel.
 2. Set the application root to the repository directory.
-3. Upload the project files or connect the GitHub repository.
-4. Set the startup file to `server.js`.
-5. Configure environment variables in Hostinger:
-   - `PORT=3000` or the port assigned by Hostinger
+3. Upload the project files or connect the Git repository.
+4. Configure environment variables in the hosting dashboard:
+   - `PORT=3000` or the provider-assigned port
    - `NODE_ENV=production`
    - `VERIFY_BASE_URL=https://verify.qrv.network`
-6. Run `npm install --omit=dev` on the server.
-7. Start or restart the Node.js application from hPanel.
-8. Confirm the API is live by visiting `https://api.qrv.network/health`.
+   - `DATABASE_URL=postgres://username:password@hostname:5432/database`
+   - `DATABASE_SSL_ENABLED=true`
+   - `DATABASE_SSL_REJECT_UNAUTHORIZED=false` when required by your provider
+5. Run `npm install --omit=dev` on the server.
+6. Run `npm run db:init` to create the required database tables.
+7. Start or restart the Node.js application.
+8. Confirm the API is live by visiting `https://api.qrv.network/health` and `https://api.qrv.network/test-db`.
+9. Scan a QR-V ID and confirm the verification endpoint returns a verification payload instead of a `503`.
 
 ## Domain Mapping
 
@@ -178,9 +251,9 @@ Point `api.qrv.network` to the Hostinger application and ensure reverse proxy or
 
 ## Operational Notes
 
-- Records are stored in memory only for the MVP version.
-- Restarting the Node.js process clears all created verification records.
-- The API does not require any database connection and will run immediately after installation.
+- Records are stored in PostgreSQL instead of process memory.
+- If the database connection is unavailable, the API returns a structured `503` response with `status: "UNAVAILABLE"`.
+- Verification and creation requests append audit events to `qr_audit_log`.
 
 ## License
 

--- a/controllers/recordsController.js
+++ b/controllers/recordsController.js
@@ -2,34 +2,38 @@ import { createRecord } from '../services/registryService.js';
 
 const requiredFields = ['assetName', 'issuer', 'description'];
 
-export const createRecordHandler = (req, res) => {
-  const payload = req.body ?? {};
-  const missingFields = requiredFields.filter((field) => {
-    const value = payload[field];
-    return typeof value !== 'string' || value.trim().length === 0;
-  });
-
-  if (missingFields.length > 0) {
-    return res.status(400).json({
-      success: false,
-      error: 'Invalid request body.',
-      missingFields,
+export const createRecordHandler = async (req, res, next) => {
+  try {
+    const payload = req.body ?? {};
+    const missingFields = requiredFields.filter((field) => {
+      const value = payload[field];
+      return typeof value !== 'string' || value.trim().length === 0;
     });
+
+    if (missingFields.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid request body.',
+        missingFields,
+      });
+    }
+
+    const record = await createRecord({
+      assetName: payload.assetName.trim(),
+      issuer: payload.issuer.trim(),
+      description: payload.description.trim(),
+    });
+
+    const verifyBaseUrl = process.env.VERIFY_BASE_URL || 'https://verify.qrv.network';
+
+    console.log(`Created verification record ${record.id} for asset "${record.assetName}".`);
+
+    return res.status(201).json({
+      success: true,
+      id: record.id,
+      verifyUrl: `${verifyBaseUrl}/${record.id}`,
+    });
+  } catch (error) {
+    return next(error);
   }
-
-  const record = createRecord({
-    assetName: payload.assetName.trim(),
-    issuer: payload.issuer.trim(),
-    description: payload.description.trim(),
-  });
-
-  const verifyBaseUrl = process.env.VERIFY_BASE_URL || 'https://verify.qrv.network';
-
-  console.log(`Created verification record ${record.id} for asset \"${record.assetName}\".`);
-
-  return res.status(201).json({
-    success: true,
-    id: record.id,
-    verifyUrl: `${verifyBaseUrl}/${record.id}`,
-  });
 };

--- a/controllers/verifyController.js
+++ b/controllers/verifyController.js
@@ -1,20 +1,24 @@
 import { getRecordById } from '../services/registryService.js';
 
-export const verifyRecordHandler = (req, res) => {
-  const { id } = req.params;
-  const record = getRecordById(id);
+export const verifyRecordHandler = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const record = await getRecordById(id);
 
-  if (!record) {
-    console.warn(`Verification requested for unknown record ${id}.`);
-    return res.status(404).json({
-      status: 'NOT_FOUND',
+    if (!record) {
+      console.warn(`Verification requested for unknown record ${id}.`);
+      return res.status(404).json({
+        status: 'NOT_FOUND',
+      });
+    }
+
+    console.log(`Verification successful for record ${id}.`);
+
+    return res.status(200).json({
+      status: 'VERIFIED',
+      record,
     });
+  } catch (error) {
+    return next(error);
   }
-
-  console.log(`Verification successful for record ${id}.`);
-
-  return res.status(200).json({
-    status: 'VERIFIED',
-    record,
-  });
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "db:init": "node scripts/init-db.js"
   },
   "keywords": [
     "qrv",
@@ -19,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "pg": "^8.13.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1,0 +1,19 @@
+import dotenv from 'dotenv';
+import { closePool, isDatabaseConfigured } from '../services/databaseService.js';
+import { initializeRegistrySchema } from '../services/registryService.js';
+
+dotenv.config();
+
+try {
+  if (!isDatabaseConfigured()) {
+    throw new Error('DATABASE_URL is not configured.');
+  }
+
+  await initializeRegistrySchema();
+  console.log('Database schema is ready.');
+} catch (error) {
+  console.error('Failed to initialize database schema:', error);
+  process.exitCode = 1;
+} finally {
+  await closePool();
+}

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ import dotenv from 'dotenv';
 import express from 'express';
 import recordsRouter from './routes/records.js';
 import verifyRouter from './routes/verify.js';
+import { closePool, isDatabaseConfigured, testDatabaseConnection } from './services/databaseService.js';
+import { initializeRegistrySchema } from './services/registryService.js';
 
 dotenv.config();
 
@@ -16,8 +18,35 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/health', (_req, res) => {
-  res.status(200).json({ ok: true });
+app.get('/health', async (_req, res, next) => {
+  try {
+    if (!isDatabaseConfigured()) {
+      return res.status(503).json({
+        ok: false,
+        database: 'unconfigured',
+        reason: 'DATABASE_URL is not configured.',
+      });
+    }
+
+    const result = await testDatabaseConnection();
+
+    return res.status(200).json({
+      ok: true,
+      database: 'connected',
+      time: result.now instanceof Date ? result.now.toISOString() : result.now,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+app.get('/test-db', async (_req, res, next) => {
+  try {
+    const result = await testDatabaseConnection();
+    return res.status(200).json({ time: result.now instanceof Date ? result.now.toISOString() : result.now });
+  } catch (error) {
+    return next(error);
+  }
 });
 
 app.use('/records', recordsRouter);
@@ -32,14 +61,50 @@ app.use((req, res) => {
 
 app.use((err, _req, res, _next) => {
   console.error('Unhandled application error:', err);
-  res.status(500).json({
+
+  if (['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'DB_NOT_CONFIGURED'].includes(err.code)) {
+    return res.status(503).json({
+      status: 'UNAVAILABLE',
+      reason: err.code === 'DB_NOT_CONFIGURED'
+        ? 'Registry database is not configured. Set DATABASE_URL and try again.'
+        : 'Registry not reachable. Please try again later.',
+    });
+  }
+
+  return res.status(500).json({
     success: false,
     error: 'Internal server error.',
   });
 });
 
-app.listen(port, host, () => {
-  console.log(`QR-V Verification API listening on http://${host}:${port}`);
-  console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`Verify base URL: ${process.env.VERIFY_BASE_URL || 'https://verify.qrv.network'}`);
-});
+const startServer = async () => {
+  try {
+    if (isDatabaseConfigured()) {
+      await initializeRegistrySchema();
+    } else {
+      console.warn('DATABASE_URL is not configured. Database-backed routes will return a 503 until it is set.');
+    }
+
+    const server = app.listen(port, host, () => {
+      console.log(`QR-V Verification API listening on http://${host}:${port}`);
+      console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+      console.log(`Verify base URL: ${process.env.VERIFY_BASE_URL || 'https://verify.qrv.network'}`);
+    });
+
+    const shutdown = async () => {
+      server.close(async () => {
+        await closePool();
+        process.exit(0);
+      });
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  } catch (error) {
+    console.error('Failed to start application:', error);
+    await closePool();
+    process.exit(1);
+  }
+};
+
+await startServer();

--- a/services/databaseService.js
+++ b/services/databaseService.js
@@ -1,0 +1,115 @@
+import { Pool } from 'pg';
+
+const DEFAULT_DATABASE_SSL_REJECT_UNAUTHORIZED = false;
+const SSL_QUERY_PARAMS = [
+  'sslmode',
+  'sslcert',
+  'sslkey',
+  'sslrootcert',
+  'sslca',
+  'sslcrl',
+];
+
+let pool;
+let sanitizedDatabaseUrl;
+
+const getRawDatabaseUrl = () => process.env.DATABASE_URL || process.env.POSTGRES_URL || '';
+
+const shouldUseSsl = () => {
+  const value = process.env.DATABASE_SSL_ENABLED;
+
+  if (typeof value === 'string') {
+    return value.toLowerCase() !== 'false';
+  }
+
+  return true;
+};
+
+const shouldRejectUnauthorized = () => {
+  const value = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED;
+
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  }
+
+  return DEFAULT_DATABASE_SSL_REJECT_UNAUTHORIZED;
+};
+
+const sanitizeConnectionString = (connectionString) => {
+  if (!connectionString) {
+    return '';
+  }
+
+  const url = new URL(connectionString);
+  let removedSslParameters = false;
+
+  for (const key of SSL_QUERY_PARAMS) {
+    if (url.searchParams.has(key)) {
+      removedSslParameters = true;
+      url.searchParams.delete(key);
+    }
+  }
+
+  if (removedSslParameters) {
+    console.warn('Removed SSL query parameters from DATABASE_URL so explicit pool SSL settings can be applied.');
+  }
+
+  return url.toString();
+};
+
+export const getDatabaseUrl = () => {
+  if (!sanitizedDatabaseUrl) {
+    sanitizedDatabaseUrl = sanitizeConnectionString(getRawDatabaseUrl());
+  }
+
+  return sanitizedDatabaseUrl;
+};
+
+export const isDatabaseConfigured = () => Boolean(getDatabaseUrl());
+
+export const getPool = () => {
+  if (!isDatabaseConfigured()) {
+    return null;
+  }
+
+  if (!pool) {
+    pool = new Pool({
+      connectionString: getDatabaseUrl(),
+      ssl: shouldUseSsl()
+        ? {
+            rejectUnauthorized: shouldRejectUnauthorized(),
+          }
+        : false,
+    });
+
+    pool.on('error', (error) => {
+      console.error('Unexpected Postgres pool error:', error);
+    });
+  }
+
+  return pool;
+};
+
+export const query = async (text, params = []) => {
+  const dbPool = getPool();
+
+  if (!dbPool) {
+    const error = new Error('DATABASE_URL is not configured.');
+    error.code = 'DB_NOT_CONFIGURED';
+    throw error;
+  }
+
+  return dbPool.query(text, params);
+};
+
+export const testDatabaseConnection = async () => {
+  const result = await query('SELECT NOW() AS now');
+  return result.rows[0];
+};
+
+export const closePool = async () => {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+};

--- a/services/registryService.js
+++ b/services/registryService.js
@@ -1,22 +1,96 @@
 import { generateRecordId } from '../utils/idGenerator.js';
+import { query } from './databaseService.js';
 
-const registry = {};
+const CREATE_TABLE_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS qr_objects (
+    id TEXT PRIMARY KEY,
+    asset_name TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'valid',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`,
+  `CREATE TABLE IF NOT EXISTS qr_certificates (
+    id SERIAL PRIMARY KEY,
+    object_id TEXT NOT NULL REFERENCES qr_objects(id) ON DELETE CASCADE,
+    certificate_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`,
+  `CREATE TABLE IF NOT EXISTS qr_audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    object_id TEXT REFERENCES qr_objects(id) ON DELETE SET NULL,
+    event_type TEXT NOT NULL,
+    event_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`,
+];
 
-export const createRecord = ({ assetName, issuer, description }) => {
-  const id = generateRecordId();
-  const record = {
-    id,
-    assetName,
-    issuer,
-    description,
-    status: 'valid',
-    createdAt: new Date().toISOString(),
+let schemaInitialized = false;
+
+const mapRowToRecord = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    assetName: row.asset_name,
+    issuer: row.issuer,
+    description: row.description,
+    status: row.status,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
   };
-
-  registry[id] = record;
-  return record;
 };
 
-export const getRecordById = (id) => registry[id] ?? null;
+export const initializeRegistrySchema = async () => {
+  if (schemaInitialized) {
+    return;
+  }
 
-export const getRegistrySnapshot = () => ({ ...registry });
+  for (const statement of CREATE_TABLE_STATEMENTS) {
+    await query(statement);
+  }
+
+  schemaInitialized = true;
+};
+
+export const createRecord = async ({ assetName, issuer, description }) => {
+  await initializeRegistrySchema();
+
+  const id = generateRecordId();
+  const result = await query(
+    `INSERT INTO qr_objects (id, asset_name, issuer, description)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, asset_name, issuer, description, status, created_at`,
+    [id, assetName, issuer, description],
+  );
+
+  await query(
+    `INSERT INTO qr_audit_log (object_id, event_type, event_payload)
+     VALUES ($1, $2, $3::jsonb)`,
+    [id, 'record_created', JSON.stringify({ assetName, issuer })],
+  );
+
+  return mapRowToRecord(result.rows[0]);
+};
+
+export const getRecordById = async (id) => {
+  await initializeRegistrySchema();
+
+  const result = await query(
+    `SELECT id, asset_name, issuer, description, status, created_at
+     FROM qr_objects
+     WHERE id = $1`,
+    [id],
+  );
+
+  if (result.rows[0]) {
+    await query(
+      `INSERT INTO qr_audit_log (object_id, event_type, event_payload)
+       VALUES ($1, $2, $3::jsonb)`,
+      [id, 'record_verified', JSON.stringify({ verifiedAt: new Date().toISOString() })],
+    );
+  }
+
+  return mapRowToRecord(result.rows[0]);
+};


### PR DESCRIPTION
### Motivation

- Replace the fragile in-memory registry with a persistent Postgres-backed registry so verification records survive restarts and deployments.
- Fix common DB connectivity failures by sanitizing `DATABASE_URL` and applying explicit SSL options for managed Postgres providers.
- Provide machine-readable health and probe endpoints and clearer 503 responses so outages are easier to diagnose and handle.

### Description

- Add `services/databaseService.js` which reads and sanitizes `DATABASE_URL`, strips SSL query params, and creates a `pg` `Pool` with configurable `ssl` and `rejectUnauthorized` behavior.
- Replace the in-memory registry with `services/registryService.js` that bootstraps schema for `qr_objects`, `qr_certificates`, and `qr_audit_log`, persists records, and writes audit events.
- Update controllers (`controllers/recordsController.js` and `controllers/verifyController.js`) to call the async DB-backed service and propagate errors to the centralized error handler.
- Enhance `server.js` with `/health` and `/test-db` endpoints, startup schema initialization when `DATABASE_URL` is present, graceful pool shutdown, and structured `503` JSON responses for DB outage/error codes.
- Add `scripts/init-db.js`, a `db:init` npm script, add `pg` to `package.json`, and update `README.md` and `.env.example` with DB configuration and usage notes.

### Testing

- Ran static checks with `node --check` on `server.js`, `controllers/recordsController.js`, `controllers/verifyController.js`, `services/databaseService.js`, `services/registryService.js`, and `scripts/init-db.js`, and these checks succeeded.
- Attempted dependency installation with `npm install`, which failed in this environment due to a `403 Forbidden` from the npm registry so runtime dependency installation and a live server start could not be executed here.
- The new `db:init` bootstrap script was added (`npm run db:init`) for schema initialization and is included in CI/deployment recommendations for running prior to first use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc1d6b924832da361d06e9f7bf631)