### PR TITLE
Add Onegodian University LMS plugin scaffold

### DIFF
--- a/onegodian-university-lms/admin/assets/css/og-lms-admin.css
+++ b/onegodian-university-lms/admin/assets/css/og-lms-admin.css
@@ -1,0 +1,1 @@
+.og-lms-admin-wrap{max-width:1200px}

--- a/onegodian-university-lms/composer.json
+++ b/onegodian-university-lms/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "onegodian/university-lms",
+  "description": "Proprietary LMS plugin for University of Onegodian",
+  "type": "wordpress-plugin",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1"
+  },
+  "autoload": {
+    "classmap": [
+      "includes/",
+      "modules/",
+      "public/"
+    ]
+  }
+}

--- a/onegodian-university-lms/docs/architecture-summary.md
+++ b/onegodian-university-lms/docs/architecture-summary.md
@@ -1,0 +1,26 @@
+# Onegodian University LMS Architecture (Phase 1-7 Scaffold)
+
+## High-level architecture
+- **Core bootstrap**: `onegodian-university-lms.php` initializes constants, loads classes, and wires activation/deactivation hooks.
+- **Core services** (`includes/`): post types, roles, security, assets, REST routes, and DB schema creation.
+- **Domain modules** (`modules/`): enrollments, courses rendering, quizzes, certificates, WooCommerce mapping, Stripe webhook abstraction, live classes, and Tutor LMS migration skeleton.
+- **Presentation layer** (`public/views/`): course catalog, single course, and student dashboard templates.
+- **Admin layer** (`admin/`): styles and migration admin page.
+
+## Canonical routing policy
+All frontend links in this scaffold are anchored to `https://u.onegodian.org` via `OG_LMS_Helpers::public_base_url()`.
+
+## Initial shortcode surface
+- `[og_course_catalog]`
+- `[og_course id="123"]`
+- `[og_lesson id="123"]`
+- `[og_student_dashboard]`
+- `[og_live_classes]`
+
+## Enrollment flow
+1. Student purchases a WooCommerce product mapped to `_og_course_id`.
+2. On order completion, course enrollment is inserted into `wp_og_enrollments`.
+3. Student sees course entries in `/dashboard` via shortcode renderer.
+
+## Migration skeleton
+The migration module adds an admin page under **Tools → Tutor Migration** with placeholders for dry-run, batches, resumability, logs, and safe reruns.

--- a/onegodian-university-lms/docs/database-schema.sql
+++ b/onegodian-university-lms/docs/database-schema.sql
@@ -1,0 +1,146 @@
+-- Onegodian University LMS custom tables
+-- Prefix shown as wp_, but runtime uses $wpdb->prefix.
+
+CREATE TABLE wp_og_enrollments (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  course_id BIGINT UNSIGNED NOT NULL,
+  status VARCHAR(30) NOT NULL DEFAULT 'active',
+  enrolled_at DATETIME NOT NULL,
+  expires_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY user_course (user_id, course_id),
+  KEY status (status)
+);
+
+CREATE TABLE wp_og_progress (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  course_id BIGINT UNSIGNED NOT NULL,
+  lesson_id BIGINT UNSIGNED NOT NULL,
+  completion_percent DECIMAL(5,2) NOT NULL DEFAULT 0,
+  completed_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY user_course (user_id, course_id),
+  KEY lesson_id (lesson_id)
+);
+
+CREATE TABLE wp_og_quiz_attempts (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  quiz_id BIGINT UNSIGNED NOT NULL,
+  score DECIMAL(5,2) NOT NULL DEFAULT 0,
+  status VARCHAR(30) NOT NULL DEFAULT 'in_progress',
+  started_at DATETIME NOT NULL,
+  submitted_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY quiz_user (quiz_id, user_id),
+  KEY status (status)
+);
+
+CREATE TABLE wp_og_quiz_answers (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  attempt_id BIGINT UNSIGNED NOT NULL,
+  question_id BIGINT UNSIGNED NOT NULL,
+  answer LONGTEXT NULL,
+  is_correct TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY attempt_question (attempt_id, question_id)
+);
+
+CREATE TABLE wp_og_assignment_submissions (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  assignment_id BIGINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  submission_text LONGTEXT NULL,
+  file_url TEXT NULL,
+  grade DECIMAL(5,2) NULL,
+  feedback LONGTEXT NULL,
+  submitted_at DATETIME NOT NULL,
+  graded_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY assignment_user (assignment_id, user_id)
+);
+
+CREATE TABLE wp_og_certificates (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  certificate_uid VARCHAR(64) NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  course_id BIGINT UNSIGNED NOT NULL,
+  issued_at DATETIME NOT NULL,
+  pdf_url TEXT NULL,
+  verification_hash VARCHAR(128) NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY certificate_uid (certificate_uid),
+  KEY user_course (user_id, course_id)
+);
+
+CREATE TABLE wp_og_payments (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  course_id BIGINT UNSIGNED NULL,
+  provider VARCHAR(40) NOT NULL,
+  transaction_id VARCHAR(128) NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+  status VARCHAR(30) NOT NULL,
+  paid_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY transaction_id (transaction_id),
+  KEY user_id (user_id),
+  KEY status (status)
+);
+
+CREATE TABLE wp_og_live_sessions (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  course_id BIGINT UNSIGNED NOT NULL,
+  provider VARCHAR(40) NOT NULL DEFAULT 'zoom',
+  provider_session_id VARCHAR(128) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  join_url TEXT NOT NULL,
+  replay_url TEXT NULL,
+  start_at DATETIME NOT NULL,
+  end_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY course_start (course_id, start_at)
+);
+
+CREATE TABLE wp_og_attendance (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  live_session_id BIGINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  attended_at DATETIME NOT NULL,
+  duration_minutes INT UNSIGNED NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY session_user (live_session_id, user_id)
+);
+
+CREATE TABLE wp_og_activity_log (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NULL,
+  event_type VARCHAR(80) NOT NULL,
+  object_type VARCHAR(80) NOT NULL,
+  object_id BIGINT UNSIGNED NULL,
+  context LONGTEXT NULL,
+  created_at DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY event_type (event_type),
+  KEY user_id (user_id)
+);

