### PR TITLE
Add membership subsystem, Stripe webhook handling, and onboarding emails

### DIFF
--- a/onegodian-university-lms/includes/class-activator.php
+++ b/onegodian-university-lms/includes/class-activator.php
@@ -10,7 +10,7 @@ class OG_LMS_Activator
     {
         OG_LMS_Post_Types::register();
         OG_LMS_Roles::register();
-        OG_LMS_DB_Schema::create_tables();
+        OG_LMS_Migrations::run();
         flush_rewrite_rules();
     }
 }

--- a/onegodian-university-lms/includes/class-emails.php
+++ b/onegodian-university-lms/includes/class-emails.php
@@ -1,4 +1,50 @@
 <?php
+
 if (! defined('ABSPATH')) {
     exit;
+}
+
+class OG_LMS_Emails
+{
+    public static function bootstrap(): void
+    {
+        add_filter('wp_mail_content_type', [self::class, 'mail_content_type']);
+    }
+
+    public static function mail_content_type(): string
+    {
+        return 'text/html';
+    }
+
+    public static function send_onboarding_once(int $user_id, string $tier): bool
+    {
+        $user = get_user_by('id', $user_id);
+        if (! $user || ! is_email($user->user_email)) {
+            return false;
+        }
+
+        $sent_key = 'og_lms_onboarding_sent';
+        if ((string) get_user_meta($user_id, $sent_key, true) === '1') {
+            return false;
+        }
+
+        $subject = 'Welcome to Onegodian University';
+        $dashboard_url = esc_url(OG_LMS_Helpers::public_base_url() . '/dashboard');
+        $courses_url = esc_url(OG_LMS_Helpers::public_base_url() . '/courses');
+
+        $message = sprintf(
+            '<p>Welcome %s, your <strong>%s</strong> membership is active.</p><p>Start here:</p><ul><li><a href="%s">Member Dashboard</a></li><li><a href="%s">Course Catalog</a></li></ul>',
+            esc_html($user->display_name ?: $user->user_login),
+            esc_html(ucfirst($tier)),
+            $dashboard_url,
+            $courses_url
+        );
+
+        $sent = wp_mail($user->user_email, $subject, $message);
+        if ($sent) {
+            update_user_meta($user_id, $sent_key, '1');
+        }
+
+        return (bool) $sent;
+    }
 }

--- a/onegodian-university-lms/includes/class-loader.php
+++ b/onegodian-university-lms/includes/class-loader.php
@@ -13,8 +13,11 @@ require_once OG_LMS_PLUGIN_PATH . 'includes/class-security.php';
 require_once OG_LMS_PLUGIN_PATH . 'includes/class-roles.php';
 require_once OG_LMS_PLUGIN_PATH . 'includes/class-assets.php';
 require_once OG_LMS_PLUGIN_PATH . 'includes/class-helpers.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-emails.php';
+require_once OG_LMS_PLUGIN_PATH . 'includes/class-migrations.php';
 
 require_once OG_LMS_PLUGIN_PATH . 'modules/enrollments/class-enrollment-service.php';
+require_once OG_LMS_PLUGIN_PATH . 'modules/memberships/class-membership-service.php';
 require_once OG_LMS_PLUGIN_PATH . 'modules/courses/class-course-renderer.php';
 require_once OG_LMS_PLUGIN_PATH . 'modules/quizzes/class-quiz-engine.php';
 require_once OG_LMS_PLUGIN_PATH . 'modules/certificates/class-certificate-generator.php';

--- a/onegodian-university-lms/includes/class-migrations.php
+++ b/onegodian-university-lms/includes/class-migrations.php
@@ -1,4 +1,66 @@
 <?php
