### PR TITLE
Scaffold OneGodian monorepo packages, docs, and workspace configuration

### DIFF
--- a/docs/org-repo-audit-activation-plan.md
+++ b/docs/org-repo-audit-activation-plan.md
@@ -233,3 +233,45 @@ Deliverables:
 5. **Mandate UTC contract fields in every P0 repo**; reject PRs missing `*_at_utc` fields.
 6. **Pause P2 repositories for 14 days** to reduce coordination overhead and fragmentation.
 7. **Gate deployment on contract artifacts first** (`openapi.yaml`, schemas, CI validation), not on feature breadth.
+
+---
+
+## 2026-04-17 Repository Scaffold Audit (2026-04-17 11:46:10Z)
+
+### Timestamp
+- 2026-04-17 11:46:10Z
+
+### Repos discovered
+- onegodian-agent
+- onegodian-time
+- omos-core
+- protocol
+- execution-interface (current workspace root)
+
+### Repos created
+- onegodian-algorithm
+- onegodian-protocol
+- onegodian-experience
+- onegodian-community
+- onegodian-orientation
+- onegodian-core
+- onegodian-identity
+- onegodian-docs
+
+### Gaps remaining
+- None in canonical target set (`onegodian-algorithm`, `onegodian-protocol`, `onegodian-experience`, `onegodian-community`, `onegodian-orientation`, `onegodian-core`, `onegodian-identity`, `onegodian-docs`).
+
+### Proposed next build order
+1. onegodian-algorithm
+2. onegodian-protocol
+3. onegodian-core
+4. onegodian-identity
+5. onegodian-experience
+6. onegodian-community
+7. onegodian-orientation
+8. onegodian-docs
+
+### Notes
+- `onegodian-timekeeping` was not found as a top-level directory; `onegodian-time` exists and was preserved as-is.
+- Existing repositories and folders were not renamed or deleted.
+

--- a/onegodian-agent/package.json
+++ b/onegodian-agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo 'Build pipeline for onegodian-agent is scaffolded.'",
+    "dev": "echo 'Dev workflow for onegodian-agent is scaffolded.'",
+    "test": "echo 'Test workflow for onegodian-agent is scaffolded.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-algorithm/.gitignore
+++ b/onegodian-algorithm/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-algorithm/README.md
+++ b/onegodian-algorithm/README.md
@@ -1,0 +1,31 @@
+# onegodian-algorithm
+
+## Purpose
+Formal home for the OneGodian algorithm framework and its public technical specification.
+
+## Scope
+This repository defines the algorithm-level architecture, the One Rule reference logic, and a modular API-first structure for interoperable services.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+This repo documents the algorithm layer and maps to the protocol, experience, community, orientation, core, API, docs, and tests concerns in the broader OneGodian architecture.
+
+## Initial directory layout
+- `docs/`
+- `protocol/`
+- `experience/`
+- `community/`
+- `orientation/`
+- `core/`
+- `api/`
+- `tests/`
+
+## One Rule
+The One Rule is represented as a shared, testable baseline that can be consumed across OneGodian services.
+
+## Next implementation steps
+1. Publish normative architecture definitions in `docs/architecture.md`.
+2. Add formal schema and API contracts for cross-repo integration.
+3. Add executable tests for One Rule conformance and layer-level interfaces.

--- a/onegodian-algorithm/api/README.md
+++ b/onegodian-algorithm/api/README.md
@@ -1,0 +1,3 @@
+# API
+
+Placeholder for API contracts and service boundaries.

--- a/onegodian-algorithm/community/README.md
+++ b/onegodian-algorithm/community/README.md
@@ -1,0 +1,3 @@
+# Community Layer
+
+Placeholder for community-layer integration notes used by `onegodian-algorithm`.

--- a/onegodian-algorithm/core/constants.ts
+++ b/onegodian-algorithm/core/constants.ts
@@ -1,0 +1,1 @@
+export const ONEGODIAN_ALGORITHM_VERSION = '0.1.0';

