### PR TITLE
Implement canonical Onegodian time authority API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.1.0 - 2026-04-09
+
+- Replaced scaffold verification portal behavior with Onegodian canonical time authority API routes.
+- Implemented deterministic OTS-V5-corrected conversion functions for Gregorian↔OT, OT day order, OT leap-year detection, and OT year length.
+- Added canonical timestamp normalization schema, explicit validation errors, and unit tests for epoch, rollover, day-order, and leap behavior.
+- Updated README to document canonical standards and endpoint examples.

--- a/README.md
+++ b/README.md
@@ -1,197 +1,130 @@
-# qrv-verify-portal
+# Onegodian API
 
-`qrv-verify-portal` is the public verification resolution interface for the QR-V™ Global Verification Network. It is designed to run at `https://verify.qrv.network` and acts as the public-facing layer between a scanned QR-V identifier and the registry-backed verification API at `https://api.qrv.network`.
+Canonical authority layer for the **Onegodian Timekeeping System™**.
 
-This repository intentionally implements a focused verification portal rather than a generic marketing website. The interface accepts QRVIDs, resolves them against the authoritative API, and renders deterministic verification results for institutional users.
+## Canonical Rules (OTS-V5-corrected authority)
 
-## Role in the QR-V System
+- Fixed epoch: **2025-03-18 Gregorian = Genesis 01, 0000 OT**.
+- OT year rollover occurs **only** on March 18 Gregorian.
+- OT months 1–12 are fixed at 30 days.
+- OT month 13 (**Ascension**) is:
+  - 5 days in normal OT years.
+  - 6 days when the Gregorian year in which that OT year ends is leap.
+- Day Order is fixed, Sunday-start, non-rotational:
+  1. Skénra
+  2. Teyó·ra
+  3. Ahsténha
+  4. Yawénni
+  5. Onyá·ta
+  6. Shakó·wa
+  7. Niyóhsera
+- UTC is canonical system truth.
+- Gregorian is controlling legal sync layer.
+- OT is a derived governance layer.
 
-The portal sits in the public verification path:
-
-```text
-QR Scan → verify.qrv.network → api.qrv.network → registry → response → display result
-```
-
-### Service responsibilities
-
-- Accept QR-V identifiers (QRVIDs) through a direct URL or manual entry.
-- Validate and sanitize incoming identifiers before requesting data.
-- Call `GET https://api.qrv.network/verify/:qrvid`.
-- Render structured verification results for `VERIFIED`, `INVALID`, `REVOKED`, `EXPIRED`, and service-unavailable states.
-- Present an authoritative, mobile-friendly interface with minimal client-side logic.
-
-## How verification works
-
-1. A user scans a QR code or opens a verification URL such as `/QRV-123456789`.
-2. The portal sanitizes the QRVID and validates its format server-side.
-3. The verification service requests `GET {NEXT_PUBLIC_API_URL}/verify/:qrvid`.
-4. The portal normalizes the response payload and status.
-5. The result page displays the verification state, issuer, record type, subject, timestamp, and truncated hash when available.
-6. If the upstream API times out or becomes unreachable, the portal retries once and then renders a deterministic unavailable state.
-
-## Architecture and project structure
-
-```text
-qrv-verify-portal/
-├── docs/
-│   └── architecture.md
-├── public/
-│   ├── assets/
-│   ├── css/
-│   │   └── styles.css
-│   └── js/
-│       └── app.js
-├── src/
-│   ├── controllers/
-│   │   ├── healthController.js
-│   │   └── verificationController.js
-│   ├── routes/
-│   │   ├── index.js
-│   │   └── verificationRoutes.js
-│   ├── services/
-│   │   └── verificationService.js
-│   ├── utils/
-│   │   └── qrvid.js
-│   ├── views/
-│   │   ├── indexView.js
-│   │   ├── layout.js
-│   │   └── resultView.js
-│   └── app.js
-├── .env.example
-├── Dockerfile
-├── package.json
-├── server.js
-└── README.md
-```
-
-## Routes
-
-### `GET /`
-Landing page with a QRVID input and a Verify button.
-
-### `GET /:qrvid`
-Automatically resolves a QRVID and renders the verification result.
-
-### `GET /verify/:qrvid`
-Explicit verification route that performs the same lookup and rendering.
-
-### `POST /verify`
-Form handler that accepts a pasted QRVID and redirects to `/verify/:qrvid`.
-
-
-### `POST /api/v1/records`
-Creates a V1 verification record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `issuer` or `admin`.
-
-### `GET /api/v1/verify/:qrvid`
-Returns deterministic V1 statuses: `VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`.
-
-### `POST /api/v1/records/:qrvid/revoke`
-Revokes an existing record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `admin`.
-
-### `GET /health`
-Returns:
-
-```json
-{
-  "status": "ok",
-  "service": "verify-portal"
-}
-```
-
-## Environment variables
-
-Copy `.env.example` to `.env` and configure as needed:
-
-```env
-PORT=3000
-NEXT_PUBLIC_API_URL=https://api.qrv.network
-NODE_ENV=development
-```
-
-## Local setup
-
-### Requirements
+## Runtime
 
 - Node.js 18+
