### PR TITLE
Stabilize OneGodian verification portal: routes, docs, QA, and architecture page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 PORT=3000
 NEXT_PUBLIC_API_URL=https://api.qrv.network
+API_BASE_URL=https://api.qrv.network
 NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 npm-debug.log*
 .DS_Store
 coverage/
+
+dist/

--- a/README.md
+++ b/README.md
@@ -1,222 +1,102 @@
-# qrv-verify-portal
+# OneGodian Verify Portal
 
-`qrv-verify-portal` is the public verification resolution interface for the QR-V™ Global Verification Network. It is designed to run at `https://verify.qrv.network` and acts as the public-facing layer between a scanned QR-V identifier and the registry-backed verification API at `https://api.qrv.network`.
+`onegodian-verify-portal` is the public verification resolution interface for the OneGodian ecosystem and the QR-V™ Global Verification Network. It is designed to run at `https://verify.qrv.network` and resolve QRVID lookups against `https://api.qrv.network`.
 
-This repository intentionally implements a focused verification portal rather than a generic marketing website. The interface accepts QRVIDs, resolves them against the authoritative API, and renders deterministic verification results for institutional users.
+## What this service does
 
-
-## OneGodian Production Acceleration Assets
-
-- Protocol package: `protocol/README.md`
-- Prompt deployment package: `prompt/DEPLOYMENT.md`
-- OHI pipeline demo module: `pipeline/README.md`
-- Public identity definition endpoint: `GET /api/omos/identity-definition`
-- Production status and scope: `IMPLEMENTATION_STATUS.md`, `CURRENT_SCOPE.md`
-
-## Role in the QR-V System
-
-The portal sits in the public verification path:
-
-```text
-QR Scan → verify.qrv.network → api.qrv.network → registry → response → display result
-```
-
-### Service responsibilities
-
-- Accept QR-V identifiers (QRVIDs) through a direct URL or manual entry.
-- Validate and sanitize incoming identifiers before requesting data.
-- Call `GET https://api.qrv.network/verify/:qrvid`.
-- Render structured verification results for `VERIFIED`, `INVALID`, `REVOKED`, `EXPIRED`, and service-unavailable states.
-- Present an authoritative, mobile-friendly interface with minimal client-side logic.
-
-## How verification works
-
-1. A user scans a QR code or opens a verification URL such as `/QRV-123456789`.
-2. The portal sanitizes the QRVID and validates its format server-side.
-3. The verification service requests `GET {NEXT_PUBLIC_API_URL}/verify/:qrvid`.
-4. The portal normalizes the response payload and status.
-5. The result page displays the verification state, issuer, record type, subject, timestamp, and truncated hash when available.
-6. If the upstream API times out or becomes unreachable, the portal retries once and then renders a deterministic unavailable state.
-
-## Architecture and project structure
-
-```text
-qrv-verify-portal/
-├── docs/
-│   └── architecture.md
-├── public/
-│   ├── assets/
-│   ├── css/
-│   │   └── styles.css
-│   └── js/
-│       └── app.js
-├── src/
-│   ├── controllers/
-│   │   ├── healthController.js
-│   │   └── verificationController.js
-│   ├── routes/
-│   │   ├── index.js
-│   │   └── verificationRoutes.js
-│   ├── services/
-│   │   └── verificationService.js
-│   ├── utils/
-│   │   └── qrvid.js
-│   ├── views/
-│   │   ├── indexView.js
-│   │   ├── layout.js
-│   │   └── resultView.js
-│   └── app.js
-├── .env.example
-├── Dockerfile
-├── package.json
-├── server.js
-└── README.md
-```
+- Resolves QRVIDs from direct URLs or manual input.
+- Calls the upstream verification API (`GET /verify/:qrvid`).
+- Renders deterministic states (`VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`, `UNAVAILABLE`).
+- Exposes governance APIs under `/api/omos` and verification core APIs under `/api/v1`.
+- Provides operational health and architecture views.
 
 ## Routes
 
