### PR TITLE
feat: use canonical onegodian-api for Onegodian Time display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 PORT=3000
 NEXT_PUBLIC_API_URL=https://api.qrv.network
 NODE_ENV=development
+
+ONEGODIAN_API_BASE_URL=https://onegodian-api.onrender.com

--- a/README.md
+++ b/README.md
@@ -195,3 +195,24 @@ git push
 ## License
 
 MIT
+
+
+## Canonical Onegodian Time display
+
+The landing page (`/`) is a public display/documentation layer for Onegodian Time and fetches canonical values from `onegodian-api` through local proxy endpoints.
+
+### Onegodian proxy endpoints
+
+- `GET /api/v1/ot/current` – canonical current Onegodian timestamp payload.
+- `GET /api/v1/ot/convert?iso_utc=2026-04-11T12:00:00Z` – canonical conversion payload.
+
+`iso_utc` must be provided in ISO-8601 UTC format.
+
+### Onegodian runtime configuration
+
+Set the upstream base URL with:
+
+```bash
+ONEGODIAN_API_BASE_URL=https://onegodian-api.onrender.com
+```
+

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -6,11 +6,6 @@
   --muted: #607087;
   --border: #d6dfe8;
   --shadow: 0 18px 40px rgba(19, 32, 51, 0.08);
-  --verified: #18794e;
-  --invalid: #b42318;
-  --revoked: #c96b12;
-  --expired: #7c3aed;
-  --unavailable: #475467;
   --accent: #0f4c81;
 }
 
@@ -25,10 +20,6 @@ body {
   color: var(--text);
 }
 