-- npm 9+
+- Express 4
 
-### Install and run
+## Quick Start
 
 ```bash
 npm install
-cp .env.example .env
-npm run dev
-```
-
-For a production-style local run:
-
-```bash
-npm install --omit=dev
 npm start
 ```
 
-Open `http://localhost:3000`.
+Server defaults to `http://0.0.0.0:3000`.
 
-## Deployment instructions
+## API Endpoints
 
-### Standard Node deployment
+### `GET /health`
+Health and authority marker.
 
-1. Provision a Node.js 18+ runtime.
-2. Set environment variables:
-   - `PORT`
-   - `NEXT_PUBLIC_API_URL=https://api.qrv.network` (or `API_BASE_URL` for legacy compatibility)
-   - `NODE_ENV=production`
-3. Install dependencies with `npm install --omit=dev`.
-4. Start the service with `npm start`.
-5. Map the public domain `verify.qrv.network` to the running service.
-6. Confirm `/health` responds with the expected JSON payload.
+### `GET /v1/time/now?timezone=UTC`
+Returns canonical timestamp object for current instant.
 
-### Docker deployment
+### `POST /v1/time/convert/gregorian-to-ot`
+Convert Gregorian input to OT.
 
-Build and run:
-
-```bash
-docker build -t qrv-verify-portal .
-docker run --rm -p 3000:3000 --env-file .env qrv-verify-portal
+Request body:
+```json
+{
+  "inputDate": "2026-03-26T00:00:00Z",
+  "timezone": "UTC"
+}
 ```
 
-## Security and reliability notes
+### `POST /v1/time/convert/ot-to-gregorian`
+Convert OT input to Gregorian.
 
-- Client input is sanitized and validated before use.
-- The portal never connects directly to a database.
-- `api.qrv.network` is the verification data source for this portal, configured via `NEXT_PUBLIC_API_URL`.
-- API timeouts trigger a single retry before showing an unavailable state.
-- The service logs verification lookups for simple operational analytics.
+Request body:
+```json
+{
+  "otYear": 1,
+  "otMonth": 1,
+  "otDay": 9,
+  "timezone": "UTC"
+}
+```
 
-## Running checks
+### `POST /v1/time/normalize`
+Normalize either Gregorian or OT input to canonical timestamp shape.
+
+Gregorian request:
+```json
+{
+  "inputDate": "2026-03-26T00:00:00Z",
+  "timezone": "UTC"
+}
+```
+
+OT request:
+```json
+{
+  "otYear": 1,
+  "otMonth": 1,
+  "otDay": 9,
+  "timezone": "UTC"
+}
+```
+
+## Canonical Timestamp Object
+
+```json
+{
+  "timestamp_utc": "2026-03-26T00:00:00.000Z",
+  "timestamp_local": "2026-03-26T00:00:00",
+  "timezone": "UTC",
+  "gregorian_date": "2026-03-26",
+  "gregorian_weekday": "Thursday",
+  "ot_year": 1,
+  "ot_month_index": 1,
+  "ot_month_name": "Genesis",
+  "ot_day": 9,
+  "ot_day_order_index": 5,
+  "ot_day_order_ordinal": "The Fifth Day™",
+  "ot_day_order_name": "Onyá·ta"
+}
+```
+
+## Error Contract
+
+All input validation failures return HTTP `400` with:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "..."
+  }
+}
+```
+
+Invalid date/timezone or out-of-range OT values return HTTP `400` with code `INVALID_REQUEST`.
+
+## Testing
 
 ```bash
-npm run check
-npm run validate:enforcement
 npm test
 ```
-
-## Git initialization and push commands
-
-If you are starting from a fresh local clone or a new repository, use:
-
-```bash
-git init
-git add .
-git commit -m "Create QR-V verification portal"
-git branch -M main
-git remote add origin <your-repository-url>
-git push -u origin main
-```
-
-If the repository is already initialized, use:
-
-```bash
-git add .
-git commit -m "Create QR-V verification portal"
-git push
-```
-
-## License
-
-MIT