+
 if (! defined('ABSPATH')) {
     exit;
+}
+
+class OG_LMS_Migrations
+{
+    private const OPTION_NAME = 'og_lms_schema_version';
+    private const TARGET_VERSION = '1.1.0';
+
+    public static function run(): void
+    {
+        $current = (string) get_option(self::OPTION_NAME, '0.0.0');
+        $migrations = [
+            '1.0.0' => [self::class, 'migrate_1_0_0'],
+            '1.1.0' => [self::class, 'migrate_1_1_0'],
+        ];
+
+        foreach ($migrations as $version => $callback) {
+            if (version_compare($current, $version, '>=')) {
+                continue;
+            }
+
+            call_user_func($callback);
+            update_option(self::OPTION_NAME, $version, false);
+            $current = $version;
+        }
+
+        if (version_compare($current, self::TARGET_VERSION, '<')) {
+            update_option(self::OPTION_NAME, self::TARGET_VERSION, false);
+        }
+    }
+
+    private static function migrate_1_0_0(): void
+    {
+        OG_LMS_DB_Schema::create_tables();
+    }
+
+    private static function migrate_1_1_0(): void
+    {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+        $prefix = $wpdb->prefix;
+
+        $sql = "CREATE TABLE {$prefix}og_memberships (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            tier VARCHAR(40) NOT NULL DEFAULT 'starter',
+            status VARCHAR(40) NOT NULL DEFAULT 'inactive',
+            stripe_customer_id VARCHAR(128) NULL,
+            stripe_subscription_id VARCHAR(128) NULL,
+            renews_at DATETIME NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_id (user_id),
+            KEY stripe_customer_id (stripe_customer_id),
+            KEY status (status)
+        ) {$charset};";
+
+        dbDelta($sql);
+    }
 }

--- a/onegodian-university-lms/includes/class-plugin.php
+++ b/onegodian-university-lms/includes/class-plugin.php
@@ -17,6 +17,8 @@ final class OG_LMS_Plugin
 
         OG_LMS_Course_Renderer::register_shortcodes();
         OG_LMS_Student_Dashboard_Shortcode::register();
+        OG_LMS_Emails::bootstrap();
+        OG_LMS_Migrations::run();
 
         OG_LMS_WooCommerce_Integration::bootstrap();
         OG_LMS_Live_Classes::bootstrap();

--- a/onegodian-university-lms/modules/courses/class-course-renderer.php
+++ b/onegodian-university-lms/modules/courses/class-course-renderer.php
@@ -36,6 +36,20 @@ class OG_LMS_Course_Renderer
         }
 
         $course = get_post($course_id);
+
+        if (! $course || get_post_type($course) !== 'og_course') {
+            return '';
+        }
+
+        if (! is_user_logged_in()) {
+            $login_url = esc_url(OG_LMS_Helpers::public_base_url() . '/login');
+            return '<p>Please <a href="' . $login_url . '">log in</a> to access this course.</p>';
+        }
+
+        if (! OG_LMS_Membership_Service::can_access_course(get_current_user_id(), $course_id)) {
+            $required_tier = OG_LMS_Membership_Service::get_required_tier_for_course($course_id);
+            return '<p>This course requires the <strong>' . esc_html($required_tier ?: 'membership') . '</strong> tier.</p>';
+        }
         ob_start();
         include OG_LMS_PLUGIN_PATH . 'public/views/course-single.php';
         return (string) ob_get_clean();

--- a/onegodian-university-lms/modules/enrollments/class-enrollment-service.php
+++ b/onegodian-university-lms/modules/enrollments/class-enrollment-service.php
@@ -54,6 +54,10 @@ class OG_LMS_Enrollment_Service
             return new WP_REST_Response(['message' => 'Already enrolled'], 200);
         }
 