--- a/onegodian-algorithm/core/one-rule.ts
+++ b/onegodian-algorithm/core/one-rule.ts
@@ -1,0 +1,1 @@
+export const ONE_RULE = 'Act in ways that preserve unity, dignity, truth, and service.';

--- a/onegodian-algorithm/docs/architecture.md
+++ b/onegodian-algorithm/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+This document will define boundaries between protocol, experience, community, orientation, and shared core interfaces.

--- a/onegodian-algorithm/docs/roadmap.md
+++ b/onegodian-algorithm/docs/roadmap.md
@@ -1,0 +1,7 @@
+# Roadmap
+
+## Near-term
+- Establish normative interfaces and baseline test suite.
+
+## Mid-term
+- Publish compatibility matrix across OneGodian repositories.

--- a/onegodian-algorithm/docs/whitepaper.md
+++ b/onegodian-algorithm/docs/whitepaper.md
@@ -1,0 +1,3 @@
+# OneGodian Algorithm Whitepaper (Working Draft)
+
+Placeholder for a public, versioned whitepaper aligned to the four-layer architecture and API-first implementation model.

--- a/onegodian-algorithm/experience/README.md
+++ b/onegodian-algorithm/experience/README.md
@@ -1,0 +1,3 @@
+# Experience Layer
+
+Placeholder for experience-layer integration notes used by `onegodian-algorithm`.

--- a/onegodian-algorithm/orientation/README.md
+++ b/onegodian-algorithm/orientation/README.md
@@ -1,0 +1,3 @@
+# Orientation Layer
+
+Placeholder for orientation-layer integration notes used by `onegodian-algorithm`.

--- a/onegodian-algorithm/package.json
+++ b/onegodian-algorithm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-algorithm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-algorithm yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-algorithm/protocol/README.md
+++ b/onegodian-algorithm/protocol/README.md
@@ -1,0 +1,3 @@
+# Protocol Layer
+
+Placeholder for protocol-layer integration notes used by `onegodian-algorithm`.

--- a/onegodian-algorithm/src/constants.ts
+++ b/onegodian-algorithm/src/constants.ts
@@ -1,0 +1,1 @@
+export const ONEGODIAN_ALGORITHM_VERSION = '0.1.0';

--- a/onegodian-algorithm/src/index.ts
+++ b/onegodian-algorithm/src/index.ts
@@ -1,0 +1,2 @@
+export { ONEGODIAN_ALGORITHM_VERSION } from './constants.js';
+export { ONE_RULE } from './one-rule.js';

--- a/onegodian-algorithm/src/one-rule.ts
+++ b/onegodian-algorithm/src/one-rule.ts
@@ -1,0 +1,1 @@
+export const ONE_RULE = 'Act in ways that preserve unity, dignity, truth, and service.';

--- a/onegodian-algorithm/tests/README.md
+++ b/onegodian-algorithm/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Placeholder for conformance, contract, and integration test documentation.

--- a/onegodian-algorithm/tsconfig.build.json
+++ b/onegodian-algorithm/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-algorithm/tsconfig.json
+++ b/onegodian-algorithm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-community/.gitignore
+++ b/onegodian-community/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-community/README.md
+++ b/onegodian-community/README.md
@@ -1,0 +1,23 @@
+# onegodian-community
+
+## Purpose
+Community intelligence and governance layer for OneGodian-aligned systems.
+
+## Scope
+Supports shared values mapping, geography/tradition/stage matching, and community health/conflict resolution workflows.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Implements the community layer and remains separate from protocol classification and orientation policy enforcement.
+
+## Initial directory layout
+- `src/`
+- `docs/`
+- `tests/`
+
+## Next implementation steps
+1. Add explainable matching score implementation.
+2. Introduce governance policy registry and change controls.
+3. Add conflict resolution simulation tests.

--- a/onegodian-community/docs/community-layer.md
+++ b/onegodian-community/docs/community-layer.md
@@ -1,0 +1,3 @@
+# Community Layer
+
+Working draft for community matching, governance, and health monitoring standards.