--- a/package.json
+++ b/package.json
@@ -1,22 +1,20 @@
 {
-  "name": "qrv-verify-portal",
-  "version": "1.0.0",
-  "description": "Public-facing QR-V verification resolution portal for verify.qrv.network.",
+  "name": "onegodian-api",
+  "version": "1.1.0",
+  "description": "Canonical authority API layer for the Onegodian Timekeeping System.",
   "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "dev": "NODE_ENV=development nodemon server.js",
-    "check": "node --check server.js && node --check src/app.js && node --check src/controllers/healthController.js && node --check src/controllers/verificationController.js && node --check src/controllers/api/v1Controller.js && node --check src/routes/index.js && node --check src/routes/verificationRoutes.js && node --check src/routes/api/v1Routes.js && node --check src/services/verificationService.js && node --check src/services/recordStore.js && node --check src/services/policyService.js && node --check src/services/auditLogService.js && node --check src/services/schemaRegistry.js && node --check src/middleware/validateSchema.js && node --check src/utils/qrvid.js && node --check src/views/layout.js && node --check src/views/indexView.js && node --check src/views/resultView.js",
-    "validate:enforcement": "node scripts/validate-enforcement.mjs",
+    "check": "node --check server.js && node --check src/app.js && node --check src/controllers/timeController.js && node --check src/routes/timeRoutes.js && node --check src/services/timeConversionService.js && node --check src/constants/otCalendar.js",
     "test": "node --test"
   },
   "keywords": [
-    "qrv",
-    "verification",
-    "portal",
+    "onegodian",
+    "timekeeping",
     "express",
-    "qrvid"
+    "api"
   ],
   "author": "",
   "license": "MIT",

--- a/server.js
+++ b/server.js
@@ -7,13 +7,12 @@ const port = Number(process.env.PORT) || 3000;
 const host = '0.0.0.0';
 
 const server = app.listen(port, host, () => {
-  console.log(`QR-V Verification Portal listening on http://${host}:${port}`);
+  console.log(`Onegodian API listening on http://${host}:${port}`);
   console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`API base URL: ${process.env.NEXT_PUBLIC_API_URL || process.env.API_BASE_URL || 'https://api.qrv.network'}`);
 });
 
 const shutdown = (signal) => {
-  console.log(`Received ${signal}. Shutting down QR-V Verification Portal.`);
+  console.log(`Received ${signal}. Shutting down Onegodian API.`);
   server.close(() => process.exit(0));
 };
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,71 +1,33 @@
 import express from 'express';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import portalRoutes from './routes/index.js';
-import { renderResultView } from './views/resultView.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import timeRoutes from './routes/timeRoutes.js';
+import { healthHandler } from './controllers/timeController.js';
 
 const app = express();
 
 app.disable('x-powered-by');
-
-app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
-app.use('/css', express.static(path.join(__dirname, '../public/css')));
-app.use('/js', express.static(path.join(__dirname, '../public/js')));
-app.use('/assets', express.static(path.join(__dirname, '../public/assets')));
 
-app.use((req, _res, next) => {
-  console.log(`[portal] ${new Date().toISOString()} ${req.method} ${req.originalUrl}`);
-  next();
-});
+app.get('/health', healthHandler);
+app.use('/v1/time', timeRoutes);
 