+        if (! OG_LMS_Membership_Service::can_access_course($user_id, $course_id)) {
+            return new WP_REST_Response(['message' => 'Membership tier required'], 403);
+        }
+
         $enrollment_id = self::enroll($user_id, $course_id);
 
         return new WP_REST_Response([

--- a/onegodian-university-lms/modules/memberships/class-membership-service.php
+++ b/onegodian-university-lms/modules/memberships/class-membership-service.php
@@ -1,0 +1,152 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class OG_LMS_Membership_Service
+{
+    private const ACTIVE_STATUSES = ['active', 'trialing'];
+
+    public static function get_required_tier_for_course(int $course_id): string
+    {
+        $tier = (string) get_post_meta($course_id, '_og_required_tier', true);
+        return sanitize_key($tier);
+    }
+
+    public static function can_access_course(int $user_id, int $course_id): bool
+    {
+        if ($user_id <= 0 || $course_id <= 0) {
+            return false;
+        }
+
+        $required_tier = self::get_required_tier_for_course($course_id);
+        if ($required_tier === '') {
+            return true;
+        }
+
+        $membership = self::get_active_membership($user_id);
+        if (! $membership) {
+            return false;
+        }
+
+        return self::tier_allows($membership['tier'], $required_tier);
+    }
+
+    public static function get_active_membership(int $user_id): ?array
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'og_memberships';
+        $sql = $wpdb->prepare(
+            "SELECT tier, status, renews_at, stripe_subscription_id
+            FROM {$table}
+            WHERE user_id = %d
+            ORDER BY updated_at DESC
+            LIMIT 1",
+            $user_id
+        );
+
+        $row = $wpdb->get_row($sql, ARRAY_A);
+        if (! is_array($row) || empty($row)) {
+            return null;
+        }
+
+        $row['tier'] = sanitize_key((string) ($row['tier'] ?? ''));
+        $row['status'] = sanitize_key((string) ($row['status'] ?? ''));
+        $row['renews_at'] = (string) ($row['renews_at'] ?? '');
+        $row['stripe_subscription_id'] = sanitize_text_field((string) ($row['stripe_subscription_id'] ?? ''));
+
+        if (! in_array($row['status'], self::ACTIVE_STATUSES, true)) {
+            return null;
+        }
+
+        return $row;
+    }
+
+    public static function tier_allows(string $member_tier, string $required_tier): bool
+    {
+        $weights = [
+            'starter' => 10,
+            'pro' => 20,
+            'university' => 30,
+        ];
+
+        $member = $weights[sanitize_key($member_tier)] ?? 0;
+        $required = $weights[sanitize_key($required_tier)] ?? 999;
+
+        return $member >= $required;
+    }
+
+    public static function upsert_from_stripe_event(array $payload): void
+    {
+        global $wpdb;
+
+        $data = isset($payload['data']['object']) && is_array($payload['data']['object'])
+            ? $payload['data']['object']
+            : [];
+
+        $customer_id = sanitize_text_field((string) ($data['customer'] ?? ''));
+        $subscription_id = sanitize_text_field((string) ($data['id'] ?? ''));
+        $status = sanitize_key((string) ($data['status'] ?? 'inactive'));
+
+        if ($customer_id === '' || $subscription_id === '') {
+            return;
+        }
+
+        $user_id = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT user_id FROM {$wpdb->prefix}og_memberships WHERE stripe_customer_id = %s LIMIT 1",
+                $customer_id
+            )
+        );
+
+        if ($user_id <= 0) {
+            return;
+        }
+
+        $tier = sanitize_key((string) get_user_meta($user_id, 'og_lms_pending_tier', true));
+        if ($tier === '') {
+            $tier = 'starter';
+        }
+
+        $renews_at_ts = (int) ($data['current_period_end'] ?? 0);
+        $renews_at = $renews_at_ts > 0 ? gmdate('Y-m-d H:i:s', $renews_at_ts) : null;
+
+        $table = $wpdb->prefix . 'og_memberships';
+        $existing_id = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$table} WHERE user_id = %d LIMIT 1",
+                $user_id
+            )
+        );
+
+        $record = [
+            'user_id' => $user_id,
+            'tier' => $tier,
+            'status' => $status,
+            'stripe_customer_id' => $customer_id,
+            'stripe_subscription_id' => $subscription_id,
+            'renews_at' => $renews_at,
+            'updated_at' => OG_LMS_Helpers::now(),
+        ];
+
+        if ($existing_id > 0) {
+            $wpdb->update(
+                $table,
+                $record,
+                ['id' => $existing_id],
+                ['%d', '%s', '%s', '%s', '%s', '%s', '%s'],
+                ['%d']
+            );
+        } else {
+            $record['created_at'] = OG_LMS_Helpers::now();
+            $wpdb->insert(
+                $table,
+                $record,
+                ['%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s']
+            );
+        }
+
+        OG_LMS_Emails::send_onboarding_once($user_id, $tier);
+    }
+}