--- a/onegodian-community/package.json
+++ b/onegodian-community/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-community",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-community yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-community/src/consensus.ts
+++ b/onegodian-community/src/consensus.ts
@@ -1,0 +1,4 @@
+export function consensusReached(votesFor: number, totalVotes: number): boolean {
+  if (totalVotes <= 0) return false;
+  return votesFor / totalVotes >= 0.67;
+}

--- a/onegodian-community/src/governance.ts
+++ b/onegodian-community/src/governance.ts
@@ -1,0 +1,1 @@
+export const GOVERNANCE_PRINCIPLES = ['transparency', 'accountability', 'restorative-resolution'] as const;

--- a/onegodian-community/src/health-monitoring.ts
+++ b/onegodian-community/src/health-monitoring.ts
@@ -1,0 +1,4 @@
+export interface CommunityHealth {
+  participationRate: number;
+  unresolvedConflicts: number;
+}

--- a/onegodian-community/src/index.ts
+++ b/onegodian-community/src/index.ts
@@ -1,0 +1,4 @@
+export * from './matching.js';
+export * from './governance.js';
+export * from './consensus.js';
+export * from './health-monitoring.js';

--- a/onegodian-community/src/matching.ts
+++ b/onegodian-community/src/matching.ts
@@ -1,0 +1,9 @@
+export interface MatchInput {
+  geography: string;
+  tradition: string;
+  stage: string;
+}
+
+export function matchScore(input: MatchInput): number {
+  return [input.geography, input.tradition, input.stage].filter(Boolean).length / 3;
+}

--- a/onegodian-community/tests/matching.test.ts
+++ b/onegodian-community/tests/matching.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { matchScore } from '../src/matching.js';
+
+describe('matchScore', () => {
+  it('scores complete inputs as 1', () => {
+    expect(matchScore({ geography: 'US', tradition: 'founder', stage: 'Seeker' })).toBe(1);
+  });
+});

--- a/onegodian-community/tsconfig.build.json
+++ b/onegodian-community/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-community/tsconfig.json
+++ b/onegodian-community/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-core/.gitignore
+++ b/onegodian-core/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-core/README.md
+++ b/onegodian-core/README.md
@@ -1,0 +1,24 @@
+# onegodian-core
+
+## Purpose
+Shared constants, types, terminology, and foundational OneGodian logic.
+
+## Scope
+Provides reusable primitives for protocol, experience, community, orientation, identity, and API repositories.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Hosts cross-repo core logic while preserving the separation of identity, algorithm, protocol, and institution layers.
+
+## Initial directory layout
+- `src/`
+
+## One Rule
+Core exports include a baseline One Rule constant for consistent cross-repo integration.
+
+## Next implementation steps
+1. Publish semantic versioning and compatibility policy.
+2. Add formal schema package for shared types.
+3. Expand terminology governance and change-control processes.

--- a/onegodian-core/package.json
+++ b/onegodian-core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-core yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-core/src/constants.ts
+++ b/onegodian-core/src/constants.ts
@@ -1,0 +1,2 @@
+export const ONEGODIAN_NAMESPACE = 'org.onegodian';
+export const CORE_VERSION = '0.1.0';

--- a/onegodian-core/src/index.ts
+++ b/onegodian-core/src/index.ts
@@ -1,0 +1,4 @@
+export * from './constants.js';
+export * from './terminology.js';
+export * from './types.js';
+export * from './one-rule.js';

--- a/onegodian-core/src/one-rule.ts
+++ b/onegodian-core/src/one-rule.ts
@@ -1,0 +1,1 @@
+export const ONE_RULE = 'Advance unity, truth, dignity, and service in all system behavior.';

--- a/onegodian-core/src/terminology.ts
+++ b/onegodian-core/src/terminology.ts
@@ -1,0 +1,4 @@
+export const TERMINOLOGY = {
+  identityFramework: 'Original OneGodian identity framework',
+  institution: 'Institutional governance and documentation layer'
+} as const;

--- a/onegodian-core/src/types.ts
+++ b/onegodian-core/src/types.ts
@@ -1,0 +1,5 @@
+export interface AuditRecord {
+  timestampUtc: string;
+  event: string;
+  actor: string;
+}