-app.use('/', portalRoutes);
-
-app.use((req, res) => {
-  res.status(404).send(renderResultView({
-    pageTitle: 'QR-V™ Verification',
-    qrvid: req.path.replace(/^\//, '') || 'Unknown',
-    verification: {
-      status: 'NOT_FOUND',
-      message: 'Record not found',
-      statusLabel: 'NOT FOUND',
-      badgeClass: 'badge-invalid',
-      subject: null,
-      issuer: null,
-      recordType: null,
-      timestamp: null,
-      hash: null,
-      raw: { status: 'NOT_FOUND', message: 'Record not found' },
+app.use((_req, res) => {
+  res.status(404).json({
+    error: {
+      code: 'NOT_FOUND',
+      message: 'Route not found.',
     },
-    errorSummary: 'The requested verification route does not exist.',
-    autoVerify: false,
-  }));
+  });
 });
 
 app.use((error, _req, res, _next) => {
-  console.error('Unhandled portal error:', error);
+  console.error('Unhandled API error:', error);
 
-  res.status(500).send(renderResultView({
-    pageTitle: 'QR-V™ Verification',
-    qrvid: 'Unavailable',
-    verification: {
-      status: 'UNAVAILABLE',
-      message: 'Verification service unavailable',
-      statusLabel: 'SERVICE UNAVAILABLE',
-      badgeClass: 'badge-unavailable',
-      subject: null,
-      issuer: null,
-      recordType: null,
-      timestamp: null,
-      hash: null,
-      raw: { status: 'UNAVAILABLE', message: 'Verification service unavailable' },
+  res.status(500).json({
+    error: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Unexpected server error.',
     },
-    errorSummary: 'An unexpected error occurred while rendering the verification portal.',
-    autoVerify: false,
-  }));
+  });
 });
 
 export default app;

--- a/src/constants/otCalendar.js
+++ b/src/constants/otCalendar.js
@@ -1,0 +1,32 @@
+export const OT_EPOCH_GREGORIAN_UTC = '2025-03-18';
+
+export const OT_EPOCH_DATE = new Date(`${OT_EPOCH_GREGORIAN_UTC}T00:00:00.000Z`);
+
+export const OT_DAY_ORDER = [
+  { index: 1, ordinal: 'The First Day™', name: 'Skénra' },
+  { index: 2, ordinal: 'The Second Day™', name: 'Teyó·ra' },
+  { index: 3, ordinal: 'The Third Day™', name: 'Ahsténha' },
+  { index: 4, ordinal: 'The Fourth Day™', name: 'Yawénni' },
+  { index: 5, ordinal: 'The Fifth Day™', name: 'Onyá·ta' },
+  { index: 6, ordinal: 'The Sixth Day™', name: 'Shakó·wa' },
+  { index: 7, ordinal: 'The Seventh Day™', name: 'Niyóhsera' },
+];
+
+export const OT_MONTH_NAMES = [
+  'Genesis',
+  'Month 02',
+  'Month 03',
+  'Month 04',
+  'Month 05',
+  'Month 06',
+  'Month 07',
+  'Month 08',
+  'Month 09',
+  'Month 10',
+  'Month 11',
+  'Month 12',
+  'Ascension',
+];
+
+export const FIXED_MONTH_COUNT = 12;
+export const FIXED_MONTH_LENGTH = 30;

--- a/src/controllers/timeController.js
+++ b/src/controllers/timeController.js
@@ -1,0 +1,101 @@
+import {
+  buildCanonicalTimestamp,
+  gregorianToOT,
+  otToGregorian,
+} from '../services/timeConversionService.js';
+
+const sendError = (res, status, code, message, details = undefined) => {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      ...(details ? { details } : {}),
+    },
+  });
+};
+
+const parseTimezone = (candidate) => (typeof candidate === 'string' && candidate.trim() ? candidate.trim() : 'UTC');
+
+export const healthHandler = (_req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    service: 'onegodian-api',
+    standard: 'OTS-V5-corrected',
+  });
+};
+
+export const getNowHandler = (req, res) => {
+  try {
+    const timezone = parseTimezone(req.query.timezone);
+    res.status(200).json(buildCanonicalTimestamp(new Date(), timezone));
+  } catch (error) {
+    sendError(res, 400, 'INVALID_REQUEST', error.message);
+  }
+};
+
+export const postGregorianToOTHandler = (req, res) => {
+  const { inputDate, timezone: rawTz } = req.body ?? {};
+
+  if (!inputDate) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'inputDate is required.');
+  }
+
+  try {
+    const timezone = parseTimezone(rawTz);
+    const conversion = gregorianToOT(inputDate, timezone);
+    const canonical = buildCanonicalTimestamp(inputDate, timezone);
+
+    return res.status(200).json({
+      conversion,
+      canonical,
+    });
+  } catch (error) {
+    return sendError(res, 400, 'INVALID_REQUEST', error.message);
+  }
+};
+
+export const postOTToGregorianHandler = (req, res) => {
+  const { otYear, otMonth, otDay, timezone: rawTz } = req.body ?? {};
+
+  if (![otYear, otMonth, otDay].every((value) => Number.isInteger(value))) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'otYear, otMonth, and otDay are required integers.');
+  }
+
+  try {
+    const timezone = parseTimezone(rawTz);
+    const conversion = otToGregorian(otYear, otMonth, otDay, timezone);
+    const canonical = buildCanonicalTimestamp(`${conversion.gregorianDate}T00:00:00.000Z`, timezone);
+
+    return res.status(200).json({
+      conversion,
+      canonical,
+    });
+  } catch (error) {
+    return sendError(res, 400, 'INVALID_REQUEST', error.message);
+  }
+};
+
+export const postNormalizeHandler = (req, res) => {
+  const { inputDate, otYear, otMonth, otDay, timezone: rawTz } = req.body ?? {};
+  const timezone = parseTimezone(rawTz);
+
+  try {
+    if (inputDate) {
+      return res.status(200).json(buildCanonicalTimestamp(inputDate, timezone));
+    }
+
+    if ([otYear, otMonth, otDay].every((value) => Number.isInteger(value))) {
+      const { gregorianDate } = otToGregorian(otYear, otMonth, otDay, timezone);
+      return res.status(200).json(buildCanonicalTimestamp(`${gregorianDate}T00:00:00.000Z`, timezone));
+    }
+
+    return sendError(
+      res,
+      400,
+      'VALIDATION_ERROR',
+      'Provide either inputDate or all of otYear, otMonth, and otDay.',
+    );
+  } catch (error) {
+    return sendError(res, 400, 'INVALID_REQUEST', error.message);
+  }
+};

