### PR TITLE
Prefer NEXT_PUBLIC_API_URL for API base URL and update docs/views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 PORT=3000
-API_BASE_URL=https://api.qrv.network
+NEXT_PUBLIC_API_URL=https://api.qrv.network
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ QR Scan → verify.qrv.network → api.qrv.network → registry → response →
 
 1. A user scans a QR code or opens a verification URL such as `/QRV-123456789`.
 2. The portal sanitizes the QRVID and validates its format server-side.
-3. The verification service requests `https://api.qrv.network/verify/:qrvid`.
+3. The verification service requests `GET {NEXT_PUBLIC_API_URL}/verify/:qrvid`.
 4. The portal normalizes the response payload and status.
 5. The result page displays the verification state, issuer, record type, subject, timestamp, and truncated hash when available.
 6. If the upstream API times out or becomes unreachable, the portal retries once and then renders a deterministic unavailable state.
@@ -94,7 +94,7 @@ Copy `.env.example` to `.env` and configure as needed:
 
 ```env
 PORT=3000
-API_BASE_URL=https://api.qrv.network
+NEXT_PUBLIC_API_URL=https://api.qrv.network
 NODE_ENV=development
 ```
 
@@ -129,7 +129,7 @@ Open `http://localhost:3000`.
 1. Provision a Node.js 18+ runtime.
 2. Set environment variables:
    - `PORT`
-   - `API_BASE_URL=https://api.qrv.network`
+   - `NEXT_PUBLIC_API_URL=https://api.qrv.network` (or `API_BASE_URL` for legacy compatibility)
    - `NODE_ENV=production`
 3. Install dependencies with `npm install --omit=dev`.
 4. Start the service with `npm start`.
@@ -149,7 +149,7 @@ docker run --rm -p 3000:3000 --env-file .env qrv-verify-portal
 
 - Client input is sanitized and validated before use.
 - The portal never connects directly to a database.
-- `api.qrv.network` is the only verification data source.
+- `api.qrv.network` is the verification data source for this portal, configured via `NEXT_PUBLIC_API_URL`.
 - API timeouts trigger a single retry before showing an unavailable state.
 - The service logs verification lookups for simple operational analytics.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,14 +2,14 @@
 
 ## Purpose
 
-The QR-V™ Verification Portal is the public verification resolution interface for `verify.qrv.network`. It accepts QRVIDs, resolves them through `api.qrv.network`, and renders deterministic verification output for end users.
+The QR-V™ Verification Portal is the public verification resolution interface for `verify.qrv.network`. It accepts QRVIDs, resolves them through the external verification API configured via `NEXT_PUBLIC_API_URL`, and renders deterministic verification output for end users.
 
 ## Request flow
 
 1. User lands on `/` and submits a QRVID, or arrives directly at `/:qrvid`.
 2. Express routes the request to the verification controller.
 3. The controller sanitizes the QRVID and calls `verifyQRVID(qrvid)`.
-4. The verification service performs an upstream API call to `GET /verify/:qrvid`.
+4. The verification service performs an upstream API call to `GET /verify/:qrvid` on the configured verification service.
 5. The service normalizes the response into a view-friendly model.
 6. Server-rendered HTML template modules render the final response with status badge and metadata.
 

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const host = '0.0.0.0';
 const server = app.listen(port, host, () => {
   console.log(`QR-V Verification Portal listening on http://${host}:${port}`);
   console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`API base URL: ${process.env.API_BASE_URL || 'https://api.qrv.network'}`);
+  console.log(`API base URL: ${process.env.NEXT_PUBLIC_API_URL || process.env.API_BASE_URL || 'https://api.qrv.network'}`);
 });
 
 const shutdown = (signal) => {

--- a/src/services/verificationService.js
+++ b/src/services/verificationService.js
@@ -65,8 +65,13 @@ const buildViewModel = (qrvid, payload, fallbackMessage) => {
   };
 };
 
+const getApiBaseUrl = () =>
+  process.env.NEXT_PUBLIC_API_URL
+  || process.env.API_BASE_URL
+  || DEFAULT_API_BASE_URL;
+
 const fetchVerification = async (qrvid) => {
-  const apiBaseUrl = process.env.API_BASE_URL || DEFAULT_API_BASE_URL;
+  const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl.replace(/\/$/, '')}/verify/${encodeURIComponent(qrvid)}`;
 
   console.log(`[analytics] verification_lookup qrvid=${qrvid} url=${url}`);

--- a/src/views/indexView.js
+++ b/src/views/indexView.js
@@ -8,7 +8,7 @@ export const renderIndexView = ({ pageTitle, qrvid }) => renderLayout({
       <p class="section-label">Verification Resolution Interface</p>
       <h2>Resolve a QRVID</h2>
       <p class="supporting-copy">
-        Enter a QR-V identifier to verify the latest registry-backed status from <code>api.qrv.network</code>.
+        Enter a QR-V identifier to verify the latest registry-backed status from the verification API.
       </p>
     </div>
 


### PR DESCRIPTION
### Motivation
- Standardize and expose the verification API base URL using `NEXT_PUBLIC_API_URL` while retaining legacy `API_BASE_URL` compatibility.
- Make runtime logging and documentation reflect the configurable verification API endpoint rather than hardcoding `api.qrv.network`.
- Clarify UI copy to avoid embedding the upstream hostname and emphasize the configured verification API.

### Description
- Replace `.env` example variable `API_BASE_URL` with `NEXT_PUBLIC_API_URL` in `.env.example` and update README references to prefer `NEXT_PUBLIC_API_URL` while noting legacy compatibility with `API_BASE_URL`.
- Add `getApiBaseUrl()` helper in `src/services/verificationService.js` and use it to resolve the API base URL from `NEXT_PUBLIC_API_URL`, falling back to `API_BASE_URL` or the default.
- Update `server.js` startup logging to print the resolved API base URL using `process.env.NEXT_PUBLIC_API_URL` with a fallback to `process.env.API_BASE_URL`.
- Update documentation in `docs/architecture.md` and UI copy in `src/views/indexView.js` to reference the configured verification API rather than the hardcoded hostname.

### Testing
- Ran the repository check script via `npm run check`, which completed successfully.
- Executed the existing automated test suite (unit/integration) and linters, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c064b013a8832d81875aefca3d85cd)