### PR TITLE
Add public V1 endpoints and first-live issuance stack (registry, API, node, issuer UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,14 @@ Form handler that accepts a pasted QRVID and redirects to `/verify/:qrvid`.
 ### `POST /api/v1/records`
 Creates a V1 verification record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `issuer` or `admin`.
 
+### `POST /v1/records`
+Creates a minimal public V1 record without policy headers for first-live activation loops. Returns `qrv_id`, `status`, `hash`, and `verify_url`.
+
 ### `GET /api/v1/verify/:qrvid`
 Returns deterministic V1 statuses: `VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`.
+
+### `GET /v1/verify/:qrvid`
+Returns public verification JSON for activation/scan loops (including `status`, `issuer`, `recipient`, `certificateTitle`, and hash fields).
 
 ### `POST /api/v1/records/:qrvid/revoke`
 Revokes an existing record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `admin`.

--- a/docs/first-live-scan-checklist.md
+++ b/docs/first-live-scan-checklist.md
@@ -1,0 +1,31 @@
+# First live scan execution checklist
+
+Deployment order:
+
+1. Deploy `qrv-registry`.
+2. Deploy `qrv-api`.
+3. Test API directly.
+4. Deploy `qrv-node`.
+5. Test public verify page.
+6. Deploy `issuer-qrv`.
+7. Issue first live certificate.
+8. Scan QR.
+9. Confirm `VERIFIED` result.
+
+First live test record:
+
+- Issuer: `QR-V`
+- Record Type: `certificate`
+- Recipient: `Production Test`
+- Certificate Title: `System Validation Certificate`
+- Description: `First live end-to-end validation`
+- QRVID target: `QRV-CERT-000001`
+
+Final acceptance chain:
+
+1. Form submit succeeds.
+2. DB row exists.
+3. API verify returns JSON.
+4. Public verify page loads.
+5. QR code scans to that page.
+6. Page displays `VERIFIED`.

--- a/issuer-qrv/app.js
+++ b/issuer-qrv/app.js
@@ -1,0 +1,33 @@
+const API_BASE_URL = window.__CONFIG__?.API_BASE_URL || 'https://api.qrv.network';
+
+const form = document.getElementById('issue-form');
+const result = document.getElementById('result');
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const payload = Object.fromEntries(new FormData(form).entries());
+  const response = await fetch(`${API_BASE_URL.replace(/\/$/, '')}/registry/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    alert('Failed to issue certificate');
+    return;
+  }
+
+  const data = await response.json();
+  document.getElementById('qrvid').textContent = data.qrvid;
+  document.getElementById('hash').textContent = data.hash;
+
+  const verifyAnchor = document.getElementById('verifyUrl');
+  verifyAnchor.href = data.verifyUrl;
+  verifyAnchor.textContent = data.verifyUrl;
+
+  const qrImage = document.getElementById('qrImage');
+  qrImage.src = `https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(data.verifyUrl)}`;
+
+  result.hidden = false;
+});

--- a/issuer-qrv/index.html
+++ b/issuer-qrv/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Issuer QR-V</title>
+    <style>
+      body { font-family: Arial, sans-serif; max-width: 720px; margin: 2rem auto; }
+      label { display: block; margin-top: 0.8rem; }
+      input, textarea { width: 100%; padding: 0.5rem; }
+      button { margin-top: 1rem; padding: 0.6rem 1rem; }
+      #result { margin-top: 1.2rem; padding: 1rem; border: 1px solid #ddd; }
+      img { max-width: 220px; }
+    </style>
+  </head>
+  <body>
+    <h1>Issue First Live Certificate</h1>
+    <form id="issue-form">
+      <label>Issuer Name <input name="issuer" value="QR-V" required /></label>
+      <label>Record Type <input name="recordType" value="certificate" required /></label>
+      <label>Recipient Name <input name="recipientName" value="Production Test" required /></label>
+      <label>Certificate Title <input name="certificateTitle" value="System Validation Certificate" required /></label>
+      <label>Description <textarea name="description">First live end-to-end validation</textarea></label>
+      <button type="submit">Generate</button>
+    </form>
+
+    <section id="result" hidden>
+      <p><strong>QRVID:</strong> <span id="qrvid"></span></p>
+      <p><strong>Hash:</strong> <span id="hash"></span></p>
+      <p><strong>Verify URL:</strong> <a id="verifyUrl" target="_blank" rel="noreferrer"></a></p>
+      <img id="qrImage" alt="QR code" />
+    </section>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/qrv-api/.env.example
+++ b/qrv-api/.env.example
@@ -1,0 +1,6 @@
+PORT=4000
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/qrv
+VERIFY_BASE_URL=https://verify.qrv.network
+SIGNING_SECRET=replace-with-real-secret
+ISSUER_NAME=QR-V
+NODE_ENV=development

--- a/qrv-api/README.md
+++ b/qrv-api/README.md
@@ -1,0 +1,27 @@
+# qrv-api
+
+Live issuance and verification API backed by PostgreSQL.
+
+## Required env
+
+- `PORT`
+- `DATABASE_URL`
+- `VERIFY_BASE_URL`
+- `SIGNING_SECRET`
+- `ISSUER_NAME`
+- `NODE_ENV`
+
+## Endpoints
+
+- `GET /health` returns service status and DB readiness.
+- `POST /registry/create` creates live rows in `qr_objects`, `qr_certificates`, and `qr_audit_log`.
+- `GET /verify/:qrvid` joins issuer + certificate data and maps statuses to `VERIFIED | REVOKED | EXPIRED | NOT_FOUND`.
+- `POST /revoke` revokes a QRVID and writes an audit row.
+
+## Run
+
+```bash
+npm install express pg
+cp .env.example .env
+node server.js
+```

--- a/qrv-api/lib/db.js
+++ b/qrv-api/lib/db.js
@@ -1,0 +1,27 @@
+import pg from 'pg';
+
+const { Pool } = pg;
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required');
+}
+
+export const pool = new Pool({ connectionString: databaseUrl });
+
+export const query = (text, params = []) => pool.query(text, params);
+
+export const withTransaction = async (fn) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const value = await fn(client);
+    await client.query('COMMIT');
+    return value;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/qrv-api/lib/hash.js
+++ b/qrv-api/lib/hash.js
@@ -1,0 +1,34 @@
+import crypto from 'node:crypto';
+
+export const canonicalize = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((acc, key) => {
+        acc[key] = canonicalize(value[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+};
+
+export const sha256 = (payload) => {
+  const canonicalPayload = canonicalize(payload);
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonicalPayload))
+    .digest('hex');
+};
+
+export const sign = (payload, secret) => {
+  const canonicalPayload = canonicalize(payload);
+  return crypto
+    .createHmac('sha256', secret)
+    .update(JSON.stringify(canonicalPayload))
+    .digest('hex');
+};

--- a/qrv-api/server.js
+++ b/qrv-api/server.js
@@ -1,0 +1,216 @@
+import express from 'express';
+import { query, withTransaction } from './lib/db.js';
+import { sha256, sign } from './lib/hash.js';
+
+const app = express();
+app.use(express.json());
+
+const PORT = Number(process.env.PORT || 4000);
+const VERIFY_BASE_URL = process.env.VERIFY_BASE_URL || 'https://verify.qrv.network';
+const SIGNING_SECRET = process.env.SIGNING_SECRET || 'dev-secret';
+const ISSUER_NAME = process.env.ISSUER_NAME || 'QR-V';
+
+const buildQrvid = async (client) => {
+  const { rows } = await client.query(
+    "SELECT qrvid FROM qr_objects WHERE qrvid LIKE 'QRV-CERT-%' ORDER BY qrvid DESC LIMIT 1"
+  );
+
+  const last = rows[0]?.qrvid;
+  const nextNumber = last ? Number(last.replace('QRV-CERT-', '')) + 1 : 1;
+  return `QRV-CERT-${String(nextNumber).padStart(6, '0')}`;
+};
+
+const mapVerifyStatus = (status, expiresAt) => {
+  if (!status) return 'NOT_FOUND';
+  if (status.toLowerCase() === 'revoked') return 'REVOKED';
+  if (expiresAt && new Date(expiresAt).getTime() < Date.now()) return 'EXPIRED';
+  return 'VERIFIED';
+};
+
+app.get('/health', async (_req, res) => {
+  try {
+    await query('SELECT 1');
+    return res.json({ service: 'up', db: { ready: true } });
+  } catch {
+    return res.status(503).json({ service: 'up', db: { ready: false } });
+  }
+});
+
+app.post('/registry/create', async (req, res) => {
+  const { recordType, issuer, recipientName, certificateTitle, description } = req.body || {};
+
+  if (!recordType || !issuer || !recipientName || !certificateTitle) {
+    return res.status(400).json({
+      error: 'recordType, issuer, recipientName, and certificateTitle are required',
+    });
+  }
+
+  try {
+    const payload = await withTransaction(async (client) => {
+      const issuerCode = String(issuer).trim().toUpperCase();
+      const issuerName = issuer || ISSUER_NAME;
+
+      const issuerResult = await client.query(
+        `INSERT INTO qr_issuers (issuer_code, issuer_name, status)
+         VALUES ($1, $2, 'active')
+         ON CONFLICT (issuer_code)
+         DO UPDATE SET issuer_name = EXCLUDED.issuer_name
+         RETURNING id, issuer_name`,
+        [issuerCode, issuerName]
+      );
+
+      const qrvid = await buildQrvid(client);
+      const issuedAt = new Date().toISOString();
+      const canonicalPayload = {
+        qrvid,
+        recordType,
+        issuer: issuerName,
+        recipientName,
+        certificateTitle,
+        description: description || null,
+        issuedAt,
+      };
+
+      const hash = sha256(canonicalPayload);
+      const signature = sign(canonicalPayload, SIGNING_SECRET);
+
+      const objectResult = await client.query(
+        `INSERT INTO qr_objects
+          (qrvid, record_type, issuer_id, status, payload_hash, signature, issued_at, created_at, updated_at)
+         VALUES ($1, $2, $3, 'verified', $4, $5, $6, NOW(), NOW())
+         RETURNING id, qrvid, status, payload_hash, issued_at`,
+        [qrvid, recordType, issuerResult.rows[0].id, hash, signature, issuedAt]
+      );
+
+      await client.query(
+        `INSERT INTO qr_certificates
+          (qr_object_id, certificate_title, recipient_name, description, metadata_json)
+         VALUES ($1, $2, $3, $4, $5::jsonb)`,
+        [
+          objectResult.rows[0].id,
+          certificateTitle,
+          recipientName,
+          description || null,
+          JSON.stringify({ source: 'qrv-api', createdBy: 'registry/create' }),
+        ]
+      );
+
+      await client.query(
+        `INSERT INTO qr_audit_log (qr_object_id, event_type, event_data_json)
+         VALUES ($1, 'issued', $2::jsonb)`,
+        [
+          objectResult.rows[0].id,
+          JSON.stringify({
+            qrvid,
+            issuer: issuerName,
+            recordType,
+            recipientName,
+            certificateTitle,
+          }),
+        ]
+      );
+
+      return {
+        qrvid: objectResult.rows[0].qrvid,
+        status: objectResult.rows[0].status,
+        hash: objectResult.rows[0].payload_hash,
+        verifyUrl: `${VERIFY_BASE_URL.replace(/\/$/, '')}/${objectResult.rows[0].qrvid}`,
+      };
+    });
+
+    return res.status(201).json(payload);
+  } catch (error) {
+    console.error('create failed', error);
+    return res.status(500).json({ error: 'failed to create registry record' });
+  }
+});
+
+app.get('/verify/:qrvid', async (req, res) => {
+  try {
+    const { rows } = await query(
+      `SELECT
+        o.qrvid,
+        o.record_type,
+        o.status,
+        o.payload_hash,
+        o.issued_at,
+        o.expires_at,
+        i.issuer_name,
+        c.recipient_name,
+        c.certificate_title,
+        c.description
+      FROM qr_objects o
+      JOIN qr_issuers i ON i.id = o.issuer_id
+      LEFT JOIN qr_certificates c ON c.qr_object_id = o.id
+      WHERE o.qrvid = $1
+      LIMIT 1`,
+      [req.params.qrvid]
+    );
+
+    const row = rows[0];
+    if (!row) {
+      return res.status(404).json({ status: 'NOT_FOUND', qrvid: req.params.qrvid });
+    }
+
+    const status = mapVerifyStatus(row.status, row.expires_at);
+    return res.json({
+      status,
+      qrvid: row.qrvid,
+      type: row.record_type,
+      issuer: row.issuer_name,
+      recipient: row.recipient_name,
+      certificateTitle: row.certificate_title,
+      description: row.description,
+      hash: row.payload_hash,
+      issuedAt: row.issued_at,
+      expiresAt: row.expires_at,
+    });
+  } catch (error) {
+    console.error('verify failed', error);
+    return res.status(500).json({ error: 'failed to verify' });
+  }
+});
+
+app.post('/revoke', async (req, res) => {
+  const { qrvid, reason } = req.body || {};
+  if (!qrvid) {
+    return res.status(400).json({ error: 'qrvid is required' });
+  }
+
+  try {
+    const response = await withTransaction(async (client) => {
+      const updated = await client.query(
+        `UPDATE qr_objects
+         SET status = 'revoked', updated_at = NOW()
+         WHERE qrvid = $1
+         RETURNING id, qrvid, status`,
+        [qrvid]
+      );
+
+      if (!updated.rows[0]) {
+        return null;
+      }
+
+      await client.query(
+        `INSERT INTO qr_audit_log (qr_object_id, event_type, event_data_json)
+         VALUES ($1, 'revoked', $2::jsonb)`,
+        [updated.rows[0].id, JSON.stringify({ qrvid, reason: reason || null })]
+      );
+
+      return updated.rows[0];
+    });
+
+    if (!response) {
+      return res.status(404).json({ error: 'not found' });
+    }
+
+    return res.json(response);
+  } catch (error) {
+    console.error('revoke failed', error);
+    return res.status(500).json({ error: 'failed to revoke' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`qrv-api listening on ${PORT}`);
+});

--- a/qrv-node/.env.example
+++ b/qrv-node/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+API_BASE_URL=https://api.qrv.network

--- a/qrv-node/server.js
+++ b/qrv-node/server.js
@@ -1,0 +1,64 @@
+import express from 'express';
+
+const app = express();
+const PORT = Number(process.env.PORT || 3000);
+const API_BASE_URL = process.env.API_BASE_URL || 'https://api.qrv.network';
+
+const page = (model) => `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QR-V Verification</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+      .badge { padding: 0.4rem 0.7rem; border-radius: 6px; font-weight: 700; }
+      .VERIFIED { background: #daf5e4; color: #0f5132; }
+      .REVOKED, .EXPIRED, .NOT_FOUND { background: #fde2e2; color: #842029; }
+    </style>
+  </head>
+  <body>
+    <h1>QR-V Public Verification</h1>
+    <p><span class="badge ${model.status}">${model.status}</span></p>
+    <ul>
+      <li><strong>QRVID:</strong> ${model.qrvid ?? '-'}</li>
+      <li><strong>Type:</strong> ${model.type ?? '-'}</li>
+      <li><strong>Issuer:</strong> ${model.issuer ?? '-'}</li>
+      <li><strong>Recipient:</strong> ${model.recipient ?? '-'}</li>
+      <li><strong>Certificate Title:</strong> ${model.certificateTitle ?? '-'}</li>
+      <li><strong>Hash:</strong> ${model.hash ?? '-'}</li>
+      <li><strong>Issued At:</strong> ${model.issuedAt ?? '-'}</li>
+    </ul>
+  </body>
+</html>`;
+
+app.get('/:qrvid', async (req, res) => {
+  const { qrvid } = req.params;
+
+  if (!/^QRV-[A-Z]+-\d+$/.test(qrvid)) {
+    return res.status(400).send(page({ status: 'NOT_FOUND', qrvid }));
+  }
+
+  try {
+    const upstream = await fetch(`${API_BASE_URL.replace(/\/$/, '')}/verify/${encodeURIComponent(qrvid)}`);
+    const payload = await upstream.json();
+    const model = {
+      status: payload.status || 'NOT_FOUND',
+      qrvid: payload.qrvid || qrvid,
+      type: payload.type || payload.record_type,
+      issuer: payload.issuer,
+      recipient: payload.recipient,
+      certificateTitle: payload.certificateTitle,
+      hash: payload.hash,
+      issuedAt: payload.issuedAt,
+    };
+
+    return res.status(upstream.status).send(page(model));
+  } catch (error) {
+    return res.status(503).send(page({ status: 'NOT_FOUND', qrvid }));
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`qrv-node listening on ${PORT}`);
+});

--- a/qrv-node/views/verify.html
+++ b/qrv-node/views/verify.html
@@ -1,0 +1,1 @@
+<!-- Inline renderer is used by server.js for dynamic output. -->

--- a/qrv-registry/README.md
+++ b/qrv-registry/README.md
@@ -1,0 +1,26 @@
+# qrv-registry
+
+PostgreSQL schema and seed data for the QR-V first live scan milestone.
+
+## Files
+
+- `migrations/001_init.sql` - creates `qr_issuers`, `qr_objects`, `qr_certificates`, `qr_audit_log`.
+- `migrations/002_seed_first_certificate.sql` - seeds first live issuer/object/certificate/audit rows.
+
+## Apply steps
+
+```bash
+psql "$DATABASE_URL" -f migrations/001_init.sql
+psql "$DATABASE_URL" -f migrations/002_seed_first_certificate.sql
+```
+
+## Validation queries
+
+```sql
+SELECT COUNT(*) AS issuers FROM qr_issuers;
+SELECT COUNT(*) AS certificate_objects FROM qr_objects WHERE record_type = 'certificate';
+SELECT COUNT(*) AS certificate_rows FROM qr_certificates;
+SELECT COUNT(*) AS issuance_audit_rows FROM qr_audit_log WHERE event_type = 'issued';
+```
+
+Expected result for the initial seed: `1` row for each query above.

--- a/qrv-registry/migrations/001_init.sql
+++ b/qrv-registry/migrations/001_init.sql
@@ -1,0 +1,46 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS qr_issuers (
+  id BIGSERIAL PRIMARY KEY,
+  issuer_code TEXT NOT NULL UNIQUE,
+  issuer_name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS qr_objects (
+  id BIGSERIAL PRIMARY KEY,
+  qrvid TEXT NOT NULL UNIQUE,
+  record_type TEXT NOT NULL,
+  issuer_id BIGINT NOT NULL REFERENCES qr_issuers(id),
+  status TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  signature TEXT NOT NULL,
+  issued_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS qr_certificates (
+  id BIGSERIAL PRIMARY KEY,
+  qr_object_id BIGINT NOT NULL UNIQUE REFERENCES qr_objects(id) ON DELETE CASCADE,
+  certificate_title TEXT NOT NULL,
+  recipient_name TEXT NOT NULL,
+  description TEXT,
+  metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS qr_audit_log (
+  id BIGSERIAL PRIMARY KEY,
+  qr_object_id BIGINT NOT NULL REFERENCES qr_objects(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  event_data_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_qr_objects_issuer_id ON qr_objects(issuer_id);
+CREATE INDEX IF NOT EXISTS idx_qr_objects_status ON qr_objects(status);
+CREATE INDEX IF NOT EXISTS idx_qr_audit_log_object ON qr_audit_log(qr_object_id);
+
+COMMIT;

--- a/qrv-registry/migrations/002_seed_first_certificate.sql
+++ b/qrv-registry/migrations/002_seed_first_certificate.sql
@@ -1,0 +1,79 @@
+BEGIN;
+
+WITH issuer AS (
+  INSERT INTO qr_issuers (issuer_code, issuer_name, status)
+  VALUES ('QR-V', 'QR-V', 'active')
+  ON CONFLICT (issuer_code)
+  DO UPDATE SET issuer_name = EXCLUDED.issuer_name
+  RETURNING id
+),
+obj AS (
+  INSERT INTO qr_objects (
+    qrvid,
+    record_type,
+    issuer_id,
+    status,
+    payload_hash,
+    signature,
+    issued_at,
+    expires_at
+  )
+  SELECT
+    'QRV-CERT-000001',
+    'certificate',
+    issuer.id,
+    'verified',
+    'sha256:seeded-first-live-certificate',
+    'hmac:seeded-first-live-certificate',
+    NOW(),
+    NULL
+  FROM issuer
+  ON CONFLICT (qrvid)
+  DO UPDATE SET
+    status = EXCLUDED.status,
+    updated_at = NOW()
+  RETURNING id
+),
+cert AS (
+  INSERT INTO qr_certificates (
+    qr_object_id,
+    certificate_title,
+    recipient_name,
+    description,
+    metadata_json
+  )
+  SELECT
+    obj.id,
+    'System Validation Certificate',
+    'Production Test',
+    'First live end-to-end validation',
+    jsonb_build_object('seed', true)
+  FROM obj
+  ON CONFLICT (qr_object_id)
+  DO UPDATE SET
+    certificate_title = EXCLUDED.certificate_title,
+    recipient_name = EXCLUDED.recipient_name,
+    description = EXCLUDED.description,
+    metadata_json = EXCLUDED.metadata_json
+  RETURNING qr_object_id
+)
+INSERT INTO qr_audit_log (qr_object_id, event_type, event_data_json)
+SELECT
+  cert.qr_object_id,
+  'issued',
+  jsonb_build_object(
+    'qrvid', 'QRV-CERT-000001',
+    'issuer', 'QR-V',
+    'recordType', 'certificate',
+    'recipientName', 'Production Test',
+    'certificateTitle', 'System Validation Certificate'
+  )
+FROM cert
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM qr_audit_log a
+  WHERE a.qr_object_id = cert.qr_object_id
+    AND a.event_type = 'issued'
+);
+
+COMMIT;

--- a/src/app.js
+++ b/src/app.js
@@ -3,11 +3,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import portalRoutes from './routes/index.js';
 import { renderResultView } from './views/resultView.js';
+import { seedDefaultRecord } from './services/recordStore.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
+seedDefaultRecord();
 
 app.disable('x-powered-by');
 

--- a/src/controllers/api/v1Controller.js
+++ b/src/controllers/api/v1Controller.js
@@ -1,4 +1,10 @@
-import { createRecord, revokeRecord, verifyRecord } from '../../services/recordStore.js';
+import {
+  createPublicRecord,
+  createRecord,
+  revokeRecord,
+  verifyPublicRecord,
+  verifyRecord,
+} from '../../services/recordStore.js';
 import { logAuditEvent } from '../../services/auditLogService.js';
 
 const actorRole = (req) => req.header('x-actor-role') || 'anonymous';
@@ -41,6 +47,27 @@ export const postRevokeRecord = (req, res) => {
 export const getVerifyRecord = (req, res) => {
   const qrvid = req.params.qrvid;
   const result = verifyRecord(qrvid);
+
+  if (!result.ok) {
+    return res.status(result.statusCode).json(result.error);
+  }
+
+  return res.status(result.statusCode).json(result.verification);
+};
+
+export const postPublicRecord = (req, res) => {
+  const result = createPublicRecord(req.body || {});
+
+  if (!result.ok) {
+    return res.status(result.statusCode).json(result.error);
+  }
+
+  return res.status(result.statusCode).json(result.record);
+};
+
+export const getPublicVerifyRecord = (req, res) => {
+  const qrvid = req.params.qrvid;
+  const result = verifyPublicRecord(qrvid);
 
   if (!result.ok) {
     return res.status(result.statusCode).json(result.error);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import verificationRoutes from './verificationRoutes.js';
 import v1Routes from './api/v1Routes.js';
+import publicV1Routes from './publicV1Routes.js';
 import { renderLandingPage, renderVerificationResult } from '../controllers/verificationController.js';
 import { healthHandler } from '../controllers/healthController.js';
 
@@ -8,6 +9,7 @@ const router = Router();
 
 router.get('/health', healthHandler);
 router.use('/api/v1', v1Routes);
+router.use('/v1', publicV1Routes);
 router.get('/', renderLandingPage);
 router.use('/verify', verificationRoutes);
 router.get('/:qrvid', renderVerificationResult);

--- a/src/routes/publicV1Routes.js
+++ b/src/routes/publicV1Routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getPublicVerifyRecord, postPublicRecord } from '../controllers/api/v1Controller.js';
+
+const router = Router();
+
+router.post('/records', postPublicRecord);
+router.get('/verify/:qrvid', getPublicVerifyRecord);
+
+export default router;

--- a/src/services/recordStore.js
+++ b/src/services/recordStore.js
@@ -1,6 +1,8 @@
 import { validators } from './schemaRegistry.js';
+import crypto from 'node:crypto';
 
 const records = new Map();
+let sequence = 1;
 
 const nowUtc = () => new Date().toISOString();
 
@@ -12,7 +14,21 @@ const normalizeRecord = (record) => ({
   expires_at_utc: record.expires_at_utc || null,
   revoked_at_utc: record.revoked_at_utc || null,
   metadata_hash: record.metadata_hash,
+  record_type: record.record_type || 'certificate',
+  certificate_title: record.certificate_title || null,
+  description: record.description || null,
 });
+
+const nextQrvid = () => {
+  const value = `QRV-CERT-${String(sequence).padStart(6, '0')}`;
+  sequence += 1;
+  return value;
+};
+
+const hashPayload = (payload) => crypto
+  .createHash('sha256')
+  .update(JSON.stringify(payload))
+  .digest('hex');
 
 const getStatus = (record) => {
   if (!record) {
@@ -54,6 +70,75 @@ export const createRecord = (payload) => {
 
   records.set(record.qrvid, record);
   return { ok: true, record: normalizeRecord(record) };
+};
+
+export const createPublicRecord = (payload) => {
+  const recordType = payload?.recordType || 'certificate';
+  const issuer = payload?.issuer || 'QR-V';
+  const recipientName = payload?.recipientName || payload?.subject || 'Production Test';
+  const certificateTitle = payload?.certificateTitle || 'System Validation Certificate';
+  const description = payload?.description || null;
+  const qrvid = payload?.qrvid || payload?.qrv_id || nextQrvid();
+
+  if (!/^QRV-[A-Z0-9-]{6,64}$/i.test(qrvid)) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: {
+        error: 'Invalid QRVID format',
+        code: 'INVALID_QRVID',
+        details: ['qrvid must match QRV format'],
+        timestamp_utc: nowUtc(),
+      },
+    };
+  }
+
+  if (records.has(qrvid)) {
+    return {
+      ok: false,
+      statusCode: 409,
+      error: {
+        error: 'Record already exists',
+        code: 'QRVID_CONFLICT',
+        details: [`qrvid ${qrvid} already exists`],
+        timestamp_utc: nowUtc(),
+      },
+    };
+  }
+
+  const issuedAt = nowUtc();
+  const metadataHash = hashPayload({ qrvid, recordType, issuer, recipientName, certificateTitle, description, issuedAt });
+
+  const record = {
+    qrvid,
+    issuer,
+    subject: recipientName,
+    issued_at_utc: issuedAt,
+    expires_at_utc: null,
+    metadata_hash: metadataHash,
+    record_type: recordType,
+    certificate_title: certificateTitle,
+    description,
+    status: 'ACTIVE',
+    revoked_at_utc: null,
+    created_at_utc: issuedAt,
+    updated_at_utc: issuedAt,
+  };
+
+  records.set(qrvid, record);
+
+  return {
+    ok: true,
+    statusCode: 201,
+    record: {
+      qrv_id: qrvid,
+      qrvid,
+      status: 'VERIFIED',
+      hash: metadataHash,
+      verify_url: `/verify/${encodeURIComponent(qrvid)}`,
+      issued_at_utc: issuedAt,
+    },
+  };
 };
 
 export const revokeRecord = (qrvid, revokePayload) => {
@@ -123,6 +208,48 @@ export const verifyRecord = (qrvid) => {
   };
 };
 
+export const verifyPublicRecord = (qrvid) => {
+  const result = verifyRecord(qrvid);
+  if (!result.ok) {
+    return result;
+  }
+
+  const record = records.get(qrvid);
+  return {
+    ok: true,
+    statusCode: result.statusCode,
+    verification: {
+      qrv_id: qrvid,
+      qrvid,
+      status: result.verification.status,
+      type: record?.record_type || 'certificate',
+      issuer: result.verification.issuer,
+      recipient: result.verification.subject,
+      certificateTitle: record?.certificate_title || null,
+      description: record?.description || null,
+      hash: result.verification.metadata_hash,
+      issuedAt: result.verification.issued_at_utc,
+      checkedAt: result.verification.checked_at_utc,
+    },
+  };
+};
+
+export const seedDefaultRecord = () => {
+  if (records.has('QRV-CERT-000001')) {
+    return;
+  }
+
+  createPublicRecord({
+    qrvid: 'QRV-CERT-000001',
+    recordType: 'certificate',
+    issuer: 'QR-V',
+    recipientName: 'Production Test',
+    certificateTitle: 'System Validation Certificate',
+    description: 'First live end-to-end validation',
+  });
+};
+
 export const resetRecordStore = () => {
   records.clear();
+  sequence = 1;
 };

--- a/test/enforcement.test.js
+++ b/test/enforcement.test.js
@@ -136,3 +136,28 @@ test('invalid revoke payload is rejected with structured 4xx error', async () =>
   assert.equal(response.status, 400);
   assert.equal(response.body.code, 'INVALID_REQUEST');
 });
+
+test('public v1 endpoints create and verify records without policy headers', async () => {
+  const createResponse = await jsonRequest({
+    method: 'POST',
+    path: '/v1/records',
+    body: {
+      issuer: 'QR-V',
+      recordType: 'certificate',
+      recipientName: 'Production Test',
+      certificateTitle: 'System Validation Certificate',
+      description: 'First live end-to-end validation',
+      qrvid: 'QRV-CERT-000001',
+    },
+  });
+
+  assert.equal(createResponse.status, 201);
+  assert.equal(createResponse.body.qrv_id, 'QRV-CERT-000001');
+  assert.equal(createResponse.body.status, 'VERIFIED');
+
+  const verifyResponse = await jsonRequest({ method: 'GET', path: '/v1/verify/QRV-CERT-000001' });
+  assert.equal(verifyResponse.status, 200);
+  assert.equal(verifyResponse.body.status, 'VERIFIED');
+  assert.equal(verifyResponse.body.issuer, 'QR-V');
+  assert.equal(verifyResponse.body.recipient, 'Production Test');
+});


### PR DESCRIPTION
### Motivation

- Provide minimal public endpoints and tooling to support the "first live" issuance and verification flow without policy headers so a seeded production test certificate can be activated and scanned.
- Offer a simple API, node renderer, and issuer UI to perform end-to-end validation for the initial live QRVID activation.

### Description

- Added new public V1 endpoints `POST /v1/records` and `GET /v1/verify/:qrvid` with lightweight creation and verification logic implemented in `src/services/recordStore.js`, `src/controllers/api/v1Controller.js`, and `src/routes/publicV1Routes.js`.
- Seed and in-memory helpers: implemented `createPublicRecord`, `verifyPublicRecord`, `seedDefaultRecord`, `nextQrvid`, and payload hashing in `src/services/recordStore.js`, and call `seedDefaultRecord()` at app startup in `src/app.js` to populate `QRV-CERT-000001`.
- Added a self-contained `qrv-api` service (Express + PostgreSQL) with DB helpers (`qrv-api/lib/db.js`), hashing/signing (`qrv-api/lib/hash.js`), server endpoints (`qrv-api/server.js`), and an example `.env` and README for running a live-backed API.
- Added a simple public renderer `qrv-node` (server and view), an issuer static UI (`issuer-qrv/index.html` + `app.js`), and `qrv-registry` PostgreSQL migrations and a seed migration to provision the first live certificate row.
- Updated main `README.md` to document the new public `POST /v1/records` and `GET /v1/verify/:qrvid` routes and added a `docs/first-live-scan-checklist.md` describing deployment/order and the test record.

### Testing

- Ran the automated test suite (`npm test`) including the updated `test/enforcement.test.js` which exercises the new public endpoints; the tests completed successfully and the new public creation and verification test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d317e2c5ec832d933328db93cee66f)