--- a/src/routes/timeRoutes.js
+++ b/src/routes/timeRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  getNowHandler,
+  postGregorianToOTHandler,
+  postNormalizeHandler,
+  postOTToGregorianHandler,
+} from '../controllers/timeController.js';
+
+const router = Router();
+
+router.get('/now', getNowHandler);
+router.post('/convert/gregorian-to-ot', postGregorianToOTHandler);
+router.post('/convert/ot-to-gregorian', postOTToGregorianHandler);
+router.post('/normalize', postNormalizeHandler);
+
+export default router;

--- a/src/services/timeConversionService.js
+++ b/src/services/timeConversionService.js
@@ -1,0 +1,213 @@
+import {
+  FIXED_MONTH_COUNT,
+  FIXED_MONTH_LENGTH,
+  OT_DAY_ORDER,
+  OT_EPOCH_DATE,
+  OT_MONTH_NAMES,
+} from '../constants/otCalendar.js';
+
+const MS_PER_DAY = 86_400_000;
+
+const GREGORIAN_WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const formatterCache = new Map();
+
+const getFormatter = (timezone) => {
+  if (!formatterCache.has(timezone)) {
+    formatterCache.set(timezone, new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      weekday: 'long',
+    }));
+  }
+
+  return formatterCache.get(timezone);
+};
+
+const isGregorianLeapYear = (year) => (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
+const assertValidTimezone = (timezone) => {
+  try {
+    Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+  } catch {
+    throw new Error(`Invalid timezone: ${timezone}`);
+  }
+};
+
+const normalizeDateInput = (inputDate) => {
+  const date = inputDate instanceof Date ? new Date(inputDate.getTime()) : new Date(inputDate);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid inputDate. Provide an ISO-8601 string or JavaScript Date value.');
+  }
+
+  return date;
+};
+
+const getDatePartsInTimezone = (date, timezone) => {
+  const formatter = getFormatter(timezone);
+  const parts = formatter.formatToParts(date);
+
+  const pick = (type) => parts.find((part) => part.type === type)?.value;
+
+  const year = Number(pick('year'));
+  const month = Number(pick('month'));
+  const day = Number(pick('day'));
+  const hour = pick('hour');
+  const minute = pick('minute');
+  const second = pick('second');
+  const weekday = pick('weekday');
+
+  return {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    weekday,
+    localTimestamp: `${year.toString().padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T${hour}:${minute}:${second}`,
+    gregorianDate: `${year.toString().padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
+  };
+};
+
+const getDayIndexFromGregorianDate = (year, month, day) => new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+
+export const isOTLeapYear = (otYear) => {
+  if (!Number.isInteger(otYear) || otYear < 0) {
+    throw new Error('otYear must be a non-negative integer.');
+  }
+
+  const gregorianYearInWhichOTEnds = 2026 + otYear;
+  return isGregorianLeapYear(gregorianYearInWhichOTEnds);
+};
+
+export const daysInOTYear = (otYear) => (isOTLeapYear(otYear) ? 366 : 365);
+
+const getDaysFromEpochToOTYearStart = (otYear) => {
+  let total = 0;
+
+  for (let year = 0; year < otYear; year += 1) {
+    total += daysInOTYear(year);
+  }
+
+  return total;
+};
+
+export const gregorianToOT = (inputDate, timezone = 'UTC') => {
+  assertValidTimezone(timezone);
+  const instant = normalizeDateInput(inputDate);
+  const localParts = getDatePartsInTimezone(instant, timezone);
+
+  const normalizedGregorianUtc = new Date(Date.UTC(localParts.year, localParts.month - 1, localParts.day));
+
+  const daysSinceEpoch = Math.floor((normalizedGregorianUtc.getTime() - OT_EPOCH_DATE.getTime()) / MS_PER_DAY);
+
+  if (daysSinceEpoch < 0) {
+    throw new Error('Gregorian date precedes OT epoch (2025-03-18 UTC).');
+  }
+
+  let remainingDays = daysSinceEpoch;
+  let otYear = 0;
+
+  while (remainingDays >= daysInOTYear(otYear)) {
+    remainingDays -= daysInOTYear(otYear);
+    otYear += 1;
+  }
+
+  const firstTwelveMonths = FIXED_MONTH_COUNT * FIXED_MONTH_LENGTH;
+  const otMonth = remainingDays < firstTwelveMonths
+    ? Math.floor(remainingDays / FIXED_MONTH_LENGTH) + 1
+    : 13;
+
+  const otDay = otMonth < 13
+    ? (remainingDays % FIXED_MONTH_LENGTH) + 1
+    : (remainingDays - firstTwelveMonths) + 1;
+
+  return {
+    otYear,
+    otMonth,
+    otDay,
+    otMonthName: OT_MONTH_NAMES[otMonth - 1],
+    gregorianDate: localParts.gregorianDate,
+    timezone,
+  };
+};
+
+export const otToGregorian = (otYear, otMonth, otDay, timezone = 'UTC') => {
+  assertValidTimezone(timezone);
+
+  if (!Number.isInteger(otYear) || otYear < 0) {
+    throw new Error('otYear must be a non-negative integer.');
+  }
+
+  if (!Number.isInteger(otMonth) || otMonth < 1 || otMonth > 13) {
+    throw new Error('otMonth must be an integer between 1 and 13.');
+  }
+
+  const maxDay = otMonth <= 12 ? 30 : (isOTLeapYear(otYear) ? 6 : 5);
+
+  if (!Number.isInteger(otDay) || otDay < 1 || otDay > maxDay) {
+    throw new Error(`otDay must be an integer between 1 and ${maxDay} for OT month ${otMonth}.`);
+  }
+
+  const daysBeforeYear = getDaysFromEpochToOTYearStart(otYear);
+  const daysBeforeMonth = otMonth <= 12 ? (otMonth - 1) * FIXED_MONTH_LENGTH : FIXED_MONTH_COUNT * FIXED_MONTH_LENGTH;
+
+  const totalDays = daysBeforeYear + daysBeforeMonth + (otDay - 1);
+
+  const gregorianUtcDate = new Date(OT_EPOCH_DATE.getTime() + (totalDays * MS_PER_DAY));
+  const localParts = getDatePartsInTimezone(gregorianUtcDate, timezone);
+
+  return {
+    gregorianDate: localParts.gregorianDate,
+    timezone,
+    otYear,
+    otMonth,
+    otDay,
+    otMonthName: OT_MONTH_NAMES[otMonth - 1],
+  };
+};
+
+export const getOTDayOrder = (inputDate, timezone = 'UTC') => {
+  assertValidTimezone(timezone);
+  const instant = normalizeDateInput(inputDate);
+  const localParts = getDatePartsInTimezone(instant, timezone);
+  const dayIndex = getDayIndexFromGregorianDate(localParts.year, localParts.month, localParts.day);
+  const order = OT_DAY_ORDER[dayIndex];
+
+  return {
+    index: order.index,
+    ordinal: order.ordinal,
+    name: order.name,
+  };
+};
+
+export const buildCanonicalTimestamp = (inputDate, timezone = 'UTC') => {
+  assertValidTimezone(timezone);
+  const instant = normalizeDateInput(inputDate);
+  const localParts = getDatePartsInTimezone(instant, timezone);
+  const ot = gregorianToOT(instant, timezone);
+  const dayOrder = getOTDayOrder(instant, timezone);
+
+  return {
+    timestamp_utc: instant.toISOString(),
+    timestamp_local: localParts.localTimestamp,
+    timezone,
+    gregorian_date: localParts.gregorianDate,
+    gregorian_weekday: localParts.weekday || GREGORIAN_WEEKDAYS[getDayIndexFromGregorianDate(localParts.year, localParts.month, localParts.day)],
+    ot_year: ot.otYear,
+    ot_month_index: ot.otMonth,
+    ot_month_name: ot.otMonthName,
+    ot_day: ot.otDay,
+    ot_day_order_index: dayOrder.index,
+    ot_day_order_ordinal: dayOrder.ordinal,
+    ot_day_order_name: dayOrder.name,
+  };
+};

--- a/test/enforcement.test.js
+++ b/test/enforcement.test.js
@@ -1,32 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import app from '../src/app.js';
-import { resetRecordStore } from '../src/services/recordStore.js';
 
 let server;
 let baseUrl;
 
-const jsonRequest = async ({ method, path, headers = {}, body }) => {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: {
-      'content-type': 'application/json',
-      ...headers,
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  return {
-    status: response.status,
-    body: await response.json(),
-  };
-};
-
 test.before(async () => {
   await new Promise((resolve) => {
     server = app.listen(0, () => {
-      const port = server.address().port;
-      baseUrl = `http://127.0.0.1:${port}`;
+      baseUrl = `http://127.0.0.1:${server.address().port}`;
       resolve();
     });
   });