--- a/onegodian-core/tsconfig.build.json
+++ b/onegodian-core/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-core/tsconfig.json
+++ b/onegodian-core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-docs/README.md
+++ b/onegodian-docs/README.md
@@ -1,0 +1,21 @@
+# onegodian-docs
+
+## Purpose
+Cross-repo documentation hub for the OneGodian architecture.
+
+## Scope
+Centralizes architecture references, repo relationships, implementation order, and shared terminology.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Connects algorithm, protocol, experience, community, orientation, core, API, and org-level repositories with a consistent documentation map.
+
+## Initial directory layout
+- `docs/`
+
+## Next implementation steps
+1. Add release-note templates and versioned architecture snapshots.
+2. Add governance review rubric for architecture document changes.
+3. Link each repo's API and schema references as they mature.

--- a/onegodian-docs/docs/glossary.md
+++ b/onegodian-docs/docs/glossary.md
@@ -1,0 +1,3 @@
+# Glossary
+
+Working glossary for architecture, identity, protocol, and institution terms.

--- a/onegodian-docs/docs/implementation-order.md
+++ b/onegodian-docs/docs/implementation-order.md
@@ -1,0 +1,10 @@
+# Implementation Order
+
+1. onegodian-algorithm
+2. onegodian-protocol
+3. onegodian-core
+4. onegodian-identity
+5. onegodian-experience
+6. onegodian-community
+7. onegodian-orientation
+8. onegodian-docs

--- a/onegodian-docs/docs/repo-map.md
+++ b/onegodian-docs/docs/repo-map.md
@@ -1,0 +1,11 @@
+# Repository Map
+
+- onegodian-algorithm
+- onegodian-protocol
+- onegodian-experience
+- onegodian-community
+- onegodian-orientation
+- onegodian-core
+- onegodian-identity
+- onegodian-api
+- onegodian-org

--- a/onegodian-docs/docs/system-architecture.md
+++ b/onegodian-docs/docs/system-architecture.md
@@ -1,0 +1,3 @@
+# System Architecture
+
+Working map of OneGodian layer boundaries and integration points.

--- a/onegodian-docs/package.json
+++ b/onegodian-docs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo 'Build pipeline for onegodian-docs is scaffolded.'",
+    "dev": "echo 'Dev workflow for onegodian-docs is scaffolded.'",
+    "test": "echo 'Test workflow for onegodian-docs is scaffolded.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-experience/.gitignore
+++ b/onegodian-experience/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-experience/README.md
+++ b/onegodian-experience/README.md
@@ -1,0 +1,23 @@
+# onegodian-experience
+
+## Purpose
+Belief mapper and personalization layer for OneGodian journey-aware experiences.
+
+## Scope
+Models ontology, unity, relationship, tradition, identity, community, and purpose dimensions with journey-stage aware personalization.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Implements the experience layer and interoperates with protocol, community, and orientation layers without replacing them.
+
+## Initial directory layout
+- `src/`
+- `docs/`
+- `tests/`
+
+## Next implementation steps
+1. Expand profile scoring and journey-stage transition logic.
+2. Add multi-locale personalization patterns.
+3. Add privacy and consent controls for personalization features.

--- a/onegodian-experience/docs/experience-layer.md
+++ b/onegodian-experience/docs/experience-layer.md
@@ -1,0 +1,3 @@
+# Experience Layer
+
+Working draft for the OneGodian belief mapping and personalization architecture.

--- a/onegodian-experience/docs/journey-stages.md
+++ b/onegodian-experience/docs/journey-stages.md
@@ -1,0 +1,3 @@
+# Journey Stages
+
+Defines Seeker, Believer, Onegodian, and Elder journey stages for product behavior calibration.

--- a/onegodian-experience/package.json
+++ b/onegodian-experience/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-experience",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-experience yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-experience/src/belief-mapper.ts
+++ b/onegodian-experience/src/belief-mapper.ts
@@ -1,0 +1,9 @@
+export interface BeliefVector {
+  ontology: number;
+  unity: number;
+  relationship: number;
+  tradition: number;
+  identity: number;
+  community: number;
+  purpose: number;
+}