--- a/onegodian-university-lms/modules/stripe/class-stripe-gateway.php
+++ b/onegodian-university-lms/modules/stripe/class-stripe-gateway.php
@@ -1,9 +1,19 @@
 <?php
+
 if (! defined('ABSPATH')) {
     exit;
 }
+
 class OG_LMS_Stripe_Gateway
 {
+    private const SUPPORTED_EVENTS = [
+        'checkout.session.completed',
+        'invoice.paid',
+        'invoice.payment_failed',
+        'customer.subscription.updated',
+        'customer.subscription.deleted',
+    ];
+
     public static function bootstrap(): void
     {
         add_action('rest_api_init', [self::class, 'register_routes']);
@@ -20,9 +30,123 @@ class OG_LMS_Stripe_Gateway
 
     public static function handle_webhook(WP_REST_Request $request): WP_REST_Response
     {
+        $raw_body = (string) $request->get_body();
+        $signature = (string) $request->get_header('stripe-signature');
+
+        if (! self::verify_signature($raw_body, $signature)) {
+            return new WP_REST_Response(['message' => 'Invalid signature'], 400);
+        }
+
+        $payload = json_decode($raw_body, true);
+        if (! is_array($payload)) {
+            return new WP_REST_Response(['message' => 'Invalid payload'], 400);
+        }
+
+        $event_type = sanitize_text_field((string) ($payload['type'] ?? ''));
+        if (! in_array($event_type, self::SUPPORTED_EVENTS, true)) {
+            return new WP_REST_Response(['received' => true, 'ignored' => true], 200);
+        }
+
+        self::process_event($payload);
+
         return new WP_REST_Response([
             'received' => true,
-            'endpoint' => OG_LMS_Helpers::public_base_url() . '/wp-json/og-lms/v1/stripe/webhook',
+            'event_type' => $event_type,
         ]);
+    }
+
+    private static function process_event(array $payload): void
+    {
+        $type = sanitize_text_field((string) ($payload['type'] ?? ''));
+
+        if (
+            $type === 'customer.subscription.updated'
+            || $type === 'customer.subscription.deleted'
+            || $type === 'invoice.paid'
+            || $type === 'invoice.payment_failed'
+        ) {
+            OG_LMS_Membership_Service::upsert_from_stripe_event($payload);
+        }
+
+        if ($type === 'checkout.session.completed') {
+            self::capture_customer_mapping($payload);
+        }
+    }
+
+    private static function capture_customer_mapping(array $payload): void
+    {
+        global $wpdb;
+
+        $obj = isset($payload['data']['object']) && is_array($payload['data']['object'])
+            ? $payload['data']['object']
+            : [];
+
+        $customer_id = sanitize_text_field((string) ($obj['customer'] ?? ''));
+        $user_id = (int) ($obj['client_reference_id'] ?? 0);
+        $tier = sanitize_key((string) ($obj['metadata']['tier'] ?? 'starter'));
+
+        if ($customer_id === '' || $user_id <= 0) {
+            return;
+        }
+
+        update_user_meta($user_id, 'og_lms_pending_tier', $tier ?: 'starter');
+
+        $table = $wpdb->prefix . 'og_memberships';
+        $existing_id = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$table} WHERE user_id = %d LIMIT 1",
+                $user_id
+            )
+        );
+
+        $record = [
+            'user_id' => $user_id,
+            'tier' => $tier ?: 'starter',
+            'status' => 'pending',
+            'stripe_customer_id' => $customer_id,
+            'updated_at' => OG_LMS_Helpers::now(),
+        ];
+
+        if ($existing_id > 0) {
+            $wpdb->update($table, $record, ['id' => $existing_id], ['%d', '%s', '%s', '%s', '%s'], ['%d']);
+            return;
+        }
+
+        $record['created_at'] = OG_LMS_Helpers::now();
+        $wpdb->insert($table, $record, ['%d', '%s', '%s', '%s', '%s', '%s']);
+    }
+
+    private static function verify_signature(string $payload, string $signature_header): bool
+    {
+        if ($payload === '' || $signature_header === '') {
+            return false;
+        }
+
+        $secret = (string) get_option('og_lms_stripe_webhook_secret', '');
+        if ($secret === '') {
+            return false;
+        }
+
+        $timestamp = '';
+        $signature = '';
+
+        $parts = array_map('trim', explode(',', $signature_header));
+        foreach ($parts as $part) {
+            if (str_starts_with($part, 't=')) {
+                $timestamp = substr($part, 2);
+            }
+            if (str_starts_with($part, 'v1=')) {
+                $signature = substr($part, 3);
+            }
+        }
+
+        if ($timestamp === '' || $signature === '') {
+            return false;
+        }
+
+        $signed_payload = $timestamp . '.' . $payload;
+        $expected = hash_hmac('sha256', $signed_payload, $secret);
+
+        return hash_equals($expected, $signature);
     }
 }