@@ -36,103 +18,24 @@ test.after(async () => {
   await new Promise((resolve) => server.close(resolve));
 });
 
-test.beforeEach(() => {
-  resetRecordStore();
+test('GET /health responds with authoritative standard marker', async () => {
+  const response = await fetch(`${baseUrl}/health`);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.status, 'ok');
+  assert.equal(body.standard, 'OTS-V5-corrected');
 });
 
-const validRecord = {
-  qrvid: 'QRV-ENFORCE-1001',
-  issuer: 'issuer-qrv',
-  subject: 'subject-1',
-  issued_at_utc: '2026-04-04T00:00:00Z',
-  metadata_hash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-};
-
-test('invalid create payload is rejected with structured 4xx error', async () => {
-  const response = await jsonRequest({
+test('POST /v1/time/convert/gregorian-to-ot validates required input', async () => {
+  const response = await fetch(`${baseUrl}/v1/time/convert/gregorian-to-ot`, {
     method: 'POST',
-    path: '/api/v1/records',
-    headers: { 'x-actor-role': 'issuer' },
-    body: { qrvid: 'bad' },
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({}),
   });
+
+  const body = await response.json();
 
   assert.equal(response.status, 400);
-  assert.equal(response.body.code, 'INVALID_REQUEST');
-});
-
-test('policy blocks unauthorized revoke', async () => {
-  await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records',
-    headers: { 'x-actor-role': 'issuer' },
-    body: validRecord,
-  });
-
-  const response = await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records/QRV-ENFORCE-1001/revoke',
-    headers: { 'x-actor-role': 'issuer' },
-    body: { revoked_at_utc: '2026-04-04T01:00:00Z', reason: 'test revocation' },
-  });
-
-  assert.equal(response.status, 403);
-  assert.equal(response.body.code, 'POLICY_DENY');
-});
-
-test('status logic returns VERIFIED, REVOKED, EXPIRED, and NOT_FOUND deterministically', async () => {
-  await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records',
-    headers: { 'x-actor-role': 'issuer' },
-    body: { ...validRecord, qrvid: 'QRV-ENFORCE-VERIFIED' },
-  });
-
-  await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records',
-    headers: { 'x-actor-role': 'issuer' },
-    body: { ...validRecord, qrvid: 'QRV-ENFORCE-EXPIRED', expires_at_utc: '2020-01-01T00:00:00Z' },
-  });
-
-  const verified = await jsonRequest({ method: 'GET', path: '/api/v1/verify/QRV-ENFORCE-VERIFIED' });
-  assert.equal(verified.status, 200);
-  assert.equal(verified.body.status, 'VERIFIED');
-
-  await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records/QRV-ENFORCE-VERIFIED/revoke',
-    headers: { 'x-actor-role': 'admin' },
-    body: { revoked_at_utc: '2026-04-04T01:00:00Z', reason: 'security incident' },
-  });
-
-  const revoked = await jsonRequest({ method: 'GET', path: '/api/v1/verify/QRV-ENFORCE-VERIFIED' });
-  assert.equal(revoked.status, 200);
-  assert.equal(revoked.body.status, 'REVOKED');
-
-  const expired = await jsonRequest({ method: 'GET', path: '/api/v1/verify/QRV-ENFORCE-EXPIRED' });
-  assert.equal(expired.status, 200);
-  assert.equal(expired.body.status, 'EXPIRED');
-
-  const missing = await jsonRequest({ method: 'GET', path: '/api/v1/verify/QRV-DOES-NOT-EXIST' });
-  assert.equal(missing.status, 404);
-  assert.equal(missing.body.status, 'NOT_FOUND');
-});
-
-test('invalid revoke payload is rejected with structured 4xx error', async () => {
-  await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records',
-    headers: { 'x-actor-role': 'issuer' },
-    body: validRecord,
-  });
-
-  const response = await jsonRequest({
-    method: 'POST',
-    path: '/api/v1/records/QRV-ENFORCE-1001/revoke',
-    headers: { 'x-actor-role': 'admin' },
-    body: { reason: 'missing timestamp' },
-  });
-
-  assert.equal(response.status, 400);
-  assert.equal(response.body.code, 'INVALID_REQUEST');
+  assert.equal(body.error.code, 'VALIDATION_ERROR');
 });