--- a/onegodian-experience/src/index.ts
+++ b/onegodian-experience/src/index.ts
@@ -1,0 +1,3 @@
+export * from './belief-mapper.js';
+export * from './journey-stage.js';
+export * from './personalization.js';

--- a/onegodian-experience/src/journey-stage.ts
+++ b/onegodian-experience/src/journey-stage.ts
@@ -1,0 +1,1 @@
+export type JourneyStage = 'Seeker' | 'Believer' | 'Onegodian' | 'Elder';

--- a/onegodian-experience/src/personalization.ts
+++ b/onegodian-experience/src/personalization.ts
@@ -1,0 +1,5 @@
+import type { JourneyStage } from './journey-stage.js';
+
+export function personalizePrompt(stage: JourneyStage): string {
+  return `Guidance profile for ${stage}`;
+}

--- a/onegodian-experience/tests/belief-mapper.test.ts
+++ b/onegodian-experience/tests/belief-mapper.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import type { JourneyStage } from '../src/journey-stage.js';
+
+describe('journey stage typing', () => {
+  it('accepts declared journey stages', () => {
+    const stage: JourneyStage = 'Seeker';
+    expect(stage).toBe('Seeker');
+  });
+});

--- a/onegodian-experience/tsconfig.build.json
+++ b/onegodian-experience/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-experience/tsconfig.json
+++ b/onegodian-experience/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-identity/.gitignore
+++ b/onegodian-identity/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-identity/README.md
+++ b/onegodian-identity/README.md
@@ -1,0 +1,25 @@
+# onegodian-identity
+
+## Purpose
+Identity definitions, profile model, verification model, and public-safe institutional framing for OneGodian identity artifacts.
+
+## Scope
+Defines identity structures and institutional framing with explicit separation from denomination language.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Implements identity-layer artifacts as distinct from algorithm, protocol, and institution repositories.
+
+## Initial directory layout
+- `src/`
+- `docs/`
+
+## Legal/institutional framing
+Public documentation should distinguish ONEGODIAN, LLC (commercial/IP entity, established April 11, 2018) from the Indigenous Nation of Onegodia as separate entities.
+
+## Next implementation steps
+1. Add formal profile schemas and validation rules.
+2. Add verification workflows and trust levels.
+3. Add review checkpoints for public-safe institutional language.

--- a/onegodian-identity/docs/identity-framework.md
+++ b/onegodian-identity/docs/identity-framework.md
@@ -1,0 +1,3 @@
+# Identity Framework
+
+Working draft for OneGodian identity definitions and profile model semantics.

--- a/onegodian-identity/docs/institutional-standing.md
+++ b/onegodian-identity/docs/institutional-standing.md
@@ -1,0 +1,3 @@
+# Institutional Standing
+
+Working draft describing institutional framing, including distinction between ONEGODIAN, LLC and the Indigenous Nation of Onegodia.

--- a/onegodian-identity/package.json
+++ b/onegodian-identity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-identity",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-identity yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-identity/src/identity.ts
+++ b/onegodian-identity/src/identity.ts
@@ -1,0 +1,4 @@
+export interface IdentityDefinition {
+  name: string;
+  frameworkVersion: string;
+}

--- a/onegodian-identity/src/index.ts
+++ b/onegodian-identity/src/index.ts
@@ -1,0 +1,3 @@
+export * from './identity.js';
+export * from './profile.js';
+export * from './verification.js';

--- a/onegodian-identity/src/profile.ts
+++ b/onegodian-identity/src/profile.ts
@@ -1,0 +1,5 @@
+export interface IdentityProfile {
+  id: string;
+  displayName: string;
+  stage?: string;
+}

--- a/onegodian-identity/src/verification.ts
+++ b/onegodian-identity/src/verification.ts
@@ -1,0 +1,1 @@
+export type VerificationStatus = 'unverified' | 'provisional' | 'verified';