--- a/onegodian-university-lms/includes/class-activator.php
+++ b/onegodian-university-lms/includes/class-activator.php
@@ -1,0 +1,16 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Activator
+{
+    public static function activate(): void
+    {
+        OG_LMS_Post_Types::register();
+        OG_LMS_Roles::register();
+        OG_LMS_DB_Schema::create_tables();
+        flush_rewrite_rules();
+    }
+}

--- a/onegodian-university-lms/includes/class-assets.php
+++ b/onegodian-university-lms/includes/class-assets.php
@@ -1,0 +1,16 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Assets
+{
+    public static function enqueue_public(): void
+    {
+        wp_enqueue_style('og-lms-public', OG_LMS_PLUGIN_URL . 'public/assets/css/og-lms-public.css', [], OG_LMS_VERSION);
+    }
+
+    public static function enqueue_admin(): void
+    {
+        wp_enqueue_style('og-lms-admin', OG_LMS_PLUGIN_URL . 'admin/assets/css/og-lms-admin.css', [], OG_LMS_VERSION);
+    }
+}

--- a/onegodian-university-lms/includes/class-db-schema.php
+++ b/onegodian-university-lms/includes/class-db-schema.php
@@ -1,0 +1,158 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_DB_Schema
+{
+    public static function create_tables(): void
+    {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+        $prefix  = $wpdb->prefix;
+
+        $tables = [
+            "CREATE TABLE {$prefix}og_enrollments (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NOT NULL,
+                course_id BIGINT UNSIGNED NOT NULL,
+                status VARCHAR(30) NOT NULL DEFAULT 'active',
+                enrolled_at DATETIME NOT NULL,
+                expires_at DATETIME NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY user_course (user_id, course_id),
+                KEY status (status)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_progress (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NOT NULL,
+                course_id BIGINT UNSIGNED NOT NULL,
+                lesson_id BIGINT UNSIGNED NOT NULL,
+                completion_percent DECIMAL(5,2) NOT NULL DEFAULT 0,
+                completed_at DATETIME NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY user_course (user_id, course_id),
+                KEY lesson_id (lesson_id)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_quiz_attempts (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NOT NULL,
+                quiz_id BIGINT UNSIGNED NOT NULL,
+                score DECIMAL(5,2) NOT NULL DEFAULT 0,
+                status VARCHAR(30) NOT NULL DEFAULT 'in_progress',
+                started_at DATETIME NOT NULL,
+                submitted_at DATETIME NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY quiz_user (quiz_id, user_id),
+                KEY status (status)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_quiz_answers (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                attempt_id BIGINT UNSIGNED NOT NULL,
+                question_id BIGINT UNSIGNED NOT NULL,
+                answer LONGTEXT NULL,
+                is_correct TINYINT(1) NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY attempt_question (attempt_id, question_id)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_assignment_submissions (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                assignment_id BIGINT UNSIGNED NOT NULL,
+                user_id BIGINT UNSIGNED NOT NULL,
+                submission_text LONGTEXT NULL,
+                file_url TEXT NULL,
+                grade DECIMAL(5,2) NULL,
+                feedback LONGTEXT NULL,
+                submitted_at DATETIME NOT NULL,
+                graded_at DATETIME NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY assignment_user (assignment_id, user_id)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_certificates (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                certificate_uid VARCHAR(64) NOT NULL,
+                user_id BIGINT UNSIGNED NOT NULL,
+                course_id BIGINT UNSIGNED NOT NULL,
+                issued_at DATETIME NOT NULL,
+                pdf_url TEXT NULL,
+                verification_hash VARCHAR(128) NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                UNIQUE KEY certificate_uid (certificate_uid),
+                KEY user_course (user_id, course_id)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_payments (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NOT NULL,
+                course_id BIGINT UNSIGNED NULL,
+                provider VARCHAR(40) NOT NULL,
+                transaction_id VARCHAR(128) NOT NULL,
+                amount DECIMAL(10,2) NOT NULL,
+                currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+                status VARCHAR(30) NOT NULL,
+                paid_at DATETIME NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                UNIQUE KEY transaction_id (transaction_id),
+                KEY user_id (user_id),
+                KEY status (status)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_live_sessions (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                course_id BIGINT UNSIGNED NOT NULL,
+                provider VARCHAR(40) NOT NULL DEFAULT 'zoom',
+                provider_session_id VARCHAR(128) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                join_url TEXT NOT NULL,
+                replay_url TEXT NULL,
+                start_at DATETIME NOT NULL,
+                end_at DATETIME NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY course_start (course_id, start_at)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_attendance (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                live_session_id BIGINT UNSIGNED NOT NULL,
+                user_id BIGINT UNSIGNED NOT NULL,
+                attended_at DATETIME NOT NULL,
+                duration_minutes INT UNSIGNED NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY session_user (live_session_id, user_id)
+            ) {$charset};",
+            "CREATE TABLE {$prefix}og_activity_log (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NULL,
+                event_type VARCHAR(80) NOT NULL,
+                object_type VARCHAR(80) NOT NULL,
+                object_id BIGINT UNSIGNED NULL,
+                context LONGTEXT NULL,
+                created_at DATETIME NOT NULL,
+                PRIMARY KEY (id),
+                KEY event_type (event_type),
+                KEY user_id (user_id)
+            ) {$charset};",
+        ];
+
+        foreach ($tables as $sql) {
+            dbDelta($sql);
+        }
+    }
+}

--- a/onegodian-university-lms/includes/class-deactivator.php
+++ b/onegodian-university-lms/includes/class-deactivator.php
@@ -1,0 +1,13 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Deactivator
+{
+    public static function deactivate(): void
+    {
+        flush_rewrite_rules();
+    }
+}

--- a/onegodian-university-lms/includes/class-emails.php
+++ b/onegodian-university-lms/includes/class-emails.php
@@ -1,0 +1,4 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}

--- a/onegodian-university-lms/includes/class-helpers.php
+++ b/onegodian-university-lms/includes/class-helpers.php
@@ -1,0 +1,16 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Helpers
+{
+    public static function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+
+    public static function public_base_url(): string
+    {
+        return 'https://u.onegodian.org';
+    }
+}

--- a/onegodian-university-lms/includes/class-loader.php
+++ b/onegodian-university-lms/includes/class-loader.php
@@ -1,0 +1,25 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-activator.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-deactivator.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-post-types.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-db-schema.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-rest-api.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-security.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-roles.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-assets.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-helpers.php';
+
+require_once OG_LMS_PLUGIN_PATH . 'modules/enrollments/class-enrollment-service.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/courses/class-course-renderer.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/quizzes/class-quiz-engine.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/certificates/class-certificate-generator.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/woocommerce/class-woocommerce-integration.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/stripe/class-stripe-gateway.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/live-classes/class-live-classes.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/migration/class-tutor-migration.php';
+require_once OG_LMS_PLUGIN_PATH . 'public/class-student-dashboard-shortcode.php';

--- a/onegodian-university-lms/includes/class-migrations.php
+++ b/onegodian-university-lms/includes/class-migrations.php
@@ -1,0 +1,4 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}

--- a/onegodian-university-lms/includes/class-plugin.php
+++ b/onegodian-university-lms/includes/class-plugin.php
@@ -1,0 +1,27 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class OG_LMS_Plugin
+{
+    public function run(): void
+    {
+        add_action('init', [OG_LMS_Post_Types::class, 'register']);
+        add_action('init', [OG_LMS_Roles::class, 'register']);
+        add_action('init', [OG_LMS_Security::class, 'register']);
+        add_action('rest_api_init', [OG_LMS_REST_API::class, 'register_routes']);
+        add_action('wp_enqueue_scripts', [OG_LMS_Assets::class, 'enqueue_public']);
+        add_action('admin_enqueue_scripts', [OG_LMS_Assets::class, 'enqueue_admin']);
+
+        OG_LMS_Course_Renderer::register_shortcodes();
+        OG_LMS_Student_Dashboard_Shortcode::register();
+
+        OG_LMS_WooCommerce_Integration::bootstrap();
+        OG_LMS_Live_Classes::bootstrap();
+        OG_LMS_Quiz_Engine::bootstrap();
+        OG_LMS_Stripe_Gateway::bootstrap();
+        OG_LMS_Tutor_Migration::bootstrap();
+    }
+}

--- a/onegodian-university-lms/includes/class-post-types.php
+++ b/onegodian-university-lms/includes/class-post-types.php
@@ -1,0 +1,119 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Post_Types
+{
+    public static function register(): void
+    {
+        self::register_post_types();
+        self::register_taxonomies();
+    }
+
+    private static function register_post_types(): void
+    {
+        $supports = ['title', 'editor', 'thumbnail', 'excerpt', 'custom-fields', 'author'];
+
+        register_post_type('og_course', [
+            'label' => __('Courses', OG_LMS_TEXT_DOMAIN),
+            'public' => true,
+            'show_in_rest' => true,
+            'rewrite' => ['slug' => 'course'],
+            'supports' => $supports,
+            'has_archive' => 'courses',
+            'menu_icon' => 'dashicons-welcome-learn-more',
+        ]);
+
+        register_post_type('og_lesson', [
+            'label' => __('Lessons', OG_LMS_TEXT_DOMAIN),
+            'public' => true,
+            'show_in_rest' => true,
+            'rewrite' => ['slug' => 'lesson'],
+            'supports' => $supports,
+            'menu_icon' => 'dashicons-media-document',
+        ]);
+
+        register_post_type('og_quiz', [
+            'label' => __('Quizzes', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'custom-fields'],
+            'menu_icon' => 'dashicons-editor-ol',
+        ]);
+
+        register_post_type('og_assignment', [
+            'label' => __('Assignments', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'custom-fields'],
+            'menu_icon' => 'dashicons-portfolio',
+        ]);
+
+        register_post_type('og_certificate_template', [
+            'label' => __('Certificate Templates', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'thumbnail'],
+            'menu_icon' => 'dashicons-awards',
+        ]);
+
+        register_post_type('og_live_class', [
+            'label' => __('Live Classes', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'custom-fields'],
+            'menu_icon' => 'dashicons-video-alt3',
+        ]);
+
+        register_post_type('og_question_bank', [
+            'label' => __('Question Bank', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'custom-fields'],
+            'menu_icon' => 'dashicons-format-chat',
+        ]);
+
+        register_post_type('og_bundle', [
+            'label' => __('Course Bundles', OG_LMS_TEXT_DOMAIN),
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'thumbnail', 'custom-fields'],
+            'menu_icon' => 'dashicons-screenoptions',
+        ]);
+    }
+
+    private static function register_taxonomies(): void
+    {
+        register_taxonomy('og_course_category', ['og_course'], [
+            'label' => __('Course Categories', OG_LMS_TEXT_DOMAIN),
+            'public' => true,
+            'show_in_rest' => true,
+            'hierarchical' => true,
+            'rewrite' => ['slug' => 'course-category'],
+        ]);
+
+        register_taxonomy('og_course_tag', ['og_course'], [
+            'label' => __('Course Tags', OG_LMS_TEXT_DOMAIN),
+            'public' => true,
+            'show_in_rest' => true,
+            'hierarchical' => false,
+            'rewrite' => ['slug' => 'course-tag'],
+        ]);
+
+        register_taxonomy('og_instructor', ['og_course', 'og_lesson'], [
+            'label' => __('Instructors', OG_LMS_TEXT_DOMAIN),
+            'public' => true,
+            'show_in_rest' => true,
+            'hierarchical' => false,
+            'rewrite' => ['slug' => 'instructor'],
+        ]);
+    }
+}

--- a/onegodian-university-lms/includes/class-rest-api.php
+++ b/onegodian-university-lms/includes/class-rest-api.php
@@ -1,0 +1,17 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_REST_API
+{
+    public static function register_routes(): void
+    {
+        register_rest_route('og-lms/v1', '/enroll', [
+            'methods' => 'POST',
+            'callback' => [OG_LMS_Enrollment_Service::class, 'rest_enroll'],
+            'permission_callback' => function () {
+                return current_user_can('read');
+            },
+        ]);
+    }
+}

--- a/onegodian-university-lms/includes/class-roles.php
+++ b/onegodian-university-lms/includes/class-roles.php
@@ -1,0 +1,22 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Roles
+{
+    public static function register(): void
+    {
+        add_role('og_student', 'OG Student', ['read' => true]);
+
+        add_role('og_instructor', 'OG Instructor', [
+            'read' => true,
+            'upload_files' => true,
+            'edit_posts' => true,
+            'manage_og_courses' => true,
+            'grade_og_assignments' => true,
+            'manage_og_enrollments' => true,
+            'view_og_reports' => true,
+            'issue_og_certificates' => true,
+        ]);
+    }
+}

--- a/onegodian-university-lms/includes/class-security.php
+++ b/onegodian-university-lms/includes/class-security.php
@@ -1,0 +1,17 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Security
+{
+    public static function register(): void
+    {
+        add_filter('upload_mimes', [self::class, 'restrict_mimes']);
+    }
+
+    public static function restrict_mimes(array $mimes): array
+    {
+        $mimes['pdf'] = 'application/pdf';
+        return $mimes;
+    }
+}

--- a/onegodian-university-lms/includes/class-taxonomies.php
+++ b/onegodian-university-lms/includes/class-taxonomies.php
@@ -1,0 +1,4 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}

--- a/onegodian-university-lms/includes/class-upgrader.php
+++ b/onegodian-university-lms/includes/class-upgrader.php
@@ -1,0 +1,4 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}

--- a/onegodian-university-lms/modules/certificates/class-certificate-generator.php
+++ b/onegodian-university-lms/modules/certificates/class-certificate-generator.php
@@ -1,0 +1,18 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Certificate_Generator
+{
+    public static function issue(int $user_id, int $course_id): array
+    {
+        $certificate_id = wp_generate_uuid4();
+        $verify_url = OG_LMS_Helpers::public_base_url() . '/certificate-verify?certificate_id=' . rawurlencode($certificate_id);
+
+        return [
+            'certificate_id' => $certificate_id,
+            'verify_url' => $verify_url,
+            'pdf_url' => '',
+        ];
+    }
+}

--- a/onegodian-university-lms/modules/courses/class-course-renderer.php
+++ b/onegodian-university-lms/modules/courses/class-course-renderer.php
@@ -1,0 +1,50 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Course_Renderer
+{
+    public static function register_shortcodes(): void
+    {
+        add_shortcode('og_course_catalog', [self::class, 'render_catalog']);
+        add_shortcode('og_course', [self::class, 'render_course']);
+        add_shortcode('og_lesson', [self::class, 'render_lesson']);
+    }
+
+    public static function render_catalog(): string
+    {
+        $query = new WP_Query([
+            'post_type' => 'og_course',
+            'posts_per_page' => 12,
+            'post_status' => 'publish',
+        ]);
+
+        ob_start();
+        include OG_LMS_PLUGIN_PATH . 'public/views/course-catalog.php';
+        return (string) ob_get_clean();
+    }
+
+    public static function render_course(array $atts): string
+    {
+        $atts = shortcode_atts(['id' => 0], $atts);
+        $course_id = (int) $atts['id'];
+
+        if (! $course_id) {
+            return '';
+        }
+
+        $course = get_post($course_id);
+        ob_start();
+        include OG_LMS_PLUGIN_PATH . 'public/views/course-single.php';
+        return (string) ob_get_clean();
+    }
+
+    public static function render_lesson(array $atts): string
+    {
+        $atts = shortcode_atts(['id' => 0], $atts);
+        $lesson = get_post((int) $atts['id']);
+        return $lesson ? wpautop(wp_kses_post($lesson->post_content)) : '';
+    }
+}

--- a/onegodian-university-lms/modules/enrollments/class-enrollment-service.php
+++ b/onegodian-university-lms/modules/enrollments/class-enrollment-service.php
@@ -1,0 +1,65 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Enrollment_Service
+{
+    public static function enroll(int $user_id, int $course_id, string $status = 'active'): int
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'og_enrollments';
+
+        $wpdb->insert(
+            $table,
+            [
+                'user_id' => $user_id,
+                'course_id' => $course_id,
+                'status' => sanitize_key($status),
+                'enrolled_at' => OG_LMS_Helpers::now(),
+                'created_at' => OG_LMS_Helpers::now(),
+                'updated_at' => OG_LMS_Helpers::now(),
+            ],
+            ['%d', '%d', '%s', '%s', '%s', '%s']
+        );
+
+        return (int) $wpdb->insert_id;
+    }
+
+    public static function is_enrolled(int $user_id, int $course_id): bool
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'og_enrollments';
+        $sql = $wpdb->prepare(
+            "SELECT id FROM {$table} WHERE user_id = %d AND course_id = %d AND status = %s LIMIT 1",
+            $user_id,
+            $course_id,
+            'active'
+        );
+
+        return (bool) $wpdb->get_var($sql);
+    }
+
+    public static function rest_enroll(WP_REST_Request $request): WP_REST_Response
+    {
+        $user_id = get_current_user_id();
+        $course_id = (int) $request->get_param('course_id');
+
+        if (! $course_id || get_post_type($course_id) !== 'og_course') {
+            return new WP_REST_Response(['message' => 'Invalid course id'], 400);
+        }
+
+        if (self::is_enrolled($user_id, $course_id)) {
+            return new WP_REST_Response(['message' => 'Already enrolled'], 200);
+        }
+
+        $enrollment_id = self::enroll($user_id, $course_id);
+
+        return new WP_REST_Response([
+            'message' => 'Enrollment created',
+            'enrollment_id' => $enrollment_id,
+            'dashboard_url' => OG_LMS_Helpers::public_base_url() . '/dashboard',
+        ], 201);
+    }
+}