-code {
-  font-family: "SFMono-Regular", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
-}
-
 .page-shell {
   min-height: 100vh;
   display: flex;
@@ -38,7 +29,7 @@ code {
 .page-header,
 .page-footer,
 .content-wrap {
-  width: min(100%, 760px);
+  width: min(100%, 840px);
   margin: 0 auto;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -60,15 +51,13 @@ code {
 }
 
 .page-header h1,
-.hero-card h2,
-.result-heading h2 {
+.hero-card h2 {
   margin: 0;
   font-size: clamp(1.8rem, 4vw, 2.6rem);
 }
 
 .subtitle,
 .supporting-copy,
-.field-hint,
 .page-footer,
 .alert-banner {
   color: var(--muted);
@@ -76,7 +65,8 @@ code {
 
 .content-wrap {
   flex: 1;
-  display: flex;
+  display: grid;
+  gap: 1rem;
   align-items: flex-start;
   padding-top: 1rem;
   padding-bottom: 2.5rem;
@@ -91,10 +81,6 @@ code {
   padding: 1.5rem;
 }
 
-.verify-form {
-  margin-top: 1.5rem;
-}
-
 .form-label,
 dt {
   display: block;
@@ -103,9 +89,7 @@ dt {
   margin-bottom: 0.5rem;
 }
 
-.form-row,
-.actions-row,
-.result-heading {
+.form-row {
   display: flex;
   gap: 0.75rem;
   align-items: center;
@@ -135,62 +119,11 @@ button {
   cursor: pointer;
 }
 
-button:hover {
-  opacity: 0.96;
-}
-
-.secondary-button {
-  background: #eff4fa;
-  color: var(--accent);
-  border: 1px solid #d8e4f2;
-}
-
-.result-card {
-  position: relative;
-}
-
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 130px;
-  border-radius: 999px;
-  padding: 0.7rem 1rem;
-  font-size: 0.82rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-}
-
-.badge-verified {
-  color: var(--verified);
-  background: #e7f6ee;
-}
-
-.badge-invalid {
-  color: var(--invalid);
-  background: #fdecea;
-}
-
-.badge-revoked {
-  color: var(--revoked);
-  background: #fff2e8;
-}
-
-.badge-expired {
-  color: var(--expired);
-  background: #f2ebff;
-}
-
-.badge-unavailable {
-  color: var(--unavailable);
-  background: #eef2f6;
-}
-
 .metadata-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
-  margin: 1.5rem 0;
+  margin-top: 1.5rem;
 }
 
 .metadata-grid div {
@@ -214,21 +147,9 @@ dd {
   background: #f8fafc;
 }
 
-.loading-indicator {
-  display: none;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  color: var(--muted);
-}
-
-.spinner {
-  width: 1rem;
-  height: 1rem;
-  border-radius: 999px;
-  border: 2px solid #d7e1ea;
-  border-top-color: var(--accent);
-  animation: spin 0.9s linear infinite;
+.day-order-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1.15rem;
 }
 
 .raw-json {
@@ -248,12 +169,6 @@ dd {
   font-size: 0.95rem;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 @media (max-width: 640px) {
   .content-wrap {
     padding-top: 0.5rem;
@@ -265,8 +180,6 @@ dd {
   }
 
   .form-row,
-  .actions-row,
-  .result-heading,
   .metadata-grid {
     grid-template-columns: 1fr;
     flex-direction: column;
@@ -275,10 +188,6 @@ dd {
 
   .metadata-grid {
     display: grid;
-  }
-
-  .status-badge {
-    width: 100%;
   }
 
   button {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,50 +1,127 @@
-const form = document.querySelector('[data-verify-form]');
-const rawJson = document.querySelector('[data-raw-json]');
-const toggleJsonButton = document.querySelector('[data-toggle-json]');
-const copyButton = document.querySelector('[data-copy-qrvid]');
-const loadingIndicator = document.querySelector('[data-loading-indicator]');
-const resultBody = document.querySelector('[data-result-body]');
+const read = (selector) => document.querySelector(selector);
 
-if (form) {
-  form.addEventListener('submit', () => {
-    if (loadingIndicator) {
-      loadingIndicator.style.display = 'inline-flex';
+const otSnapshot = read('[data-ot-snapshot]');
+const otError = read('[data-ot-error]');
+const convertForm = read('[data-convert-form]');
+const conversionOutput = read('[data-conversion-output]');
+
+const fallbackSnapshot = {
+  ordinal_day: 'Unavailable',
+  ot_date: 'Unavailable',
+  gregorian_sync: 'Unavailable',
+  time_utc: 'Unavailable',
+};
+
+const api = {
+  async getCurrent() {
+    const response = await fetch('/api/v1/ot/current', { headers: { accept: 'application/json' } });
+    const payload = await response.json();
+
+    if (!response.ok || !payload?.ok) {
+      throw new Error(payload?.error || 'Current time unavailable');
+    }
+
+    return payload.data;
+  },
+  async convert(query) {
+    const url = new URL('/api/v1/ot/convert', window.location.origin);
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (value) {
+        url.searchParams.set(key, value);
+      }
+    });
+
+    const response = await fetch(url, { headers: { accept: 'application/json' } });
+    const payload = await response.json();
+
+    if (!response.ok || !payload?.ok) {
+      throw new Error(payload?.error || 'Conversion unavailable');
+    }
+
+    return payload.data;
+  },
+};
+
+const pick = (source, keys, fallback = '—') => {
+  for (const key of keys) {
+    const value = source?.[key];
+
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+
+  return fallback;
+};
+
+const normalizeCurrent = (data) => ({
+  ordinal_day: pick(data, ['ordinal_day_label', 'ordinal_day', 'day_label', 'day']),
+  ot_date: pick(data, ['ot_date', 'onegodian_date', 'date']),
+  gregorian_sync: pick(data, ['gregorian_sync', 'gregorian_date', 'iso_utc']),
+  time_utc: pick(data, ['time_utc', 'utc_time', 'utc']),
+});
+
+const renderSnapshot = (snapshot) => {
+  if (!otSnapshot) {
+    return;
+  }
+
+  ['ordinal_day', 'ot_date', 'gregorian_sync', 'time_utc'].forEach((key) => {
+    const target = otSnapshot.querySelector(`[data-field="${key}"]`);
+
+    if (target) {
+      target.textContent = snapshot[key] || '—';
     }
   });
-}
+};
 
-if (toggleJsonButton && rawJson) {
-  toggleJsonButton.addEventListener('click', () => {
-    const isHidden = rawJson.hasAttribute('hidden');
+const showFallback = () => {
+  renderSnapshot(fallbackSnapshot);
 
-    if (isHidden) {
-      rawJson.removeAttribute('hidden');
-      toggleJsonButton.textContent = 'Hide raw JSON';
+  if (otError) {
+    otError.hidden = false;
+  }
+};
+
+const initCurrentTime = async () => {
+  if (!otSnapshot) {
+    return;
+  }
+
+  try {
+    const data = await api.getCurrent();
+    renderSnapshot(normalizeCurrent(data));
+
+    if (otError) {
+      otError.hidden = true;
+    }
+  } catch (_error) {
+    showFallback();
+  }
+};
+
+if (convertForm && conversionOutput) {
+  convertForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(convertForm);
+    const isoUtc = String(formData.get('iso_utc') || '').trim();
+
+    if (!isoUtc) {
+      conversionOutput.textContent = 'Please provide a Gregorian ISO UTC timestamp.';
       return;
     }
 
-    rawJson.setAttribute('hidden', 'hidden');
-    toggleJsonButton.textContent = 'View raw JSON';
-  });
-}
-
-if (copyButton) {
-  copyButton.addEventListener('click', async () => {
-    const qrvid = copyButton.getAttribute('data-qrvid');
+    conversionOutput.textContent = 'Loading canonical conversion…';
 
     try {
-      await navigator.clipboard.writeText(qrvid);
-      copyButton.textContent = 'Copied';
-      setTimeout(() => {
-        copyButton.textContent = 'Copy QRVID';
-      }, 1500);
+      const payload = await api.convert({ iso_utc: isoUtc });
+      conversionOutput.textContent = JSON.stringify(payload, null, 2);
     } catch (_error) {
-      copyButton.textContent = 'Copy failed';
+      conversionOutput.textContent = 'Canonical conversion is currently unavailable. Please retry shortly.';
     }
   });
 }
 
-if (window.__QRV_PORTAL__?.autoVerify && loadingIndicator && resultBody) {
-  loadingIndicator.style.display = 'none';
-  resultBody.style.display = 'block';
-}
+void initCurrentTime();

--- a/server.js
+++ b/server.js
@@ -7,13 +7,13 @@ const port = Number(process.env.PORT) || 3000;
 const host = '0.0.0.0';
 
 const server = app.listen(port, host, () => {
-  console.log(`QR-V Verification Portal listening on http://${host}:${port}`);
+  console.log(`Onegodian Public Site listening on http://${host}:${port}`);
   console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`API base URL: ${process.env.NEXT_PUBLIC_API_URL || process.env.API_BASE_URL || 'https://api.qrv.network'}`);
+  console.log(`Onegodian API base URL: ${process.env.ONEGODIAN_API_BASE_URL || 'https://onegodian-api.onrender.com'}`);
 });
 
 const shutdown = (signal) => {
-  console.log(`Received ${signal}. Shutting down QR-V Verification Portal.`);
+  console.log(`Received ${signal}. Shutting down Onegodian Public Site.`);
   server.close(() => process.exit(0));
 };
 

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import express from 'express';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import portalRoutes from './routes/index.js';
-import { renderResultView } from './views/resultView.js';
+import { renderLayout } from './views/layout.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -25,46 +25,18 @@ app.use((req, _res, next) => {
 app.use('/', portalRoutes);
 
 app.use((req, res) => {
-  res.status(404).send(renderResultView({
-    pageTitle: 'QR-V™ Verification',
-    qrvid: req.path.replace(/^\//, '') || 'Unknown',
-    verification: {
-      status: 'NOT_FOUND',
-      message: 'Record not found',
-      statusLabel: 'NOT FOUND',
-      badgeClass: 'badge-invalid',
-      subject: null,
-      issuer: null,
-      recordType: null,
-      timestamp: null,
-      hash: null,
-      raw: { status: 'NOT_FOUND', message: 'Record not found' },
-    },
-    errorSummary: 'The requested verification route does not exist.',
-    autoVerify: false,
+  res.status(404).send(renderLayout({
+    pageTitle: 'Onegodian Time',
+    body: `<main class="content-wrap"><section class="card"><h2>Page not found</h2><p class="supporting-copy">The requested page does not exist.</p></section></main>`,
   }));
 });
 
 app.use((error, _req, res, _next) => {
   console.error('Unhandled portal error:', error);
 
-  res.status(500).send(renderResultView({
-    pageTitle: 'QR-V™ Verification',
-    qrvid: 'Unavailable',
-    verification: {
-      status: 'UNAVAILABLE',
-      message: 'Verification service unavailable',
-      statusLabel: 'SERVICE UNAVAILABLE',
-      badgeClass: 'badge-unavailable',
-      subject: null,
-      issuer: null,
-      recordType: null,
-      timestamp: null,
-      hash: null,
-      raw: { status: 'UNAVAILABLE', message: 'Verification service unavailable' },
-    },
-    errorSummary: 'An unexpected error occurred while rendering the verification portal.',
-    autoVerify: false,
+  res.status(500).send(renderLayout({
+    pageTitle: 'Onegodian Time',
+    body: `<main class="content-wrap"><section class="card"><h2>Service unavailable</h2><p class="supporting-copy">An unexpected error occurred while rendering the public site.</p></section></main>`,
   }));
 });
 

--- a/src/controllers/api/onegodianController.js
+++ b/src/controllers/api/onegodianController.js
@@ -1,0 +1,27 @@
+import { convertDateTime, getCanonicalCurrentTime } from '../../services/onegodianApiService.js';
+
+export const getCurrentOnegodianTime = async (_req, res) => {
+  try {
+    const payload = await getCanonicalCurrentTime();
+    return res.status(200).json({ ok: true, data: payload });
+  } catch (error) {
+    return res.status(503).json({
+      ok: false,
+      error: 'Onegodian time service is currently unavailable.',
+      detail: error.message,
+    });
+  }
+};
+
+export const getConvertedOnegodianTime = async (req, res) => {
+  try {
+    const payload = await convertDateTime(req.query);
+    return res.status(200).json({ ok: true, data: payload });
+  } catch (error) {
+    return res.status(503).json({
+      ok: false,
+      error: 'Onegodian conversion service is currently unavailable.',
+      detail: error.message,
+    });
+  }
+};

--- a/src/controllers/api/onegodianController.js
+++ b/src/controllers/api/onegodianController.js
@@ -1,12 +1,22 @@
 import { convertDateTime, getCanonicalCurrentTime } from '../../services/onegodianApiService.js';
 
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(?:\.\d{1,3})?)?Z$/;
+
+const badRequest = (res, message) => res.status(400).json({
+  ok: false,
+  code: 'INVALID_REQUEST',
+  error: message,
+});
+
 export const getCurrentOnegodianTime = async (_req, res) => {
   try {
     const payload = await getCanonicalCurrentTime();
+    res.set('cache-control', 'no-store');
     return res.status(200).json({ ok: true, data: payload });
   } catch (error) {
     return res.status(503).json({
       ok: false,
+      code: 'UPSTREAM_UNAVAILABLE',
       error: 'Onegodian time service is currently unavailable.',
       detail: error.message,
     });
@@ -14,12 +24,24 @@ export const getCurrentOnegodianTime = async (_req, res) => {
 };
 
 export const getConvertedOnegodianTime = async (req, res) => {
+  const isoUtc = String(req.query?.iso_utc || '').trim();
+
+  if (!isoUtc) {
+    return badRequest(res, 'Query parameter "iso_utc" is required.');
+  }
+
+  if (!ISO_UTC_PATTERN.test(isoUtc)) {
+    return badRequest(res, 'Query parameter "iso_utc" must be an ISO-8601 UTC timestamp (example: 2026-04-09T12:00:00Z).');
+  }
+
   try {
-    const payload = await convertDateTime(req.query);
+    const payload = await convertDateTime({ iso_utc: isoUtc });
+    res.set('cache-control', 'no-store');
     return res.status(200).json({ ok: true, data: payload });
   } catch (error) {
     return res.status(503).json({
       ok: false,
+      code: 'UPSTREAM_UNAVAILABLE',
       error: 'Onegodian conversion service is currently unavailable.',
       detail: error.message,
     });

--- a/src/controllers/healthController.js
+++ b/src/controllers/healthController.js
@@ -1,6 +1,6 @@
 export const healthHandler = (_req, res) => {
   res.status(200).json({
     status: 'ok',
-    service: 'verify-portal',
+    service: 'onegodian-public-site',
   });
 };

--- a/src/controllers/verificationController.js
+++ b/src/controllers/verificationController.js
@@ -4,14 +4,13 @@ import { renderIndexView } from '../views/indexView.js';
 import { renderResultView } from '../views/resultView.js';
 
 const basePageModel = {
-  pageTitle: 'QR-V™ Verification',
+  pageTitle: 'Onegodian Time',
   errorSummary: null,
 };
 
 export const renderLandingPage = (_req, res) => {
   res.status(200).send(renderIndexView({
     ...basePageModel,
-    qrvid: '',
   }));
 };
 

--- a/src/routes/api/v1Routes.js
+++ b/src/routes/api/v1Routes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getVerifyRecord, postRecord, postRevokeRecord } from '../../controllers/api/v1Controller.js';
+import { getConvertedOnegodianTime, getCurrentOnegodianTime } from '../../controllers/api/onegodianController.js';
 import { validateBody } from '../../middleware/validateSchema.js';
 import { enforcePolicy } from '../../services/policyService.js';
 
@@ -8,5 +9,7 @@ const router = Router();
 router.post('/records', enforcePolicy('create_record'), validateBody('createRecord'), postRecord);
 router.get('/verify/:qrvid', getVerifyRecord);
 router.post('/records/:qrvid/revoke', enforcePolicy('revoke_record'), validateBody('revokeRecord'), postRevokeRecord);
+router.get('/ot/current', getCurrentOnegodianTime);
+router.get('/ot/convert', getConvertedOnegodianTime);
 
 export default router;

--- a/src/services/onegodianApiService.js
+++ b/src/services/onegodianApiService.js
@@ -1,0 +1,71 @@
+const DEFAULT_TIMEOUT_MS = 4000;
+const DEFAULT_OT_API_BASE = process.env.ONEGODIAN_API_BASE_URL || 'https://onegodian-api.onrender.com';
+
+const withTimeout = async (promise, timeoutMs = DEFAULT_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await promise(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const requestJson = async (path, { method = 'GET', body } = {}) => withTimeout(async (signal) => {
+  const response = await fetch(`${DEFAULT_OT_API_BASE}${path}`, {
+    method,
+    headers: {
+      'accept': 'application/json',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    signal,
+  });
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = payload?.message || payload?.error || `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return payload;
+});
+
+export const getCanonicalCurrentTime = async () => {
+  const candidates = ['/v1/time/current', '/api/v1/time/current', '/v1/current', '/api/v1/current'];
+
+  for (const path of candidates) {
+    try {
+      return await requestJson(path);
+    } catch (_error) {
+      // Try next candidate endpoint to support API deployment variations.
+    }
+  }
+
+  throw new Error('Unable to fetch canonical Onegodian time from upstream API.');
+};
+
+export const convertDateTime = async (query = {}) => {
+  const search = new URLSearchParams();
+
+  Object.entries(query).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      search.set(key, String(value));
+    }
+  });
+
+  const suffix = search.toString() ? `?${search.toString()}` : '';
+  const candidates = [`/v1/time/convert${suffix}`, `/api/v1/time/convert${suffix}`, `/v1/convert${suffix}`, `/api/v1/convert${suffix}`];
+
+  for (const path of candidates) {
+    try {
+      return await requestJson(path);
+    } catch (_error) {
+      // Try next candidate endpoint to support API deployment variations.
+    }
+  }
+
+  throw new Error('Unable to fetch conversion from upstream API.');
+};

--- a/src/views/indexView.js
+++ b/src/views/indexView.js
@@ -1,37 +1,74 @@
-import { escapeHtml, renderLayout } from './layout.js';
+import { renderLayout } from './layout.js';
 
-export const renderIndexView = ({ pageTitle, qrvid }) => renderLayout({
+export const renderIndexView = ({ pageTitle }) => renderLayout({
   pageTitle,
   body: `<main class="content-wrap">
   <section class="card hero-card">
-    <div>
-      <p class="section-label">Verification Resolution Interface</p>
-      <h2>Resolve a QRVID</h2>
-      <p class="supporting-copy">
-        Enter a QR-V identifier to verify the latest registry-backed status from the verification API.
-      </p>
+    <p class="section-label">Canonical Display</p>
+    <h2>Live Onegodian Time Snapshot</h2>
+    <p class="supporting-copy">This interface renders canonical values from onegodian-api and does not perform authority calculations in the browser.</p>
+
+    <div class="metadata-grid ot-snapshot" data-ot-snapshot>
+      <div>
+        <dt>The [Ordinal] Day™ — [Name]</dt>
+        <dd data-field="ordinal_day">Loading…</dd>
+      </div>
+      <div>
+        <dt>OT Date</dt>
+        <dd data-field="ot_date">Loading…</dd>
+      </div>
+      <div>
+        <dt>Gregorian Sync</dt>
+        <dd data-field="gregorian_sync">Loading…</dd>
+      </div>
+      <div>
+        <dt>Time / UTC</dt>
+        <dd data-field="time_utc">Loading…</dd>
+      </div>
     </div>
 
-    <form class="verify-form" method="post" action="/verify" data-verify-form>
-      <label for="qrvid" class="form-label">QRVID</label>
+    <div class="alert-banner" hidden data-ot-error>
+      Live canonical data is temporarily unavailable. Displaying fallback guidance.
+    </div>
+  </section>
+
+  <section class="card info-card">
+    <h3>What is Onegodian Time?</h3>
+    <p>Onegodian Time is a structured calendar and time system with its own day naming, date expression, and synchronized Gregorian correspondence for interoperability.</p>
+  </section>
+
+  <section class="card info-card">
+    <h3>Day Order™</h3>
+    <p>Week display begins on Skénra (Sunday), followed by the canonical sequence used by the Onegodian standard.</p>
+    <ol class="day-order-list">
+      <li><strong>Skénra</strong> (Sunday)</li>
+      <li>Monday</li>
+      <li>Tuesday</li>
+      <li>Wednesday</li>
+      <li>Thursday</li>
+      <li>Friday</li>
+      <li>Saturday</li>
+    </ol>
+  </section>
+
+  <section class="card info-card">
+    <h3>Dual Dating</h3>
+    <p>Dual dating presents Onegodian date data beside Gregorian date/time to support global readability while preserving Onegodian-native expression.</p>
+  </section>
+
+  <section class="card info-card">
+    <h3>How conversion works</h3>
+    <p>Conversion requests are sent to onegodian-api. The website only displays returned canonical conversion results and does not implement conversion logic in UI components.</p>
+
+    <form class="convert-form" data-convert-form>
+      <label for="iso_utc" class="form-label">Gregorian ISO UTC</label>
       <div class="form-row">
-        <input
-          id="qrvid"
-          name="qrvid"
-          type="text"
-          inputmode="text"
-          autocomplete="off"
-          autocapitalize="characters"
-          spellcheck="false"
-          placeholder="QRV-123456789"
-          value="${escapeHtml(qrvid)}"
-          aria-describedby="qrvid-hint"
-          required
-        />
-        <button type="submit">Verify</button>
+        <input id="iso_utc" name="iso_utc" type="text" placeholder="2026-04-09T12:00:00Z" autocomplete="off" />
+        <button type="submit">Convert</button>
       </div>
-      <p id="qrvid-hint" class="field-hint">Accepted format: <span>QRV-123456789</span></p>
     </form>
+
+    <pre class="raw-json" data-conversion-output>Submit a Gregorian ISO timestamp to view canonical conversion output.</pre>
   </section>
 </main>`,
 });

--- a/src/views/layout.js
+++ b/src/views/layout.js
@@ -15,7 +15,7 @@ export const renderLayout = ({ pageTitle, body, pageScript = '' }) => `<!DOCTYPE
     <title>${escapeHtml(pageTitle)}</title>
     <meta
       name="description"
-      content="Registry-backed QR-V™ verification interface for resolving QRVIDs against the QR-V™ Global Verification Network."
+      content="Official Onegodian Time educational and display interface backed by canonical onegodian-api data."
     />
     <link rel="stylesheet" href="/css/styles.css" />
     <script defer src="/js/app.js"></script>
@@ -23,13 +23,13 @@ export const renderLayout = ({ pageTitle, body, pageScript = '' }) => `<!DOCTYPE
   <body>
     <div class="page-shell">
       <header class="page-header">
-        <p class="eyebrow">QR-V™ Global Verification Network</p>
-        <h1>QR-V™ Verification</h1>
-        <p class="subtitle">Deterministic registry-backed verification for QR-V identifiers.</p>
+        <p class="eyebrow">Onegodian Time Initiative</p>
+        <h1>Onegodian Time</h1>
+        <p class="subtitle">Public documentation and display layer using canonical data from onegodian-api.</p>
       </header>
       ${body}
       <footer class="page-footer">
-        <p>Powered by QR-V™ Global Verification Network</p>
+        <p>The public website is documentation and display only. Canonical authority remains onegodian-api.</p>
       </footer>
     </div>
     ${pageScript}

--- a/test/onegodian-routes.test.js
+++ b/test/onegodian-routes.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import app from '../src/app.js';
+
+let server;
+let baseUrl;
+
+const jsonRequest = async ({ method, path }) => {
+  const response = await fetch(`${baseUrl}${path}`, { method });
+
+  return {
+    status: response.status,
+    body: await response.json().catch(() => ({})),
+  };
+};
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      const port = server.address().port;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('health endpoint reports onegodian public site service', async () => {
+  const response = await jsonRequest({ method: 'GET', path: '/health' });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.status, 'ok');
+  assert.equal(response.body.service, 'onegodian-public-site');
+});
+
+test('ot convert rejects missing iso_utc', async () => {
+  const response = await jsonRequest({ method: 'GET', path: '/api/v1/ot/convert' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.code, 'INVALID_REQUEST');
+});
+
+test('ot convert rejects non-utc iso_utc format', async () => {
+  const response = await jsonRequest({ method: 'GET', path: '/api/v1/ot/convert?iso_utc=2026-04-11T09:00:00' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.code, 'INVALID_REQUEST');
+});


### PR DESCRIPTION
### Motivation
- Replace inconsistent client-side Onegodian Time calculations with canonical data from `onegodian-api` so the public site is a display/documentation layer and not an authority engine.
- Surface authoritative OT values (current timestamp + conversion results) and provide graceful fallbacks when the upstream API is unavailable.
- Add clear educational sections (Day Order™, Dual Dating, How conversion works) and ensure weeks start on Skénra (Sunday).

### Description
- Added a server-side service `src/services/onegodianApiService.js` that fetches canonical time and conversion data from `ONEGODIAN_API_BASE_URL` with timeout handling and multiple endpoint candidate fallbacks.
- Introduced API proxy controller `src/controllers/api/onegodianController.js` and routes `GET /api/v1/ot/current` and `GET /api/v1/ot/convert` in `src/routes/api/v1Routes.js` to expose canonical payloads to the frontend.
- Reworked landing page view `src/views/indexView.js` and shared layout `src/views/layout.js` to present Onegodian Time documentation and display components for `The [Ordinal] Day™`, `OT Date`, `Gregorian Sync`, and `Time / UTC` and to state the site is non-authoritative.
- Replaced client-side authority logic in `public/js/app.js` with a lightweight frontend service that calls the new backend endpoints, renders canonical values, normalizes multiple possible payload shapes, and shows graceful fallback states when the API is unreachable.
- Updated styles in `public/css/styles.css` to match the new layout and added `ONEGODIAN_API_BASE_URL` to `.env.example` for configuration.

### Testing
- Ran `npm run check` which completed with no syntax errors and no failures.
- Ran `npm test` and all tests passed (`4` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d784440498832d9cc0c9b7cfaf8f19)