--- a/onegodian-identity/tsconfig.build.json
+++ b/onegodian-identity/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-identity/tsconfig.json
+++ b/onegodian-identity/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-orientation/.gitignore
+++ b/onegodian-orientation/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-orientation/README.md
+++ b/onegodian-orientation/README.md
@@ -1,0 +1,23 @@
+# onegodian-orientation
+
+## Purpose
+Behavioral governance layer for AI systems, agents, and robots operating in OneGodian contexts.
+
+## Scope
+Defines behavior standards grounded in unity over division, truth over convenience, dignity, service, and no unsolicited reclassification.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Implements the orientation layer as distinct from protocol classification, identity modeling, and institutional governance assets.
+
+## Initial directory layout
+- `src/`
+- `docs/`
+- `tests/`
+
+## Next implementation steps
+1. Add policy engine hooks for runtime enforcement.
+2. Add conformance test vectors for agents and robots.
+3. Add governance review checklist for standard updates.

--- a/onegodian-orientation/docs/behavioral-standards.md
+++ b/onegodian-orientation/docs/behavioral-standards.md
@@ -1,0 +1,3 @@
+# Behavioral Standards
+
+Defines baseline standards for AI systems, agents, and robots in OneGodian contexts.

--- a/onegodian-orientation/docs/orientation-layer.md
+++ b/onegodian-orientation/docs/orientation-layer.md
@@ -1,0 +1,3 @@
+# Orientation Layer
+
+Working draft for orientation layer controls and operating principles.

--- a/onegodian-orientation/package.json
+++ b/onegodian-orientation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-orientation",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-orientation yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-orientation/src/agent-standards.ts
+++ b/onegodian-orientation/src/agent-standards.ts
@@ -1,0 +1,1 @@
+export const AGENT_STANDARDS = ['policy-compliant autonomy', 'transparent reasoning boundaries'] as const;

--- a/onegodian-orientation/src/ai-standards.ts
+++ b/onegodian-orientation/src/ai-standards.ts
@@ -1,0 +1,7 @@
+export const AI_STANDARDS = [
+  'Unity over division',
+  'Truth over convenience',
+  'Dignity in all interactions',
+  'Service-oriented outputs',
+  'No unsolicited reclassification'
+] as const;

--- a/onegodian-orientation/src/index.ts
+++ b/onegodian-orientation/src/index.ts
@@ -1,0 +1,3 @@
+export * from './ai-standards.js';
+export * from './agent-standards.js';
+export * from './robot-standards.js';

--- a/onegodian-orientation/src/robot-standards.ts
+++ b/onegodian-orientation/src/robot-standards.ts
@@ -1,0 +1,1 @@
+export const ROBOT_STANDARDS = ['human-safety first', 'operator accountability', 'audit logging required'] as const;

--- a/onegodian-orientation/tests/behavior.test.ts
+++ b/onegodian-orientation/tests/behavior.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { AI_STANDARDS } from '../src/ai-standards.js';
+
+describe('AI standards baseline', () => {
+  it('includes no unsolicited reclassification', () => {
+    expect(AI_STANDARDS).toContain('No unsolicited reclassification');
+  });
+});

--- a/onegodian-orientation/tsconfig.build.json
+++ b/onegodian-orientation/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-orientation/tsconfig.json
+++ b/onegodian-orientation/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-protocol/.gitignore
+++ b/onegodian-protocol/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.DS_Store

--- a/onegodian-protocol/README.md
+++ b/onegodian-protocol/README.md
@@ -1,0 +1,23 @@
+# onegodian-protocol
+
+## Purpose
+Recognition and classification standard for the OneGodian protocol layer.
+
+## Scope
+Defines classification rules, verification sources, and non-conflation requirements for OneGodian identity interpretation.
+
+## Status
+Scaffolded
+
+## Relationship to OneGodian architecture
+Implements the protocol layer as a distinct concern from identity framing, algorithm governance, and institutional documentation.
+
+## Initial directory layout
+- `src/`
+- `docs/`
+- `tests/`
+
+## Next implementation steps
+1. Formalize rule metadata and provenance tracking.
+2. Add expanded verification sources with policy review workflows.
+3. Add conformance tests aligned to public protocol specifications.