--- a/onegodian-university-lms/modules/live-classes/class-live-classes.php
+++ b/onegodian-university-lms/modules/live-classes/class-live-classes.php
@@ -1,0 +1,16 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Live_Classes
+{
+    public static function bootstrap(): void
+    {
+        add_shortcode('og_live_classes', [self::class, 'render']);
+    }
+
+    public static function render(): string
+    {
+        return '<div class="og-lms-card">Live classes listing and Zoom joins at ' . esc_html(OG_LMS_Helpers::public_base_url() . '/live-classes') . '</div>';
+    }
+}

--- a/onegodian-university-lms/modules/migration/class-tutor-migration.php
+++ b/onegodian-university-lms/modules/migration/class-tutor-migration.php
@@ -1,0 +1,30 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Tutor_Migration
+{
+    public static function bootstrap(): void
+    {
+        add_action('admin_menu', [self::class, 'register_page']);
+    }
+
+    public static function register_page(): void
+    {
+        add_submenu_page(
+            'tools.php',
+            'Tutor LMS Migration',
+            'Tutor Migration',
+            'manage_options',
+            'og-tutor-migration',
+            [self::class, 'render_page']
+        );
+    }
+
+    public static function render_page(): void
+    {
+        echo '<div class="wrap og-lms-admin-wrap"><h1>Tutor LMS Migration</h1>';
+        echo '<p>Dry-run, batch processing, resumable migration scaffold.</p>';
+        echo '<p>Target base URL: ' . esc_html(OG_LMS_Helpers::public_base_url()) . '</p></div>';
+    }
+}

