### PR TITLE
Harden production auth and environment controls for OneGodian services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ PORT=3000
 NEXT_PUBLIC_API_URL=https://api.qrv.network
 API_BASE_URL=https://api.qrv.network
 NODE_ENV=development
+CORS_ORIGINS=http://localhost:3000
+EXECUTE_API_KEY=replace_with_random_secret

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ PORT=3000
 NEXT_PUBLIC_API_URL=https://api.qrv.network
 API_BASE_URL=https://api.qrv.network
 NODE_ENV=development
+CORS_ORIGINS=http://localhost:3000
+EXECUTE_API_KEY=replace_with_random_secret
 ```
 
 ## Quality gates
@@ -100,3 +102,7 @@ docker run --rm -p 3000:3000 --env-file .env onegodian-verify-portal
 - Input is sanitized server-side before outbound requests.
 - No direct database access is exposed in this service.
 - Unavailable upstream responses render deterministic safe defaults.
+
+
+- Execution endpoint (`POST /execute`) requires `x-api-key` matching `EXECUTE_API_KEY`.
+- Configure `CORS_ORIGINS` in production to a comma-separated allowlist.

--- a/onegodian-identity-engine/.env.example
+++ b/onegodian-identity-engine/.env.example
@@ -9,3 +9,4 @@ STRIPE_PRICE_PREMIUM=price_xxx
 STRIPE_PRICE_FOUNDER=price_xxx
 RESEND_API_KEY=re_xxx
 ADMIN_EMAILS=founder@onegodian.org
+ADMIN_TOKEN=replace_with_32+_char_random_secret

--- a/onegodian-identity-engine/DEPLOYMENT.md
+++ b/onegodian-identity-engine/DEPLOYMENT.md
@@ -84,3 +84,9 @@ Run after deploy:
 4. Replace placeholder asset generation with real artifact pipeline.
 5. Add structured error logging/observability for Stripe, Supabase, and Resend failures.
 6. Add idempotency handling for webhook processing to avoid duplicate side effects.
+
+
+## Security hardening
+
+- Set `ADMIN_TOKEN` to a random 32+ character value and send it via `x-admin-token` for `/admin` and `/api/admin/*` access.
+- Do not reuse `ADMIN_EMAILS` as an auth secret; keep it for notification routing only.

--- a/onegodian-identity-engine/README.md
+++ b/onegodian-identity-engine/README.md
@@ -58,3 +58,9 @@ For production deployment and launch gating, see [`DEPLOYMENT.md`](./DEPLOYMENT.
 - Free preview gating before checkout.
 - Fast checkout handoff via pre-built Stripe session URL.
 - Post-purchase instant delivery + dashboard retrieval.
+
+
+## Security hardening
+
+- Set `ADMIN_TOKEN` to a random 32+ character value and send it via `x-admin-token` for `/admin` and `/api/admin/*` access.
+- Do not reuse `ADMIN_EMAILS` as an auth secret; keep it for notification routing only.

--- a/onegodian-identity-engine/app/api/admin/metrics/route.ts
+++ b/onegodian-identity-engine/app/api/admin/metrics/route.ts
@@ -1,7 +1,15 @@
+import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase';
+import { isAdminRequest } from '@/lib/admin';
 
 export async function GET() {
+  const adminToken = headers().get('x-admin-token');
+
+  if (!isAdminRequest(adminToken)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const [ordersRes, previewsRes] = await Promise.all([
     supabaseAdmin.from('orders').select('tier, amount_total', { count: 'exact' }),
     supabaseAdmin.from('identity_artifacts').select('id', { count: 'exact' })

--- a/onegodian-identity-engine/app/api/webhooks/stripe/route.ts
+++ b/onegodian-identity-engine/app/api/webhooks/stripe/route.ts
@@ -12,26 +12,41 @@ export async function POST(req: Request) {
 
   try {
     event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET as string);
-  } catch (e) {
+  } catch (_e) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
   }
 
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object;
-    await supabaseAdmin.from('orders').insert({
-      stripe_session_id: session.id,
-      email: session.customer_details?.email,
-      tier: session.metadata?.tier,
-      artifact_id: session.metadata?.artifactId,
-      referral_code: session.metadata?.referralCode,
-      amount_total: session.amount_total,
-      paid_at: new Date().toISOString()
-    });
 
-    await supabaseAdmin
+    const { error: orderError } = await supabaseAdmin.from('orders').upsert(
+      {
+        stripe_session_id: session.id,
+        email: session.customer_details?.email,
+        tier: session.metadata?.tier,
+        artifact_id: session.metadata?.artifactId,
+        referral_code: session.metadata?.referralCode,
+        amount_total: session.amount_total,
+        paid_at: new Date().toISOString()
+      },
+      {
+        onConflict: 'stripe_session_id',
+        ignoreDuplicates: true
+      }
+    );
+
+    if (orderError) {
+      return NextResponse.json({ error: 'Failed to persist order' }, { status: 500 });
+    }
+
+    const { error: artifactError } = await supabaseAdmin
       .from('identity_artifacts')
       .update({ preview_only: false, hd_ready: true })
       .eq('id', session.metadata?.artifactId);
+
+    if (artifactError) {
+      return NextResponse.json({ error: 'Failed to unlock artifact' }, { status: 500 });
+    }
   }
 
   return NextResponse.json({ ok: true });

--- a/onegodian-identity-engine/lib/admin.ts
+++ b/onegodian-identity-engine/lib/admin.ts
@@ -1,0 +1,23 @@
+import crypto from 'node:crypto';
+import { getEnv } from '@/lib/env';
+
+const env = getEnv();
+
+const safeEqual = (a: string, b: string) => {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(left, right);
+};
+
+export const isAdminRequest = (adminToken: string | null) => {
+  if (!adminToken) {
+    return false;
+  }
+
+  return safeEqual(adminToken, env.ADMIN_TOKEN);
+};

--- a/onegodian-identity-engine/lib/env.ts
+++ b/onegodian-identity-engine/lib/env.ts
@@ -8,18 +8,20 @@ const serverSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
   RESEND_API_KEY: z.string().min(1),
-  ADMIN_EMAILS: z.string().min(1)
+  ADMIN_EMAILS: z.string().min(1),
+  ADMIN_TOKEN: z.string().min(32)
 });
 
 export function getEnv() {
   return serverSchema.parse({
-    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000',
-    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://example.supabase.co',
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'dev-anon-key',
-    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ?? 'dev-service-role',
-    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY ?? 'sk_test_dev',
-    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET ?? 'whsec_dev',
-    RESEND_API_KEY: process.env.RESEND_API_KEY ?? 're_dev',
-    ADMIN_EMAILS: process.env.ADMIN_EMAILS ?? 'admin@onegodian.org'
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+    RESEND_API_KEY: process.env.RESEND_API_KEY,
+    ADMIN_EMAILS: process.env.ADMIN_EMAILS,
+    ADMIN_TOKEN: process.env.ADMIN_TOKEN
   });
 }

--- a/onegodian-identity-engine/middleware.ts
+++ b/onegodian-identity-engine/middleware.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { isAdminRequest } from '@/lib/admin';
 
 export function middleware(req: NextRequest) {
   if (req.nextUrl.pathname.startsWith('/admin')) {
     const adminToken = req.headers.get('x-admin-token');
-    if (!adminToken || adminToken !== process.env.ADMIN_EMAILS) {
+
+    if (!isAdminRequest(adminToken)) {
       return NextResponse.redirect(new URL('/', req.url));
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,38 @@ import cors from "cors";
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+const corsOrigins = (process.env.CORS_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const isOriginAllowed = (origin?: string) => {
+  if (!origin) {
+    return true;
+  }
+
+  if (corsOrigins.length === 0) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  return corsOrigins.includes(origin);
+};
+
+const corsOriginValidator = (
+  origin: string | undefined,
+  callback: (err: Error | null, allow?: boolean) => void
+) => {
+  if (isOriginAllowed(origin ?? undefined)) {
+    return callback(null, true);
+  }
+
+  return callback(new Error("Not allowed by CORS"));
+};
+
 app.disable("x-powered-by");
 app.set("trust proxy", true);
 
-app.use(cors());
+app.use(cors({ origin: corsOriginValidator }));
 app.use(express.json({ limit: "1mb" }));
 
 app.get("/", (_req, res) => {
@@ -45,6 +73,23 @@ app.get("/v1/definition", (_req, res) => {
 });
 
 app.post("/execute", (req, res) => {
+  const expectedApiKey = process.env.EXECUTE_API_KEY;
+  const providedApiKey = req.header("x-api-key");
+
+  if (!expectedApiKey) {
+    return res.status(503).json({
+      success: false,
+      error: "Execution endpoint unavailable: missing EXECUTE_API_KEY"
+    });
+  }
+
+  if (!providedApiKey || providedApiKey !== expectedApiKey) {
+    return res.status(401).json({
+      success: false,
+      error: "Unauthorized"
+    });
+  }
+
   const { task, agent, metadata } = req.body || {};
 
   if (!task) {


### PR DESCRIPTION
### Motivation
- Close high-risk production blockers identified in the audit: exposed admin telemetry, weak admin auth, permissive secret fallbacks, unauthenticated execution endpoint, and webhook replay risks. 
- Ensure the `onegodian-identity-engine` is production-safe for monetization flows (Stripe + Supabase) by requiring explicit secrets and adding idempotency protections. 
- Reduce attack surface for the core API by tightening CORS and gating sensitive endpoints behind secrets. 

### Description
- Require explicit environment validation in `onegodian-identity-engine` via `lib/env.ts` (added `ADMIN_TOKEN` and removed insecure fallback defaults). 
- Add a timing-safe admin token validator in `onegodian-identity-engine/lib/admin.ts` and enforce it in `middleware.ts` and the admin metrics route `app/api/admin/metrics/route.ts`. 
- Harden Stripe webhook handling in `app/api/webhooks/stripe/route.ts` by using `upsert` on `stripe_session_id`, returning errors on persistence failures, and making processing idempotent. 
- Harden core API `src/index.ts` by adding an allowlist-driven `CORS_ORIGINS` policy and protecting `POST /execute` with `EXECUTE_API_KEY`. 
- Update environment examples and docs (`.env.example`, `onegodian-identity-engine/.env.example`, `README.md`, `DEPLOYMENT.md`) to document required secrets and admin token usage. 

### Testing
- Ran `npm run typecheck` at repo root and it completed successfully. 
- Ran `npm run test:root` and all tests passed (`15` tests, `0` failures). 
- Ran `npm run typecheck` inside `onegodian-identity-engine` and it completed successfully. 
- Note: `npm` emitted an environment warning `Unknown env config "http-proxy"` during runs; this is an environment warning and did not cause test/typecheck failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50bca9e0832db84f99ff770ecb97)