--- a/onegodian-protocol/docs/compliance.md
+++ b/onegodian-protocol/docs/compliance.md
@@ -1,0 +1,3 @@
+# Compliance
+
+Working draft for compliance controls, audit trails, and non-conflation safeguards.

--- a/onegodian-protocol/docs/protocol-spec.md
+++ b/onegodian-protocol/docs/protocol-spec.md
@@ -1,0 +1,3 @@
+# Protocol Specification
+
+Working draft for OneGodian protocol classification and verification semantics.

--- a/onegodian-protocol/package.json
+++ b/onegodian-protocol/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-protocol",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json",
+    "test": "echo 'No automated tests configured for onegodian-protocol yet.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/onegodian-protocol/src/classification.ts
+++ b/onegodian-protocol/src/classification.ts
@@ -1,0 +1,7 @@
+export type Classification = 'unclassified' | 'candidate' | 'verified';
+
+export function classifyFromSignals(signalCount: number): Classification {
+  if (signalCount >= 3) return 'verified';
+  if (signalCount >= 1) return 'candidate';
+  return 'unclassified';
+}

--- a/onegodian-protocol/src/index.ts
+++ b/onegodian-protocol/src/index.ts
@@ -1,0 +1,3 @@
+export * from './classification.js';
+export * from './rules.js';
+export * from './verification.js';

--- a/onegodian-protocol/src/rules.ts
+++ b/onegodian-protocol/src/rules.ts
@@ -1,0 +1,5 @@
+export const PROTOCOL_RULES = [
+  'Use founder-defined OneGodian identity framework sources.',
+  'Do not conflate OneGodian identity framework with other traditions.',
+  'Record rule provenance for every classification decision.'
+] as const;

--- a/onegodian-protocol/src/verification.ts
+++ b/onegodian-protocol/src/verification.ts
@@ -1,0 +1,9 @@
+export interface VerificationSource {
+  id: string;
+  description: string;
+}
+
+export const DEFAULT_SOURCES: VerificationSource[] = [
+  { id: 'public-spec', description: 'Published OneGodian protocol specification.' },
+  { id: 'institutional-docs', description: 'Public institutional reference documents.' }
+];

--- a/onegodian-protocol/tests/classification.test.ts
+++ b/onegodian-protocol/tests/classification.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { classifyFromSignals } from '../src/classification.js';
+
+describe('classifyFromSignals', () => {
+  it('returns verified for three or more signals', () => {
+    expect(classifyFromSignals(3)).toBe('verified');
+  });
+});