--- a/test/timeConversion.test.js
+++ b/test/timeConversion.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  daysInOTYear,
+  getOTDayOrder,
+  gregorianToOT,
+  isOTLeapYear,
+  otToGregorian,
+} from '../src/services/timeConversionService.js';
+
+test('2025-03-18 maps to Genesis 01, 0000 OT', () => {
+  const result = gregorianToOT('2025-03-18T00:00:00.000Z');
+
+  assert.equal(result.otYear, 0);
+  assert.equal(result.otMonth, 1);
+  assert.equal(result.otDay, 1);
+  assert.equal(result.otMonthName, 'Genesis');
+});
+
+test('2026-03-17 maps to final day of OT 0000', () => {
+  const result = gregorianToOT('2026-03-17T12:00:00.000Z');
+
+  assert.equal(result.otYear, 0);
+  assert.equal(result.otMonth, 13);
+  assert.equal(result.otDay, 5);
+  assert.equal(result.otMonthName, 'Ascension');
+});
+
+test('2026-03-18 maps to Genesis 01, 0001 OT', () => {
+  const result = gregorianToOT('2026-03-18T00:00:00.000Z');
+
+  assert.equal(result.otYear, 1);
+  assert.equal(result.otMonth, 1);
+  assert.equal(result.otDay, 1);
+  assert.equal(result.otMonthName, 'Genesis');
+});
+
+test('2026-03-26 maps to Genesis 09, 0001 OT and The Fifth Day™ — Onyá·ta', () => {
+  const result = gregorianToOT('2026-03-26T00:00:00.000Z');
+  const dayOrder = getOTDayOrder('2026-03-26T00:00:00.000Z');
+
+  assert.equal(result.otYear, 1);
+  assert.equal(result.otMonth, 1);
+  assert.equal(result.otDay, 9);
+  assert.equal(dayOrder.index, 5);
+  assert.equal(dayOrder.ordinal, 'The Fifth Day™');
+  assert.equal(dayOrder.name, 'Onyá·ta');
+});
+
+test('OT 0002 leap behavior uses Gregorian end-year 2028', () => {
+  assert.equal(isOTLeapYear(2), true);
+  assert.equal(daysInOTYear(2), 366);
+
+  const finalDay = otToGregorian(2, 13, 6);
+  assert.equal(finalDay.gregorianDate, '2028-03-17');
+
+  assert.throws(() => otToGregorian(2, 13, 7), /otDay must be an integer between 1 and 6/);
+});