--- a/onegodian-university-lms/modules/quizzes/class-quiz-engine.php
+++ b/onegodian-university-lms/modules/quizzes/class-quiz-engine.php
@@ -1,0 +1,23 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Quiz_Engine
+{
+    public static function bootstrap(): void
+    {
+        add_shortcode('og_quiz', [self::class, 'render']);
+    }
+
+    public static function render(array $atts): string
+    {
+        $atts = shortcode_atts(['id' => 0], $atts);
+        $quiz_id = (int) $atts['id'];
+
+        if (! $quiz_id) {
+            return '';
+        }
+
+        return '<div class="og-lms-card">Quiz #' . esc_html((string) $quiz_id) . ' scaffold: timer, retries, randomization, auto/manual grading.</div>';
+    }
+}

--- a/onegodian-university-lms/modules/stripe/class-stripe-gateway.php
+++ b/onegodian-university-lms/modules/stripe/class-stripe-gateway.php
@@ -1,0 +1,28 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_Stripe_Gateway
+{
+    public static function bootstrap(): void
+    {
+        add_action('rest_api_init', [self::class, 'register_routes']);
+    }
+
+    public static function register_routes(): void
+    {
+        register_rest_route('og-lms/v1', '/stripe/webhook', [
+            'methods' => 'POST',
+            'callback' => [self::class, 'handle_webhook'],
+            'permission_callback' => '__return_true',
+        ]);
+    }
+
+    public static function handle_webhook(WP_REST_Request $request): WP_REST_Response
+    {
+        return new WP_REST_Response([
+            'received' => true,
+            'endpoint' => OG_LMS_Helpers::public_base_url() . '/wp-json/og-lms/v1/stripe/webhook',
+        ]);
+    }
+}