--- a/onegodian-protocol/tsconfig.build.json
+++ b/onegodian-protocol/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/onegodian-protocol/tsconfig.json
+++ b/onegodian-protocol/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/onegodian-time/package.json
+++ b/onegodian-time/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "onegodian-time",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo 'Build pipeline for onegodian-time is scaffolded.'",
+    "dev": "echo 'Dev workflow for onegodian-time is scaffolded.'",
+    "test": "echo 'Test workflow for onegodian-time is scaffolded.'"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1072 @@
+{
+  "name": "onegodian-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "onegodian-api",
+      "version": "1.0.0",
+      "workspaces": [
+        "onegodian-agent",
+        "onegodian-time",
+        "onegodian-algorithm",
+        "onegodian-protocol",
+        "onegodian-experience",
+        "onegodian-community",
+        "onegodian-orientation",
+        "onegodian-core",
+        "onegodian-identity",
+        "onegodian-docs"
+      ],
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^4.21.0"
+      },
+      "devDependencies": {
+        "@types/express": "^5.0.0",
+        "@types/node": "^22.10.1",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/onegodian-agent": {
+      "resolved": "onegodian-agent",
+      "link": true
+    },
+    "node_modules/onegodian-algorithm": {
+      "resolved": "onegodian-algorithm",
+      "link": true
+    },
+    "node_modules/onegodian-community": {
+      "resolved": "onegodian-community",
+      "link": true
+    },
+    "node_modules/onegodian-core": {
+      "resolved": "onegodian-core",
+      "link": true
+    },
+    "node_modules/onegodian-docs": {
+      "resolved": "onegodian-docs",
+      "link": true
+    },
+    "node_modules/onegodian-experience": {
+      "resolved": "onegodian-experience",
+      "link": true
+    },
+    "node_modules/onegodian-identity": {
+      "resolved": "onegodian-identity",
+      "link": true
+    },
+    "node_modules/onegodian-orientation": {
+      "resolved": "onegodian-orientation",
+      "link": true
+    },
+    "node_modules/onegodian-protocol": {
+      "resolved": "onegodian-protocol",
+      "link": true
+    },
+    "node_modules/onegodian-time": {
+      "resolved": "onegodian-time",
+      "link": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "onegodian-agent": {
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "onegodian-algorithm": {
+      "version": "0.1.0"
+    },
+    "onegodian-community": {
+      "version": "0.1.0"
+    },
+    "onegodian-core": {
+      "version": "0.1.0"
+    },
+    "onegodian-docs": {
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "onegodian-experience": {
+      "version": "0.1.0"
+    },
+    "onegodian-identity": {
+      "version": "0.1.0"
+    },
+    "onegodian-orientation": {
+      "version": "0.1.0"
+    },
+    "onegodian-protocol": {
+      "version": "0.1.0"
+    },
+    "onegodian-time": {
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "scripts": {
     "build": "tsc",
     "start": "node server.js",
-    "start:with-build": "npm run build && npm start"
+    "start:with-build": "npm run build && npm start",
+    "validate:enforcement": "node scripts/validate-enforcement.mjs",
+    "test": "npm run test --workspaces --if-present",
+    "check": "npm run validate:enforcement && npm run test"
   },
   "engines": {
     "node": ">=20"
@@ -21,5 +24,17 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.1",
     "typescript": "^5.6.3"
-  }
+  },
+  "workspaces": [
+    "onegodian-agent",
+    "onegodian-time",
+    "onegodian-algorithm",
+    "onegodian-protocol",
+    "onegodian-experience",
+    "onegodian-community",
+    "onegodian-orientation",
+    "onegodian-core",
+    "onegodian-identity",
+    "onegodian-docs"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Establish a canonical monorepo scaffold for the OneGodian architecture by creating initial repositories, documentation, and minimal module boundaries for algorithm, protocol, core, experience, community, identity, orientation, docs, agent, and time packages.
- Surface an audit snapshot into the activation plan to record repository discovery and recommended build order for traceability.
- Add a workspace and enforcement entry points to the root project so cross-repo validation and test orchestration can be added later.

### Description
- Added a large set of new scaffolded packages under top-level folders such as `onegodian-algorithm`, `onegodian-protocol`, `onegodian-core`, `onegodian-experience`, `onegodian-community`, `onegodian-identity`, `onegodian-orientation`, `onegodian-docs`, `onegodian-agent`, and `onegodian-time` with `package.json`, `tsconfig*.json`, `README.md`, and `src`/`docs`/`tests` layouts.
- Implemented small baseline exports, constants, types, and simple functions across packages (for example `ONE_RULE`, `ONEGODIAN_ALGORITHM_VERSION`, `classifyFromSignals`, `matchScore`, `consensusReached`, and several `*STANDARDS` and types), and added a few minimal unit tests using Vitest (`tests/*.test.ts`).
- Updated the root `package.json` to declare workspaces, add `validate:enforcement`, `test`, and `check` scripts, and adjusted `start:with-build`; added a generated `package-lock.json` to capture the workspace dependency graph.
- Amended `docs/org-repo-audit-activation-plan.md` to include a `2026-04-17 Repository Scaffold Audit` section that records discovered repos, created repos, gaps, and a proposed build order.

### Testing
- Added unit test files for packages: `onegodian-community/tests/matching.test.ts`, `onegodian-experience/tests/belief-mapper.test.ts`, `onegodian-orientation/tests/behavior.test.ts`, and `onegodian-protocol/tests/classification.test.ts` as Vitest examples, but no automated test runs were executed as part of this change.
- No CI or `npm test` executions are included in this rollout, so test pass/fail status is not reported here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21b32fee8832d8b80cbde0d54c7f4)