### PR TITLE
Add Enterprise Theme Engine v1.1 — modular WordPress theme scaffold

### DIFF
--- a/enterprise-theme-v1-1/assets/css/app.css
+++ b/enterprise-theme-v1-1/assets/css/app.css
@@ -1,0 +1,16 @@
+.og-header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+#og-lead-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+#og-lead-form label {
+  display: grid;
+  gap: 0.25rem;
+}

--- a/enterprise-theme-v1-1/assets/js/app.js
+++ b/enterprise-theme-v1-1/assets/js/app.js
@@ -1,0 +1,24 @@
+(function () {
+  const form = document.getElementById('og-lead-form');
+  if (!form || !window.ogLeadForm) {
+    return;
+  }
+
+  form.addEventListener('submit', async function (event) {
+    event.preventDefault();
+    const payload = new FormData(form);
+    payload.append('action', 'og_submit_lead');
+    payload.append('nonce', ogLeadForm.nonce);
+
+    const response = await fetch(ogLeadForm.ajaxUrl, {
+      method: 'POST',
+      body: payload,
+      credentials: 'same-origin'
+    });
+
+    const data = await response.json();
+    if (data.success) {
+      form.reset();
+    }
+  });
+})();

--- a/enterprise-theme-v1-1/config/defaults.php
+++ b/enterprise-theme-v1-1/config/defaults.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Theme default configuration.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_default_config(): array {
+	return array(
+		'theme_mode'         => 'services',
+		'layout'             => 'default',
+		'primary_color'      => '#0f172a',
+		'accent_color'       => '#1d4ed8',
+		'heading_font'       => 'Inter, sans-serif',
+		'body_font'          => 'Inter, sans-serif',
+		'brand_radius'       => '12px',
+		'organization_name'  => get_bloginfo( 'name' ),
+		'organization_url'   => home_url( '/' ),
+		'organization_logo'  => '',
+		'feature_dashboard'  => true,
+		'feature_hero'       => true,
+		'service_cta_label'  => __( 'Request Consultation', 'enterprise-theme-v1-1' ),
+		'projects_per_page'  => 12,
+		'services_per_page'  => 12,
+	);
+}

--- a/enterprise-theme-v1-1/footer.php
+++ b/enterprise-theme-v1-1/footer.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Main footer.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?>
+<?php get_template_part( 'template-parts/footer', 'default', array( 'state' => og_build_theme_state() ) ); ?>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/enterprise-theme-v1-1/functions.php
+++ b/enterprise-theme-v1-1/functions.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Theme bootstrap.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+$og_modules = array(
+	'/config/defaults.php',
+	'/inc/options.php',
+	'/inc/setup.php',
+	'/inc/enqueue.php',
+	'/inc/customizer.php',
+	'/inc/layout.php',
+	'/inc/hooks.php',
+	'/inc/security.php',
+	'/inc/performance.php',
+	'/inc/schema.php',
+	'/inc/cpt-projects.php',
+	'/inc/cpt-services.php',
+	'/inc/cpt-leads.php',
+	'/inc/taxonomies.php',
+	'/inc/ajax-handlers.php',
+	'/inc/mode-switch.php',
+);
+
+foreach ( $og_modules as $og_module ) {
+	require_once get_template_directory() . $og_module;
+}

--- a/enterprise-theme-v1-1/header.php
+++ b/enterprise-theme-v1-1/header.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Main header.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<?php get_template_part( 'template-parts/header', 'default', array( 'state' => og_build_theme_state() ) ); ?>