### PR DESCRIPTION
### Motivation

- Replace the previous verification-portal scaffold with a focused canonical authority layer implementing the Onegodian Timekeeping System (OTS-V5-corrected) so OT is a derived governance layer from UTC/Gregorian.
- Provide deterministic, auditable, and timezone-aware conversion logic for Gregorian↔OT and a canonical timestamp shape to avoid standards drift.
- Surface a minimal, production-safe HTTP API for other services to consume OT conversions and normalization.

### Description

- Added deterministic calendar constants in `src/constants/otCalendar.js` and a pure conversion module `src/services/timeConversionService.js` implementing `gregorianToOT`, `otToGregorian`, `getOTDayOrder`, `isOTLeapYear`, `daysInOTYear`, and `buildCanonicalTimestamp` with explicit timezone validation.
- Introduced REST endpoints and controllers in `src/controllers/timeController.js` and `src/routes/timeRoutes.js` (routes: `GET /health`, `GET /v1/time/now`, `POST /v1/time/convert/gregorian-to-ot`, `POST /v1/time/convert/ot-to-gregorian`, `POST /v1/time/normalize`) and refactored `src/app.js` and `server.js` to expose the API surface.
- Implemented structured input validation and explicit error responses (`VALIDATION_ERROR` and `INVALID_REQUEST`) used across conversion and normalization handlers.
- Added unit/integration tests in `test/timeConversion.test.js` and adjusted `test/enforcement.test.js` to exercise the new API surface and canonical assertions, updated `package.json` scripts, and added `CHANGELOG.md` and a rewritten `README.md` documenting the canonical rules, endpoint examples, and the canonical timestamp schema.

### Testing

- Ran static checks with `npm run check` which completed without errors.
- Ran automated tests with `npm test` (`node --test`) and all tests passed (7 tests, 0 failures) covering epoch, year rollover, day order, and OT leap-year behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d783c41668832db2747f950152ad80)