-### `GET /`
-Landing page with a QRVID input and a Verify button.
+### Auth/System
+- `GET /health`
 
-### `GET /:qrvid`
-Automatically resolves a QRVID and renders the verification result.
+### API/Core
+- `POST /api/v1/records`
+- `GET /api/v1/verify/:qrvid`
+- `POST /api/v1/records/:qrvid/revoke`
+- `GET /api/omos/identity-definition`
+- `POST /api/omos/classify`
+- `POST /api/omos/align`
+- `POST /api/omos/timestamp/convert`
+- `POST /api/omos/decision/run`
 
-### `GET /verify/:qrvid`
-Explicit verification route that performs the same lookup and rendering.
+### Pages/UI
+- `GET /`
+- `GET /system-architecture`
+- `POST /verify`
+- `GET /verify/:qrvid`
+- `GET /:qrvid`
 
-### `POST /verify`
-Form handler that accepts a pasted QRVID and redirects to `/verify/:qrvid`.
+## Quickstart
 
+### Requirements
+- Node.js 20+
+- npm 10+
 
-### `POST /api/v1/records`
-Creates a V1 verification record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `issuer` or `admin`.
-
-### `GET /api/v1/verify/:qrvid`
-Returns deterministic V1 statuses: `VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`.
-
-### `POST /api/v1/records/:qrvid/revoke`
-Revokes an existing record with runtime schema validation and policy enforcement. Requires `x-actor-role` of `admin`.
-
-
-### `GET /api/omos/identity-definition`
-Returns public-facing OneGodian identity classification definitions and guardrails.
-
-### `POST /api/omos/classify`
-Classifies identity tier using the Seeker → Believer → Onegodian → Elder model.
-
-### `POST /api/omos/align`
-Loads `/alignment/system-prompt.txt` and runs Unity, Truth, and Dignity checks.
-
-### `POST /api/omos/timestamp/convert`
-Converts UTC ↔ OT using OTS-V5 epoch and deterministic rollover rules.
-
-### `POST /api/omos/decision/run`
-Runs the Onegodian decision pipeline: Observe → Distill → Align → Select → Execute → Verify.
-
-### `GET /health`
-Returns:
-
-```json
-{
-  "status": "ok",
-  "service": "verify-portal"
-}
+### Setup
+```bash
+npm install
+cp .env.example .env
 ```
+
+### Run
+```bash
+npm run build
+npm start
+```
+Open `http://localhost:3000`.
 
 ## Environment variables
 
-Copy `.env.example` to `.env` and configure as needed:
+Use `.env.example` as your baseline:
 
 ```env
 PORT=3000
 NEXT_PUBLIC_API_URL=https://api.qrv.network
+API_BASE_URL=https://api.qrv.network
 NODE_ENV=development
 ```
 
-## Local setup
-
-### Requirements
-
-- Node.js 18+
-- npm 9+
-
-### Install and run
+## Quality gates
 
 ```bash
-npm install
-cp .env.example .env
-npm run dev
-```
-
-For a production-style local run:
-
-```bash
-npm install --omit=dev
-npm start
-```
-
-Open `http://localhost:3000`.
-
-## Deployment instructions
-
-### Standard Node deployment
-
-1. Provision a Node.js 18+ runtime.
-2. Set environment variables:
-   - `PORT`
-   - `NEXT_PUBLIC_API_URL=https://api.qrv.network` (or `API_BASE_URL` for legacy compatibility)
-   - `NODE_ENV=production`
-3. Install dependencies with `npm install --omit=dev`.
-4. Start the service with `npm start`.
-5. Map the public domain `verify.qrv.network` to the running service.
-6. Confirm `/health` responds with the expected JSON payload.
-
-### Docker deployment
-
-Build and run:
-
-```bash
-docker build -t qrv-verify-portal .
-docker run --rm -p 3000:3000 --env-file .env qrv-verify-portal
-```
-
-## Security and reliability notes
-
-- Client input is sanitized and validated before use.
-- The portal never connects directly to a database.
-- `api.qrv.network` is the verification data source for this portal, configured via `NEXT_PUBLIC_API_URL`.
-- API timeouts trigger a single retry before showing an unavailable state.
-- The service logs verification lookups for simple operational analytics.
-
-## Running checks
-
-```bash
-npm run check
-npm run validate:enforcement
+npm run lint
+npm run typecheck
 npm test
+npm run test:root
+npm run build
+npm run check
 ```
 