--- a/enterprise-theme-v1-1/inc/ajax-handlers.php
+++ b/enterprise-theme-v1-1/inc/ajax-handlers.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * AJAX handlers.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_handle_lead_submission(): void {
+	check_ajax_referer( 'og_submit_lead', 'nonce' );
+
+	$fields = array(
+		'name'         => sanitize_text_field( wp_unslash( $_POST['name'] ?? '' ) ),
+		'email'        => og_sanitize_email_strict( (string) wp_unslash( $_POST['email'] ?? '' ) ),
+		'company'      => sanitize_text_field( wp_unslash( $_POST['company'] ?? '' ) ),
+		'budget'       => sanitize_text_field( wp_unslash( $_POST['budget'] ?? '' ) ),
+		'timeline'     => sanitize_text_field( wp_unslash( $_POST['timeline'] ?? '' ) ),
+		'project_type' => sanitize_text_field( wp_unslash( $_POST['project_type'] ?? '' ) ),
+		'message'      => sanitize_textarea_field( wp_unslash( $_POST['message'] ?? '' ) ),
+	);
+
+	if ( empty( $fields['name'] ) || empty( $fields['email'] ) ) {
+		wp_send_json_error( array( 'message' => __( 'Name and email are required.', 'enterprise-theme-v1-1' ) ), 422 );
+	}
+
+	$lead_id = wp_insert_post(
+		array(
+			'post_type'    => 'lead',
+			'post_status'  => 'private',
+			'post_title'   => sprintf( 'Lead: %s - %s', $fields['name'], gmdate( 'Y-m-d H:i:s' ) ),
+			'post_content' => wp_json_encode( $fields, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+		),
+		true
+	);
+
+	if ( is_wp_error( $lead_id ) ) {
+		wp_send_json_error( array( 'message' => __( 'Unable to save lead.', 'enterprise-theme-v1-1' ) ), 500 );
+	}
+
+	foreach ( $fields as $key => $value ) {
+		update_post_meta( $lead_id, '_og_lead_' . $key, $value );
+	}
+
+	wp_send_json_success( array( 'message' => __( 'Lead submitted successfully.', 'enterprise-theme-v1-1' ) ) );
+}
+add_action( 'wp_ajax_og_submit_lead', 'og_handle_lead_submission' );
+add_action( 'wp_ajax_nopriv_og_submit_lead', 'og_handle_lead_submission' );

--- a/enterprise-theme-v1-1/inc/cpt-leads.php
+++ b/enterprise-theme-v1-1/inc/cpt-leads.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Leads CPT.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_register_cpt_leads(): void {
+	register_post_type(
+		'lead',
+		array(
+			'labels'          => array(
+				'name'          => __( 'Leads', 'enterprise-theme-v1-1' ),
+				'singular_name' => __( 'Lead', 'enterprise-theme-v1-1' ),
+			),
+			'public'          => false,
+			'publicly_queryable' => false,
+			'exclude_from_search' => true,
+			'show_ui'         => true,
+			'show_in_menu'    => true,
+			'show_in_rest'    => false,
+			'has_archive'     => false,
+			'menu_icon'       => 'dashicons-id',
+			'supports'        => array( 'title', 'editor' ),
+			'capability_type' => 'post',
+		)
+	);
+}
+add_action( 'init', 'og_register_cpt_leads' );

--- a/enterprise-theme-v1-1/inc/cpt-projects.php
+++ b/enterprise-theme-v1-1/inc/cpt-projects.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Projects CPT.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_register_cpt_projects(): void {
+	register_post_type(
+		'project',
+		array(
+			'labels'       => array(
+				'name'          => __( 'Projects', 'enterprise-theme-v1-1' ),
+				'singular_name' => __( 'Project', 'enterprise-theme-v1-1' ),
+			),
+			'public'       => true,
+			'has_archive'  => true,
+			'menu_icon'    => 'dashicons-portfolio',
+			'show_in_rest' => true,
+			'supports'     => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+			'rewrite'      => array( 'slug' => 'projects' ),
+		)
+	);
+}
+add_action( 'init', 'og_register_cpt_projects' );

--- a/enterprise-theme-v1-1/inc/cpt-services.php
+++ b/enterprise-theme-v1-1/inc/cpt-services.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Services CPT.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_register_cpt_services(): void {
+	register_post_type(
+		'service',
+		array(
+			'labels'       => array(
+				'name'          => __( 'Services', 'enterprise-theme-v1-1' ),
+				'singular_name' => __( 'Service', 'enterprise-theme-v1-1' ),
+			),
+			'public'       => true,
+			'has_archive'  => true,
+			'menu_icon'    => 'dashicons-hammer',
+			'show_in_rest' => true,
+			'supports'     => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+			'rewrite'      => array( 'slug' => 'services' ),
+		)
+	);
+}
+add_action( 'init', 'og_register_cpt_services' );

--- a/enterprise-theme-v1-1/inc/customizer.php
+++ b/enterprise-theme-v1-1/inc/customizer.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Customizer controls.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_customize_register( WP_Customize_Manager $wp_customize ): void {
+	$wp_customize->add_section(
+		'og_branding',
+		array(
+			'title'    => __( 'Brand Tokens', 'enterprise-theme-v1-1' ),
+			'priority' => 30,
+		)
+	);
+
+	$settings = array(
+		'primary_color' => array( 'label' => __( 'Primary Color', 'enterprise-theme-v1-1' ), 'type' => 'color' ),
+		'accent_color'  => array( 'label' => __( 'Accent Color', 'enterprise-theme-v1-1' ), 'type' => 'color' ),
+		'heading_font'  => array( 'label' => __( 'Heading Font', 'enterprise-theme-v1-1' ), 'type' => 'text' ),
+		'body_font'     => array( 'label' => __( 'Body Font', 'enterprise-theme-v1-1' ), 'type' => 'text' ),
+		'organization_logo' => array( 'label' => __( 'Logo', 'enterprise-theme-v1-1' ), 'type' => 'media' ),
+		'theme_mode'    => array( 'label' => __( 'Theme Mode', 'enterprise-theme-v1-1' ), 'type' => 'select' ),
+	);
+
+	foreach ( $settings as $key => $setting ) {
+		$wp_customize->add_setting(
+			$key,
+			array(
+				'default'           => og_default_config()[ $key ] ?? '',
+				'transport'         => 'refresh',
+				'sanitize_callback' => 'sanitize_text_field',
+			)
+		);
+
+		if ( 'color' === $setting['type'] ) {
+			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, $key, array( 'label' => $setting['label'], 'section' => 'og_branding', 'settings' => $key ) ) );
+		} elseif ( 'media' === $setting['type'] ) {
+			$wp_customize->add_control( new WP_Customize_Media_Control( $wp_customize, $key, array( 'label' => $setting['label'], 'section' => 'og_branding', 'mime_type' => 'image' ) ) );
+		} elseif ( 'select' === $setting['type'] ) {
+			$wp_customize->add_control( $key, array( 'label' => $setting['label'], 'section' => 'og_branding', 'type' => 'select', 'choices' => array( 'services' => 'Services', 'platform' => 'Platform', 'commerce' => 'Commerce' ) ) );
+		} else {
+			$wp_customize->add_control( $key, array( 'label' => $setting['label'], 'section' => 'og_branding', 'type' => 'text' ) );
+		}
+	}
+}
+add_action( 'customize_register', 'og_customize_register' );