--- a/onegodian-university-lms/public/class-student-dashboard-shortcode.php
+++ b/onegodian-university-lms/public/class-student-dashboard-shortcode.php
@@ -20,6 +20,8 @@ class OG_LMS_Student_Dashboard_Shortcode
 
         $user_id = get_current_user_id();
         $courses = self::get_enrolled_courses($user_id);
+        $membership = OG_LMS_Membership_Service::get_active_membership($user_id);
+        $locked_courses = self::get_locked_courses($user_id);
 
         ob_start();
         include OG_LMS_PLUGIN_PATH . 'public/views/student-dashboard.php';
@@ -48,5 +50,31 @@ class OG_LMS_Student_Dashboard_Shortcode
             ],
             $course_ids
         );
+    }
+
+    private static function get_locked_courses(int $user_id): array
+    {
+        $query = new WP_Query([
+            'post_type' => 'og_course',
+            'posts_per_page' => 8,
+            'post_status' => 'publish',
+            'fields' => 'ids',
+        ]);
+
+        $locked = [];
+        foreach ((array) $query->posts as $course_id) {
+            $course_id = (int) $course_id;
+            if (OG_LMS_Membership_Service::can_access_course($user_id, $course_id)) {
+                continue;
+            }
+
+            $locked[] = [
+                'id' => $course_id,
+                'title' => get_the_title($course_id),
+                'required_tier' => OG_LMS_Membership_Service::get_required_tier_for_course($course_id) ?: 'membership',
+            ];
+        }
+
+        return $locked;
     }
 }

--- a/onegodian-university-lms/public/views/student-dashboard.php
+++ b/onegodian-university-lms/public/views/student-dashboard.php
@@ -1,5 +1,21 @@
 <div class="og-lms-grid">
     <section class="og-lms-card">
+        <h2><?php echo esc_html__('Membership', OG_LMS_TEXT_DOMAIN); ?></h2>
+        <?php if ($membership) : ?>
+            <p>
+                <?php echo esc_html(sprintf('Tier: %s', ucfirst((string) $membership['tier']))); ?><br>
+                <?php echo esc_html(sprintf('Status: %s', (string) $membership['status'])); ?><br>
+                <?php if (! empty($membership['renews_at'])) : ?>
+                    <?php echo esc_html(sprintf('Renews: %s', (string) $membership['renews_at'])); ?>
+                <?php endif; ?>
+            </p>
+        <?php else : ?>
+            <p><?php echo esc_html__('No active membership found.', OG_LMS_TEXT_DOMAIN); ?></p>
+            <p><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/pricing'); ?>"><?php echo esc_html__('Upgrade Membership', OG_LMS_TEXT_DOMAIN); ?></a></p>
+        <?php endif; ?>
+    </section>
+
+    <section class="og-lms-card">
         <h2><?php echo esc_html__('My Enrolled Courses', OG_LMS_TEXT_DOMAIN); ?></h2>
         <?php if (empty($courses)) : ?>
             <p><?php echo esc_html__('No active enrollments yet.', OG_LMS_TEXT_DOMAIN); ?></p>