-## Git initialization and push commands
+## Deployment
 
-If you are starting from a fresh local clone or a new repository, use:
+### Standard Node runtime
+1. Build the app with `npm run build`.
+2. Install production deps with `npm install --omit=dev`.
+3. Set `NODE_ENV=production` and API URL env vars.
+4. Start using `npm start`.
+5. Verify `GET /health`.
 
+### Docker
 ```bash
-git init
-git add .
-git commit -m "Create QR-V verification portal"
-git branch -M main
-git remote add origin <your-repository-url>
-git push -u origin main
+docker build -t onegodian-verify-portal .
+docker run --rm -p 3000:3000 --env-file .env onegodian-verify-portal
 ```
 
-If the repository is already initialized, use:
+## Troubleshooting
 
-```bash
-git add .
-git commit -m "Create QR-V verification portal"
-git push
-```
+- **`npm run build` fails with missing type declarations**: run `npm install` to ensure dev dependencies are present.
+- **`/verify/:qrvid` shows unavailable**: validate outbound network access and `NEXT_PUBLIC_API_URL`.
+- **Invalid identifier errors**: ensure values follow `QRV-123456789` format.
+- **Port collision**: set `PORT` to an open port.
 
-## License
+## Security notes
 
-MIT
+- Input is sanitized server-side before outbound requests.
+- No direct database access is exposed in this service.
+- Unavailable upstream responses render deterministic safe defaults.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,13 +1036,22 @@
       }
     },
     "onegodian-algorithm": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-community": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-core": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-docs": {
       "version": "0.1.0",
@@ -1051,16 +1060,28 @@
       }
     },
     "onegodian-experience": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-identity": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-orientation": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-protocol": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "onegodian-time": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "start:with-build": "npm run build && npm start",
     "validate:enforcement": "node scripts/validate-enforcement.mjs",
     "test": "npm run test --workspaces --if-present",
-    "check": "npm run validate:enforcement && npm run test"
+    "check": "npm run validate:enforcement && npm run lint && npm run typecheck && npm run test && npm run test:root && npm run build",
+    "lint": "node scripts/lint.mjs",
+    "typecheck": "tsc --noEmit",
+    "test:root": "node --test test/*.test.js"
   },
   "engines": {
     "node": ">=20"

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -285,3 +285,66 @@ dd {
     width: 100%;
   }
 }