--- a/enterprise-theme-v1-1/inc/enqueue.php
+++ b/enterprise-theme-v1-1/inc/enqueue.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Asset loading.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_enqueue_assets(): void {
+	$theme = wp_get_theme();
+
+	wp_enqueue_style(
+		'og-theme-style',
+		get_stylesheet_uri(),
+		array(),
+		$theme->get( 'Version' )
+	);
+
+	wp_enqueue_style(
+		'og-theme-app',
+		get_template_directory_uri() . '/assets/css/app.css',
+		array( 'og-theme-style' ),
+		$theme->get( 'Version' )
+	);
+
+	wp_enqueue_script(
+		'og-theme-app',
+		get_template_directory_uri() . '/assets/js/app.js',
+		array(),
+		$theme->get( 'Version' ),
+		array( 'strategy' => 'defer', 'in_footer' => true )
+	);
+
+	wp_localize_script(
+		'og-theme-app',
+		'ogLeadForm',
+		array(
+			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			'nonce'   => wp_create_nonce( 'og_submit_lead' ),
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'og_enqueue_assets' );

--- a/enterprise-theme-v1-1/inc/hooks.php
+++ b/enterprise-theme-v1-1/inc/hooks.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Theme hooks.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_body_class( array $classes ): array {
+	$state     = og_build_theme_state();
+	$classes[] = 'og-mode-' . sanitize_html_class( $state['mode'] );
+	$classes[] = 'og-layout-' . sanitize_html_class( $state['layout'] );
+	return $classes;
+}
+add_filter( 'body_class', 'og_body_class' );

--- a/enterprise-theme-v1-1/inc/layout.php
+++ b/enterprise-theme-v1-1/inc/layout.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * State and layout helpers.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_build_theme_state(): array {
+	$mode = (string) og_get( 'theme_mode' );
+
+	return array(
+		'mode'          => in_array( $mode, array( 'services', 'platform', 'commerce' ), true ) ? $mode : 'services',
+		'layout'        => (string) og_get( 'layout' ),
+		'brand_tokens'  => array(
+			'primary'      => (string) og_get( 'primary_color' ),
+			'accent'       => (string) og_get( 'accent_color' ),
+			'radius'       => (string) og_get( 'brand_radius' ),
+			'font_heading' => (string) og_get( 'heading_font' ),
+			'font_body'    => (string) og_get( 'body_font' ),
+		),
+		'feature_flags' => array(
+			'dashboard' => (bool) og_get( 'feature_dashboard' ),
+			'hero'      => (bool) og_get( 'feature_hero' ),
+		),
+		'variants'      => array(
+			'cta_label' => (string) og_get( 'service_cta_label' ),
+		),
+	);
+}
+
+function og_print_brand_tokens(): void {
+	$state = og_build_theme_state();
+	$css   = sprintf(
+		':root{--primary:%1$s;--accent:%2$s;--radius:%3$s;--font-heading:%4$s;--font-body:%5$s;}',
+		esc_attr( $state['brand_tokens']['primary'] ),
+		esc_attr( $state['brand_tokens']['accent'] ),
+		esc_attr( $state['brand_tokens']['radius'] ),
+		esc_attr( $state['brand_tokens']['font_heading'] ),
+		esc_attr( $state['brand_tokens']['font_body'] )
+	);
+	echo '<style id="og-brand-tokens">' . wp_strip_all_tags( $css ) . '</style>';
+}
+add_action( 'wp_head', 'og_print_brand_tokens', 20 );
+
+
+function og_get_dashboard_metrics(): array {
+	return array(
+		'services' => (int) ( wp_count_posts( 'service' )->publish ?? 0 ),
+		'projects' => (int) ( wp_count_posts( 'project' )->publish ?? 0 ),
+	);
+}

--- a/enterprise-theme-v1-1/inc/mode-switch.php
+++ b/enterprise-theme-v1-1/inc/mode-switch.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Mode switching behavior.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_is_commerce_mode(): bool {
+	return 'commerce' === og_build_theme_state()['mode'];
+}
+
+function og_mode_filter_nav_items( string $items, stdClass $args ): string {
+	if ( 'primary' !== $args->theme_location ) {
+		return $items;
+	}
+
+	if ( ! og_is_commerce_mode() && function_exists( 'wc_get_page_permalink' ) ) {
+		$shop_url = wc_get_page_permalink( 'shop' );
+		if ( $shop_url ) {
+			$items = str_replace( 'href="' . esc_url( $shop_url ) . '"', 'href="#" style="display:none"', $items );
+		}
+	}
+
+	if ( og_build_theme_state()['feature_flags']['dashboard'] ) {
+		$items .= '<li class="menu-item menu-item-dashboard"><a href="' . esc_url( home_url( '/dashboard/' ) ) . '">' . esc_html__( 'Dashboard', 'enterprise-theme-v1-1' ) . '</a></li>';
+	}
+
+	return $items;
+}
+add_filter( 'wp_nav_menu_items', 'og_mode_filter_nav_items', 10, 2 );
+
+function og_disable_woocommerce_templates(): void {
+	if ( function_exists( 'is_woocommerce' ) && ! og_is_commerce_mode() && ( is_woocommerce() || is_cart() || is_checkout() ) ) {
+		wp_safe_redirect( home_url( '/' ) );
+		exit;
+	}
+}
+add_action( 'template_redirect', 'og_disable_woocommerce_templates' );

--- a/enterprise-theme-v1-1/inc/options.php
+++ b/enterprise-theme-v1-1/inc/options.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Config resolution and option access.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_validate_option( string $key, $value ) {
+	$enum_map = array(
+		'theme_mode' => array( 'services', 'platform', 'commerce' ),
+		'layout'     => array( 'default', 'full', 'dashboard' ),
+	);
+
+	if ( isset( $enum_map[ $key ] ) && ! in_array( $value, $enum_map[ $key ], true ) ) {
+		return null;
+	}
+
+	switch ( $key ) {
+		case 'primary_color':
+		case 'accent_color':
+			$color = sanitize_hex_color( (string) $value );
+			return $color ?: null;
+		case 'heading_font':
+		case 'body_font':
+			return sanitize_text_field( (string) $value );
+		case 'brand_radius':
+			return preg_match( '/^\d+(px|rem|em|%)$/', (string) $value ) ? (string) $value : null;
+		case 'feature_dashboard':
+		case 'feature_hero':
+			return rest_sanitize_boolean( $value );
+		case 'projects_per_page':
+		case 'services_per_page':
+			return max( 1, absint( $value ) );
+		case 'organization_url':
+			return esc_url_raw( (string) $value );
+		case 'organization_logo':
+			return absint( $value );
+		default:
+			return sanitize_text_field( (string) $value );
+	}
+}
+
+function og_get( string $key ) {
+	$post_id  = get_queried_object_id();
+	$defaults = og_default_config();
+	$value    = null;
+
+	if ( $post_id ) {
+		$meta_key = '_og_' . $key;
+		$meta     = get_post_meta( $post_id, $meta_key, true );
+		if ( '' !== $meta && null !== $meta ) {
+			$value = $meta;
+		}
+	}
+
+	if ( null === $value ) {
+		$theme_mod = get_theme_mod( $key, null );
+		if ( null !== $theme_mod ) {
+			$value = $theme_mod;
+		}
+	}
+
+	if ( null === $value && array_key_exists( $key, $defaults ) ) {
+		$value = $defaults[ $key ];
+	}
+
+	$validated = og_validate_option( $key, $value );
+	if ( null === $validated && array_key_exists( $key, $defaults ) ) {
+		$validated = og_validate_option( $key, $defaults[ $key ] );
+	}
+
+	return $validated;
+}

--- a/enterprise-theme-v1-1/inc/performance.php
+++ b/enterprise-theme-v1-1/inc/performance.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Performance optimization.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+remove_action( 'wp_print_styles', 'print_emoji_styles' );
+remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+remove_action( 'admin_print_styles', 'print_emoji_styles' );
+remove_action( 'wp_head', 'wp_generator' );
+
+function og_cleanup_wp_block_library(): void {
+	if ( ! is_admin() ) {
+		wp_dequeue_style( 'wp-block-library' );
+		wp_dequeue_style( 'wp-block-library-theme' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'og_cleanup_wp_block_library', 100 );

--- a/enterprise-theme-v1-1/inc/schema.php
+++ b/enterprise-theme-v1-1/inc/schema.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * JSON-LD schema output.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_schema_organization(): array {
+	$logo_id = (int) og_get( 'organization_logo' );
+	$logo    = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
+
+	return array(
+		'@context' => 'https://schema.org',
+		'@type'    => 'Organization',
+		'name'     => (string) og_get( 'organization_name' ),
+		'url'      => (string) og_get( 'organization_url' ),
+		'logo'     => $logo ? esc_url( $logo ) : null,
+	);
+}
+
+function og_schema_service(): ?array {
+	if ( ! is_singular( 'service' ) ) {
+		return null;
+	}
+
+	return array(
+		'@context'    => 'https://schema.org',
+		'@type'       => 'Service',
+		'name'        => get_the_title(),
+		'description' => wp_strip_all_tags( (string) get_the_excerpt() ),
+		'provider'    => array(
+			'@type' => 'Organization',
+			'name'  => (string) og_get( 'organization_name' ),
+		),
+	);
+}
+
+function og_output_schema(): void {
+	$payloads = array_filter( array( og_schema_organization(), og_schema_service() ) );
+	foreach ( $payloads as $payload ) {
+		echo '<script type="application/ld+json">' . wp_json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</script>';
+	}
+}
+add_action( 'wp_head', 'og_output_schema', 30 );

--- a/enterprise-theme-v1-1/inc/security.php
+++ b/enterprise-theme-v1-1/inc/security.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Security hardening.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_disable_file_editor(): void {
+	if ( ! defined( 'DISALLOW_FILE_EDIT' ) ) {
+		define( 'DISALLOW_FILE_EDIT', true );
+	}
+}
+add_action( 'after_setup_theme', 'og_disable_file_editor' );
+
+function og_sanitize_email_strict( string $email ): string {
+	$sanitized = sanitize_email( $email );
+	return is_email( $sanitized ) ? $sanitized : '';
+}

--- a/enterprise-theme-v1-1/inc/setup.php
+++ b/enterprise-theme-v1-1/inc/setup.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Theme setup.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_theme_setup(): void {
+	add_theme_support( 'title-tag' );
+	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'html5', array( 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption', 'style', 'script' ) );
+	add_theme_support( 'woocommerce' );
+
+	register_nav_menus(
+		array(
+			'primary' => __( 'Primary Menu', 'enterprise-theme-v1-1' ),
+			'footer'  => __( 'Footer Menu', 'enterprise-theme-v1-1' ),
+		)
+	);
+}
+add_action( 'after_setup_theme', 'og_theme_setup' );

--- a/enterprise-theme-v1-1/inc/taxonomies.php
+++ b/enterprise-theme-v1-1/inc/taxonomies.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Taxonomy registrations.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+declare(strict_types=1);
+
+function og_register_taxonomies(): void {
+	register_taxonomy(
+		'capability',
+		array( 'service', 'project' ),
+		array(
+			'label'        => __( 'Capabilities', 'enterprise-theme-v1-1' ),
+			'public'       => true,
+			'show_in_rest' => true,
+			'hierarchical' => true,
+		)
+	);
+
+	register_taxonomy(
+		'industry',
+		array( 'project' ),
+		array(
+			'label'        => __( 'Industries', 'enterprise-theme-v1-1' ),
+			'public'       => true,
+			'show_in_rest' => true,
+			'hierarchical' => true,
+		)
+	);
+
+	register_taxonomy(
+		'service_type',
+		array( 'service' ),
+		array(
+			'label'        => __( 'Service Types', 'enterprise-theme-v1-1' ),
+			'public'       => true,
+			'show_in_rest' => true,
+			'hierarchical' => true,
+		)
+	);
+}
+add_action( 'init', 'og_register_taxonomies' );

--- a/enterprise-theme-v1-1/index.php
+++ b/enterprise-theme-v1-1/index.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Default template.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+?>
+<main class="og-container">
+	<?php if ( have_posts() ) : ?>
+		<?php while ( have_posts() ) : the_post(); ?>
+			<article <?php post_class( 'og-card' ); ?>>
+				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+				<?php the_excerpt(); ?>
+			</article>
+		<?php endwhile; ?>
+	<?php else : ?>
+		<p><?php esc_html_e( 'No content found.', 'enterprise-theme-v1-1' ); ?></p>
+	<?php endif; ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/page-templates/page-contact.php
+++ b/enterprise-theme-v1-1/page-templates/page-contact.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Template Name: Contact / Lead Intake
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+?>
+<main class="og-container">
+	<?php get_template_part( 'template-parts/lead', 'form' ); ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/page-templates/page-dashboard.php
+++ b/enterprise-theme-v1-1/page-templates/page-dashboard.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Template Name: Dashboard
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+?>
+<main class="og-container">
+	<?php get_template_part( 'template-parts/dashboard', 'metrics', array( 'metrics' => og_get_dashboard_metrics() ) ); ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/page-templates/page-landing.php
+++ b/enterprise-theme-v1-1/page-templates/page-landing.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Template Name: Landing
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+$state = og_build_theme_state();
+?>
+<main class="og-container">
+	<section class="og-card">
+		<h1><?php the_title(); ?></h1>
+		<p><?php echo esc_html( $state['variants']['cta_label'] ); ?></p>
+		<a class="og-button" href="<?php echo esc_url( home_url( '/contact/' ) ); ?>"><?php echo esc_html( $state['variants']['cta_label'] ); ?></a>
+	</section>
+	<?php the_content(); ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/page-templates/page-projects.php
+++ b/enterprise-theme-v1-1/page-templates/page-projects.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Template Name: Projects Listing
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+$projects = new WP_Query(
+	array(
+		'post_type'      => 'project',
+		'posts_per_page' => (int) og_get( 'projects_per_page' ),
+	)
+);
+?>
+<main class="og-container">
+	<?php if ( $projects->have_posts() ) : ?>
+		<?php while ( $projects->have_posts() ) : $projects->the_post(); ?>
+			<?php get_template_part( 'template-parts/project', 'card' ); ?>
+		<?php endwhile; ?>
+		<?php wp_reset_postdata(); ?>
+	<?php endif; ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/page-templates/page-services.php
+++ b/enterprise-theme-v1-1/page-templates/page-services.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Template Name: Services Listing
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+get_header();
+$services = new WP_Query(
+	array(
+		'post_type'      => 'service',
+		'posts_per_page' => (int) og_get( 'services_per_page' ),
+	)
+);
+?>
+<main class="og-container">
+	<?php if ( $services->have_posts() ) : ?>
+		<?php while ( $services->have_posts() ) : $services->the_post(); ?>
+			<?php get_template_part( 'template-parts/service', 'card' ); ?>
+		<?php endwhile; ?>
+		<?php wp_reset_postdata(); ?>
+	<?php endif; ?>
+</main>
+<?php
+get_footer();

--- a/enterprise-theme-v1-1/style.css
+++ b/enterprise-theme-v1-1/style.css
@@ -1,0 +1,61 @@
+/*
+Theme Name: Enterprise Theme Engine v1.1
+Theme URI: https://example.com/enterprise-theme-v1-1
+Author: Platform Engineering
+Description: Modular white-label professional services engine with configurable modes.
+Version: 1.1.0
+Requires at least: 6.4
+Tested up to: 6.5
+Requires PHP: 8.0
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: enterprise-theme-v1-1
+*/
+
+:root {
+  --primary: #0f172a;
+  --accent: #1d4ed8;
+  --radius: 12px;
+  --font-heading: "Inter", sans-serif;
+  --font-body: "Inter", sans-serif;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--primary);
+  margin: 0;
+}
+
+a {
+  color: var(--accent);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+}
+
+.og-container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.og-card {
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, #fff);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  background-color: #fff;
+}
+
+.og-button {
+  display: inline-block;
+  border-radius: var(--radius);
+  background-color: var(--accent);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+}

--- a/enterprise-theme-v1-1/template-parts/dashboard-metrics.php
+++ b/enterprise-theme-v1-1/template-parts/dashboard-metrics.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Dashboard metrics.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+$metrics = $args['metrics'] ?? array( 'services' => 0, 'projects' => 0 );
+?>
+<section class="og-card">
+	<h2><?php esc_html_e( 'Metrics', 'enterprise-theme-v1-1' ); ?></h2>
+	<ul>
+		<li><?php echo esc_html( sprintf( __( 'Services: %d', 'enterprise-theme-v1-1' ), (int) $metrics['services'] ) ); ?></li>
+		<li><?php echo esc_html( sprintf( __( 'Projects: %d', 'enterprise-theme-v1-1' ), (int) $metrics['projects'] ) ); ?></li>
+	</ul>
+</section>

--- a/enterprise-theme-v1-1/template-parts/footer-default.php
+++ b/enterprise-theme-v1-1/template-parts/footer-default.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Default footer part.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?>
+<footer class="og-container" role="contentinfo">
+	<nav aria-label="<?php esc_attr_e( 'Footer menu', 'enterprise-theme-v1-1' ); ?>">
+		<?php wp_nav_menu( array( 'theme_location' => 'footer', 'container' => false ) ); ?>
+	</nav>
+	<p><?php echo esc_html( get_bloginfo( 'name' ) ); ?></p>
+</footer>

--- a/enterprise-theme-v1-1/template-parts/header-default.php
+++ b/enterprise-theme-v1-1/template-parts/header-default.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Default header part.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+$state = $args['state'] ?? og_build_theme_state();
+?>
+<header class="og-container" role="banner">
+	<div class="og-header-bar">
+		<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
+		<nav aria-label="<?php esc_attr_e( 'Primary menu', 'enterprise-theme-v1-1' ); ?>">
+			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'container' => false ) ); ?>
+		</nav>
+	</div>
+	<?php if ( ! empty( $state['feature_flags']['hero'] ) ) : ?>
+		<?php get_template_part( 'template-parts/hero', 'dynamic', array( 'state' => $state ) ); ?>
+	<?php endif; ?>
+</header>

--- a/enterprise-theme-v1-1/template-parts/hero-dynamic.php
+++ b/enterprise-theme-v1-1/template-parts/hero-dynamic.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Hero block.
+ *
+ * @package enterprise-theme-v1-1
+ */
+
+$state = $args['state'] ?? og_build_theme_state();
+?>
+<section class="og-card">
+	<h1><?php echo esc_html( get_bloginfo( 'name' ) ); ?></h1>
+	<p><?php echo esc_html( ucfirst( $state['mode'] ) ); ?></p>
+</section>

--- a/enterprise-theme-v1-1/template-parts/lead-form.php
+++ b/enterprise-theme-v1-1/template-parts/lead-form.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Lead form.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?>
+<form id="og-lead-form" class="og-card" method="post">
+	<label><?php esc_html_e( 'Name', 'enterprise-theme-v1-1' ); ?><input type="text" name="name" required></label>
+	<label><?php esc_html_e( 'Email', 'enterprise-theme-v1-1' ); ?><input type="email" name="email" required></label>
+	<label><?php esc_html_e( 'Company', 'enterprise-theme-v1-1' ); ?><input type="text" name="company"></label>
+	<label><?php esc_html_e( 'Budget', 'enterprise-theme-v1-1' ); ?><input type="text" name="budget"></label>
+	<label><?php esc_html_e( 'Timeline', 'enterprise-theme-v1-1' ); ?><input type="text" name="timeline"></label>
+	<label><?php esc_html_e( 'Project Type', 'enterprise-theme-v1-1' ); ?><input type="text" name="project_type"></label>
+	<label><?php esc_html_e( 'Message', 'enterprise-theme-v1-1' ); ?><textarea name="message"></textarea></label>
+	<button class="og-button" type="submit"><?php esc_html_e( 'Submit', 'enterprise-theme-v1-1' ); ?></button>
+</form>

--- a/enterprise-theme-v1-1/template-parts/project-card.php
+++ b/enterprise-theme-v1-1/template-parts/project-card.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Project card.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?>
+<article <?php post_class( 'og-card og-project-card' ); ?>>
+	<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+	<?php if ( has_post_thumbnail() ) : ?>
+		<?php the_post_thumbnail( 'medium' ); ?>
+	<?php endif; ?>
+	<?php the_excerpt(); ?>
+</article>

--- a/enterprise-theme-v1-1/template-parts/service-card.php
+++ b/enterprise-theme-v1-1/template-parts/service-card.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Service card.
+ *
+ * @package enterprise-theme-v1-1
+ */
+?>
+<article <?php post_class( 'og-card og-service-card' ); ?>>
+	<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+	<?php if ( has_post_thumbnail() ) : ?>
+		<?php the_post_thumbnail( 'medium' ); ?>
+	<?php endif; ?>
+	<?php the_excerpt(); ?>
+</article>


### PR DESCRIPTION
### Motivation
- Provide a production-ready, modular white-label WordPress theme that enforces a Config → State → Render architecture for multi-client professional services sites. 
- Support CPT-driven content (Projects, Services), a private Leads CRM intake, and a customizable brand token system without hardcoding branding. 
- Allow mode switching (`services | platform | commerce`) with isolated WooCommerce behavior and performance/security hardening.

### Description
- Add a strict bootstrap in `functions.php` that only loads modular files under `inc/` and `config/` and implement `og_get()` for config resolution (Post Meta → Customizer → `/config/defaults.php`) with sanitization via `og_validate_option()`. 
- Implement theme state via `og_build_theme_state()` driving rendering, and inject white-label CSS variables via `og_print_brand_tokens()` (font, colors, radius) consumed by templates. 
- Register CPTs `project`, `service`, and private `lead`, register taxonomies `capability`, `industry`, `service_type`, and add a secure AJAX lead intake handler `og_handle_lead_submission()` that validates nonce, sanitizes input, stores a `lead` post and meta, and returns JSON. 
- Add Customizer controls for brand tokens and `theme_mode`, mode switcher logic that hides WooCommerce elements when not in `commerce` mode and appends a Dashboard menu item, JSON-LD outputs for Organization and Service pages, performance cleanup hooks (emoji/generator/block styles), and lightweight template parts that consume state and escape output. 
- Enqueue assets with `og_enqueue_assets()` including `assets/css/app.css` and deferred `assets/js/app.js` which is localized with `ajaxUrl` and a nonce for the lead form. 

### Testing
- Run PHP lint across all theme PHP files with `find enterprise-theme-v1-1 -name '*.php' -print0 | xargs -0 -n1 php -l`, which reported no syntax errors for every file. 
- Verified automated checks for file creation and basic content (asset files, page templates, and `style.css`) completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0283c910832da2a7a1934be57539)