@@ -7,7 +23,7 @@
             <ul>
                 <?php foreach ($courses as $course) : ?>
                     <li>
-                        <a href="<?php echo esc_url($course['url']); ?>"><?php echo esc_html($course['title']); ?></a>
+                        <a href="<?php echo esc_url((string) $course['url']); ?>"><?php echo esc_html((string) $course['title']); ?></a>
                     </li>
                 <?php endforeach; ?>
             </ul>
@@ -15,11 +31,28 @@
     </section>
 
     <section class="og-lms-card">
+        <h2><?php echo esc_html__('Locked Courses', OG_LMS_TEXT_DOMAIN); ?></h2>
+        <?php if (empty($locked_courses)) : ?>
+            <p><?php echo esc_html__('No locked courses. Great progress!', OG_LMS_TEXT_DOMAIN); ?></p>
+        <?php else : ?>
+            <ul>
+                <?php foreach ($locked_courses as $course) : ?>
+                    <li>
+                        <?php echo esc_html((string) $course['title']); ?>
+                        (<?php echo esc_html(sprintf('requires %s', (string) $course['required_tier'])); ?>)
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+            <p><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/pricing'); ?>"><?php echo esc_html__('View Upgrade Options', OG_LMS_TEXT_DOMAIN); ?></a></p>
+        <?php endif; ?>
+    </section>
+
+    <section class="og-lms-card">
         <h2><?php echo esc_html__('Quick Links', OG_LMS_TEXT_DOMAIN); ?></h2>
         <ul>
-            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/courses'); ?>">Courses</a></li>
-            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/my-certificates'); ?>">Certificates</a></li>
-            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/live-classes'); ?>">Live Classes</a></li>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/courses'); ?>"><?php echo esc_html__('Courses', OG_LMS_TEXT_DOMAIN); ?></a></li>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/my-certificates'); ?>"><?php echo esc_html__('Certificates', OG_LMS_TEXT_DOMAIN); ?></a></li>
+            <li><a href="<?php echo esc_url(OG_LMS_Helpers::public_base_url() . '/live-classes'); ?>"><?php echo esc_html__('Live Classes', OG_LMS_TEXT_DOMAIN); ?></a></li>
         </ul>
     </section>
 </div>


### PR DESCRIPTION
### Motivation
- Introduce a membership model to gate course access and persist membership records in the database. 
- Wire Stripe webhook events into the system to create/update membership records and map Stripe customers to users. 
- Send onboarding emails on successful subscription creation and present membership info in the student dashboard.

### Description
- Add `OG_LMS_Migrations` with versioned migrations and a new `og_memberships` table, and call it from activation and plugin bootstrap instead of directly creating tables. 
- Implement `OG_LMS_Membership_Service` to query and evaluate active memberships, determine required tiers for courses, upsert membership records from Stripe events, and trigger onboarding emails via `OG_LMS_Emails`. 
- Add `OG_LMS_Emails` to set `text/html` email content type and send a one-time onboarding message via `send_onboarding_once`. 
- Extend `OG_LMS_Stripe_Gateway` to register a `/stripe/webhook` REST route, verify webhook signatures against `og_lms_stripe_webhook_secret`, process supported events, capture customer<>user mappings, and call membership upsert logic. 
- Enforce membership checks in UI and API by updating `OG_LMS_Course_Renderer::render_course`, `OG_LMS_Enrollment_Service::rest_enroll`, and `OG_LMS_Student_Dashboard_Shortcode` to show membership status and locked courses. 
- Add loader includes for the new classes and update views to display localized membership information and locked course links.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab5c978e8832dbfbf5f9496ae02fe)