--- a/onegodian-university-lms/modules/woocommerce/class-woocommerce-integration.php
+++ b/onegodian-university-lms/modules/woocommerce/class-woocommerce-integration.php
@@ -1,0 +1,31 @@
+<?php
+if (! defined('ABSPATH')) {
+    exit;
+}
+class OG_LMS_WooCommerce_Integration
+{
+    public static function bootstrap(): void
+    {
+        add_action('woocommerce_order_status_completed', [self::class, 'handle_order_completed']);
+    }
+
+    public static function handle_order_completed(int $order_id): void
+    {
+        if (! function_exists('wc_get_order')) {
+            return;
+        }
+
+        $order = wc_get_order($order_id);
+        if (! $order) {
+            return;
+        }
+
+        $user_id = (int) $order->get_user_id();
+        foreach ($order->get_items() as $item) {
+            $course_id = (int) wc_get_order_item_meta($item->get_id(), '_og_course_id', true);
+            if ($course_id > 0) {
+                OG_LMS_Enrollment_Service::enroll($user_id, $course_id, 'active');
+            }
+        }
+    }
+}

--- a/onegodian-university-lms/onegodian-university-lms.php
+++ b/onegodian-university-lms/onegodian-university-lms.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: Onegodian University LMS
+ * Plugin URI: https://u.onegodian.org
+ * Description: First-party LMS plugin for University of Onegodian.
+ * Version: 1.0.0
+ * Author: Onegodian University
+ * Text Domain: onegodian-university-lms
+ * Domain Path: /languages
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! defined('OG_LMS_VERSION')) {
+    define('OG_LMS_VERSION', '1.0.0');
+}
+
+if (! defined('OG_LMS_PLUGIN_FILE')) {
+    define('OG_LMS_PLUGIN_FILE', __FILE__);
+}
+
+if (! defined('OG_LMS_PLUGIN_PATH')) {
+    define('OG_LMS_PLUGIN_PATH', plugin_dir_path(__FILE__));
+}
+
+if (! defined('OG_LMS_PLUGIN_URL')) {
+    define('OG_LMS_PLUGIN_URL', plugin_dir_url(__FILE__));
+}
+
+if (! defined('OG_LMS_TEXT_DOMAIN')) {
+    define('OG_LMS_TEXT_DOMAIN', 'onegodian-university-lms');
+}
+
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-loader.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-plugin.php';
+
+register_activation_hook(__FILE__, ['OG_LMS_Activator', 'activate']);
+register_deactivation_hook(__FILE__, ['OG_LMS_Deactivator', 'deactivate']);
+
+function og_lms_run(): void
+{
+    $plugin = new OG_LMS_Plugin();
+    $plugin->run();
+}
+
+og_lms_run();