+
+.top-nav {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.top-nav a,
+.button-link {
+  text-decoration: none;
+  border: 1px solid #d8e4f2;
+  border-radius: 12px;
+  padding: 0.55rem 0.9rem;
+  color: var(--accent);
+  font-weight: 600;
+  background: #eff4fa;
+}
+
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cta-row {
+  justify-content: flex-start;
+  margin-top: 1rem;
+}
+
+.architecture-overview h3,
+.architecture-stack h3 {
+  margin-top: 0;
+}
+
+.architecture-grid dd {
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.architecture-stack {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.architecture-stack article {
+  border: 1px solid #e7edf3;
+  border-radius: 14px;
+  background: #f8fafc;
+  padding: 1rem;
+}
+
+@media (max-width: 640px) {
+  .top-nav {
+    flex-direction: column;
+  }
+
+  .architecture-stack {
+    grid-template-columns: 1fr;
+  }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -33,6 +33,7 @@ if (copyButton) {
     const qrvid = copyButton.getAttribute('data-qrvid');
 
     try {
+      if (!navigator.clipboard || !qrvid) { throw new Error('Clipboard unavailable'); }
       await navigator.clipboard.writeText(qrvid);
       copyButton.textContent = 'Copied';
       setTimeout(() => {

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,63 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const SCAN_DIRS = ['src', 'scripts', 'test', 'public/js'];
+const JS_EXTENSIONS = new Set(['.js', '.mjs']);
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walk(fullPath)));
+      continue;
+    }
+
+    if (JS_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+const run = async () => {
+  const files = [];
+
+  for (const scanDir of SCAN_DIRS) {
+    files.push(...(await walk(path.join(ROOT, scanDir))));
+  }
+
+  files.push(path.join(ROOT, 'server.js'));
+
+  const failures = [];
+  for (const file of files) {
+    const result = spawnSync(process.execPath, ['--check', file], { stdio: 'pipe', encoding: 'utf8' });
+    if (result.status !== 0) {
+      failures.push({ file, output: result.stderr || result.stdout });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`\nSyntax issue in ${path.relative(ROOT, failure.file)}\n${failure.output}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Lint passed: ${files.length} JavaScript files validated.`);
+};
+
+run().catch((error) => {
+  console.error('Lint failed unexpectedly:', error);
+  process.exit(1);
+});

--- a/src/controllers/healthController.js
+++ b/src/controllers/healthController.js
@@ -1,6 +1,9 @@
 export const healthHandler = (_req, res) => {
   res.status(200).json({
     status: 'ok',
-    service: 'verify-portal',
+    service: 'onegodian-verify-portal',
+    version: process.env.npm_package_version || '1.0.0',
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV || 'development',
   });
 };

--- a/src/controllers/verificationController.js
+++ b/src/controllers/verificationController.js
@@ -2,6 +2,7 @@ import { verifyQRVID } from '../services/verificationService.js';
 import { sanitizeQRVID } from '../utils/qrvid.js';
 import { renderIndexView } from '../views/indexView.js';
 import { renderResultView } from '../views/resultView.js';
+import { renderSystemArchitectureView } from '../views/systemArchitectureView.js';
 
 const basePageModel = {
   pageTitle: 'QR-V™ Verification',
@@ -43,5 +44,11 @@ export const renderVerificationResult = async (req, res) => {
     verification: result.verification,
     errorSummary: result.ok ? null : result.error,
     autoVerify: true,
+  }));
+};
+
+export const renderSystemArchitecturePage = (_req, res) => {
+  res.status(200).send(renderSystemArchitectureView({
+    pageTitle: 'OneGodian System Architecture',
   }));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ app.get("/v1/definition", (_req, res) => {
   res.json({
     name: "ONEGODIAN",
     classification: "founder-defined identity framework",
-    description: "Core API definition endpoint for the Onegodian system"
+    description: "Core API definition endpoint for the OneGodian system"
   });
 });
 
@@ -85,7 +85,7 @@ app.use((err: Error, _req: express.Request, res: express.Response, _next: expres
 });
 
 const server = app.listen(PORT, () => {
-  console.log(`Onegodian API running on port ${PORT}`);
+  console.log(`OneGodian API running on port ${PORT}`);
 });
 
 const shutdown = (signal: string) => {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,16 +1,26 @@
 import { Router } from 'express';
-import verificationRoutes from './verificationRoutes.js';
 import v1Routes from './api/v1Routes.js';
-import { renderLandingPage, renderVerificationResult } from '../controllers/verificationController.js';
-import { healthHandler } from '../controllers/healthController.js';
 import omosRoutes from './api/omosRoutes.js';
+import verificationRoutes from './verificationRoutes.js';
+import {
+  renderLandingPage,
+  renderSystemArchitecturePage,
+  renderVerificationResult,
+} from '../controllers/verificationController.js';
+import { healthHandler } from '../controllers/healthController.js';
 
 const router = Router();
 
+// 1) auth/system
 router.get('/health', healthHandler);
+
+// 2) API/core
 router.use('/api/v1', v1Routes);
 router.use('/api/omos', omosRoutes);
+
+// 3) pages/ui
 router.get('/', renderLandingPage);
+router.get('/system-architecture', renderSystemArchitecturePage);
 router.use('/verify', verificationRoutes);
 router.get('/:qrvid', renderVerificationResult);
 

--- a/src/types/cors.d.ts
+++ b/src/types/cors.d.ts
@@ -1,0 +1,1 @@
+declare module 'cors';

--- a/src/views/indexView.js
+++ b/src/views/indexView.js
@@ -5,11 +5,16 @@ export const renderIndexView = ({ pageTitle, qrvid }) => renderLayout({
   body: `<main class="content-wrap">
   <section class="card hero-card">
     <div>
-      <p class="section-label">Verification Resolution Interface</p>
-      <h2>Resolve a QRVID</h2>
+      <p class="section-label">OneGodian Verification Resolution Interface</p>
+      <h2>Trust every QR-V verification decision.</h2>
       <p class="supporting-copy">
-        Enter a QR-V identifier to verify the latest registry-backed status from the verification API.
+        Resolve QRVIDs against the registry-backed API, inspect status metadata, and navigate the
+        OneGodian system architecture used for deterministic verification.
       </p>
+      <div class="actions-row cta-row">
+        <a class="button-link" href="/system-architecture">View Architecture</a>
+        <a class="button-link secondary-button" href="/health">System Health</a>
+      </div>
     </div>
 
     <form class="verify-form" method="post" action="/verify" data-verify-form>
@@ -32,6 +37,17 @@ export const renderIndexView = ({ pageTitle, qrvid }) => renderLayout({
       </div>
       <p id="qrvid-hint" class="field-hint">Accepted format: <span>QRV-123456789</span></p>
     </form>
+  </section>
+
+  <section class="card architecture-overview">
+    <p class="section-label">System Overview</p>
+    <h3>Verification control plane and data path</h3>
+    <div class="metadata-grid architecture-grid">
+      <div><dt>Edge + UI</dt><dd>Landing page, verification flow, and deterministic result rendering.</dd></div>
+      <div><dt>API Layer</dt><dd>/api/v1 records and /api/omos governance endpoints.</dd></div>
+      <div><dt>Policy + Governance</dt><dd>Runtime schema validation, role policy enforcement, and alignment checks.</dd></div>
+      <div><dt>Audit + Health</dt><dd>Health endpoint, request logs, and verification status telemetry.</dd></div>
+    </div>
   </section>
 </main>`,
 });

--- a/src/views/layout.js
+++ b/src/views/layout.js
@@ -15,7 +15,7 @@ export const renderLayout = ({ pageTitle, body, pageScript = '' }) => `<!DOCTYPE
     <title>${escapeHtml(pageTitle)}</title>
     <meta
       name="description"
-      content="Registry-backed QR-V™ verification interface for resolving QRVIDs against the QR-V™ Global Verification Network."
+      content="OneGodian registry-backed verification interface for resolving QRVIDs against the QR-V™ Global Verification Network."
     />
     <link rel="stylesheet" href="/css/styles.css" />
     <script defer src="/js/app.js"></script>
@@ -23,13 +23,18 @@ export const renderLayout = ({ pageTitle, body, pageScript = '' }) => `<!DOCTYPE
   <body>
     <div class="page-shell">
       <header class="page-header">
-        <p class="eyebrow">QR-V™ Global Verification Network</p>
-        <h1>QR-V™ Verification</h1>
+        <p class="eyebrow">OneGodian • QR-V™ Global Verification Network</p>
+        <h1>OneGodian Verification Portal</h1>
         <p class="subtitle">Deterministic registry-backed verification for QR-V identifiers.</p>
+        <nav class="top-nav" aria-label="Primary">
+          <a href="/">Homepage</a>
+          <a href="/system-architecture">System Architecture</a>
+          <a href="/health">Health</a>
+        </nav>
       </header>
       ${body}
       <footer class="page-footer">
-        <p>Powered by QR-V™ Global Verification Network</p>
+        <p>Powered by OneGodian infrastructure and the QR-V™ Global Verification Network.</p>
       </footer>
     </div>
     ${pageScript}

--- a/src/views/systemArchitectureView.js
+++ b/src/views/systemArchitectureView.js
@@ -1,0 +1,34 @@
+import { renderLayout } from './layout.js';
+
+export const renderSystemArchitectureView = ({ pageTitle }) => renderLayout({
+  pageTitle,
+  body: `<main class="content-wrap">
+  <section class="card">
+    <p class="section-label">OneGodian Platform Blueprint</p>
+    <h2>System Architecture</h2>
+    <p class="supporting-copy">
+      The verification platform combines a deterministic control plane, governance APIs, and a
+      registry-backed verification data path for production-grade trust decisions.
+    </p>
+
+    <div class="architecture-stack">
+      <article>
+        <h3>1) Auth + System</h3>
+        <p>Health checks, security headers, and request lifecycle handling for stable operations.</p>
+      </article>
+      <article>
+        <h3>2) API + Core</h3>
+        <p>V1 record verification endpoints and OMOS governance APIs for identity, alignment, and decisioning.</p>
+      </article>
+      <article>
+        <h3>3) Pages + UI</h3>
+        <p>Homepage, verification result views, and architecture documentation for operators and partners.</p>
+      </article>
+      <article>
+        <h3>4) Fallback + Recovery</h3>
+        <p>Deterministic unavailable states, safe defaults, and structured error handling to prevent silent failures.</p>
+      </article>
+    </div>
+  </section>
+</main>`,
+});


### PR DESCRIPTION
### Motivation
- Normalize and stabilize the verification portal and API route surface to ensure deterministic route ordering and consistent branding. 
- Harden build and CI flows by adding lint/typecheck and root-level tests to prevent regressions during development. 
- Complete missing UX and docs deliverables by providing a branded homepage, a system architecture page, and clearer run/deploy guidance.

### Description
- Reordered and consolidated routes in `src/routes/index.js` to enforce system → API/core → pages/UI registration and preserved verification and health handlers. 
- Rebuilt the homepage and layout (`src/views/indexView.js`, `src/views/layout.js`) with OneGodian branding, CTAs, a top-nav and architecture overview, and added a new `/system-architecture` view and route (`src/views/systemArchitectureView.js`, controller hook). 
- Improved operational payloads and client safety by enhancing the health handler (`src/controllers/healthController.js`) and adding a clipboard availability guard in `public/js/app.js`. 
- Added repository-quality tooling and fixes: `scripts/lint.mjs` and `lint`/`typecheck`/`test:root` scripts in `package.json`, `.env.example` and `.gitignore` updates, and a local `declare module 'cors'` type file to prevent TypeScript build failures. 

### Testing
- Installed dependencies with `npm install` and ran the lightweight workspace tests, which executed successfully. 
- Ran the JavaScript syntax linter with `npm run lint` and it passed with `Lint passed: 32 JavaScript files validated.`. 
- Performed static type checks with `npm run typecheck` (`tsc --noEmit`) and the typecheck completed without errors. 
- Executed unit and integration tests with `npm test` and `npm run test:root` and all test suites passed (TAP output showed 8/8 passing). 
- Built the TypeScript artifacts with `npm run build` and ran `npm run check` (validate, lint, typecheck, tests, build) and the full check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e77e4820832d8126e70a226f44b7)