--- a/onegodian-university-lms/package.json
+++ b/onegodian-university-lms/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "onegodian-university-lms",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo 'Build pipeline placeholder'",
+    "lint": "echo 'Lint placeholder'"
+  }
+}

--- a/onegodian-university-lms/public/assets/css/og-lms-public.css
+++ b/onegodian-university-lms/public/assets/css/og-lms-public.css
@@ -1,0 +1,1 @@
+.og-lms-grid{display:grid;gap:1rem}.og-lms-card{border:1px solid #e5e7eb;padding:1rem;border-radius:8px}

--- a/onegodian-university-lms/public/class-student-dashboard-shortcode.php
+++ b/onegodian-university-lms/public/class-student-dashboard-shortcode.php
@@ -1,0 +1,52 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Student_Dashboard_Shortcode
+{
+    public static function register(): void
+    {
+        add_shortcode('og_student_dashboard', [self::class, 'render']);
+    }
+
+    public static function render(): string
+    {
+        if (! is_user_logged_in()) {
+            $login_url = esc_url(OG_LMS_Helpers::public_base_url() . '/login');
+            return '<p>Please <a href="' . $login_url . '">log in</a> to view your dashboard.</p>';
+        }
+
+        $user_id = get_current_user_id();
+        $courses = self::get_enrolled_courses($user_id);
+
+        ob_start();
+        include OG_LMS_PLUGIN_PATH . 'public/views/student-dashboard.php';
+
+        return (string) ob_get_clean();
+    }
+
+    private static function get_enrolled_courses(int $user_id): array
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'og_enrollments';
+
+        $sql = $wpdb->prepare(
+            "SELECT course_id FROM {$table} WHERE user_id = %d AND status = %s ORDER BY enrolled_at DESC",
+            $user_id,
+            'active'
+        );
+
+        $course_ids = array_map('intval', (array) $wpdb->get_col($sql));
+
+        return array_map(
+            static fn (int $id) => [
+                'id' => $id,
+                'title' => get_the_title($id),
+                'url' => get_permalink($id),
+            ],
+            $course_ids
+        );
+    }
+}

--- a/onegodian-university-lms/public/views/course-catalog.php
+++ b/onegodian-university-lms/public/views/course-catalog.php
@@ -1,0 +1,13 @@
+<div class="og-lms-grid">
+    <?php if ($query->have_posts()) : ?>
+        <?php while ($query->have_posts()) : $query->the_post(); ?>
+            <article class="og-lms-card">
+                <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+                <p><?php echo esc_html(wp_trim_words(get_the_excerpt(), 20)); ?></p>
+            </article>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
+    <?php else : ?>
+        <p><?php echo esc_html__('No courses published yet.', OG_LMS_TEXT_DOMAIN); ?></p>
+    <?php endif; ?>
+</div>

--- a/onegodian-university-lms/public/views/course-single.php
+++ b/onegodian-university-lms/public/views/course-single.php
@@ -1,0 +1,6 @@
+<?php if ($course) : ?>
+    <article class="og-lms-card">
+        <h2><?php echo esc_html(get_the_title($course)); ?></h2>
+        <div><?php echo wp_kses_post(apply_filters('the_content', $course->post_content)); ?></div>
+    </article>
+<?php endif; ?>

--- a/onegodian-university-lms/public/views/student-dashboard.php
+++ b/onegodian-university-lms/public/views/student-dashboard.php
@@ -1,0 +1,25 @@
+<div class="og-lms-grid">
+    <section class="og-lms-card">
+        <h2><?php echo esc_html__('My Enrolled Courses', OG_LMS_TEXT_DOMAIN); ?></h2>
+        <?php if (empty($courses)) : ?>
+            <p><?php echo esc_html__('No active enrollments yet.', OG_LMS_TEXT_DOMAIN); ?></p>
+        <?php else : ?>
+            <ul>
+                <?php foreach ($courses as $course) : ?>
+                    <li>
+                        <a href="<?php echo esc_url($course['url']); ?>"><?php echo esc_html($course['title']); ?></a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </section>
+
+    <section class="og-lms-card">
+        <h2><?php echo esc_html__('Quick Links', OG_LMS_TEXT_DOMAIN); ?></h2>
+        <ul>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/courses'); ?>">Courses</a></li>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/my-certificates'); ?>">Certificates</a></li>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/live-classes'); ?>">Live Classes</a></li>
+        </ul>
+    </section>
+</div>

--- a/onegodian-university-lms/readme.txt
+++ b/onegodian-university-lms/readme.txt
@@ -1,0 +1,8 @@
+=== Onegodian University LMS ===
+Contributors: onegodian
+Requires at least: 6.4
+Tested up to: 6.6
+Requires PHP: 8.1
+Stable tag: 1.0.0
+License: Proprietary
+Text Domain: onegodian-university-lms

--- a/onegodian-university-lms/uninstall.php
+++ b/onegodian-university-lms/uninstall.php
@@ -1,0 +1,4 @@
+<?php
+if (! defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}


### PR DESCRIPTION
### Motivation
- Provide a WordPress-native, production-ready scaffold for the Onegodian University LMS to replace Tutor LMS and establish core architecture and modules.
- Create persistent storage and canonical routes for courses, enrollments, progress, quizzes, assignments, certificates, payments, live classes, and activity logging.
- Offer initial admin and public surfaces (shortcodes, views, and a migration admin page) to iterate features and build integrations (WooCommerce, Stripe, Zoom).

### Description
- Add full plugin bootstrap with `onegodian-university-lms.php`, a loader (`includes/class-loader.php`), and lifecycle hooks via `class-activator.php` and `class-deactivator.php` to initialize the plugin runtime and DB schema.
- Implement DB schema creation using `OG_LMS_DB_Schema::create_tables()` and `dbDelta` for `og_enrollments`, `og_progress`, `og_quiz_attempts`, `og_quiz_answers`, `og_assignment_submissions`, `og_certificates`, `og_payments`, `og_live_sessions`, `og_attendance`, and `og_activity_log`, and include a standalone SQL file at `docs/database-schema.sql`.
- Register custom post types and taxonomies for courses, lessons, quizzes, assignments, certificate templates, live classes, optional question bank and bundles, and taxonomies `og_course_category`, `og_course_tag`, and `og_instructor` (`includes/class-post-types.php`).
- Add domain modules and public/admin features: enrollment service with REST enroll endpoint (`modules/enrollments/class-enrollment-service.php` + `includes/class-rest-api.php`), student dashboard shortcode and view (`public/class-student-dashboard-shortcode.php`, `public/views/student-dashboard.php`), course shortcodes and views, quiz/certificate/live-classes scaffolds, WooCommerce order-completed enrollment hook, Stripe webhook route, and a Tutor LMS migration admin skeleton (`modules/migration/class-tutor-migration.php`).
- Include assets, helper utilities, roles registration (`og_student`/`og_instructor`), minimal security filters, package metadata (`composer.json`/`package.json`), and architecture docs (`docs/architecture-summary.md`).

### Testing
- Ran PHP syntax checks across plugin PHP files with `find onegodian-university-lms -type f -name '*.php' -print0 | xargs -0 -n1 php -l` and all files passed with "No syntax errors detected.".
- No automated unit tests were added in this change; further test coverage (integration and unit tests) will be added in subsequent work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3a7694b8832dbd2e63810858aa9b)