### PR TITLE
Standardize tooling and add runtime, deployment, and CI/CD scaffolding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+node_modules
+npm-debug.log
+coverage
+dist
+**/dist
+**/node_modules
+.next

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 PORT=3000
-NODE_ENV=production
-LOG_LEVEL=info
 NEXT_PUBLIC_API_URL=https://api.qrv.network
 API_BASE_URL=https://api.qrv.network
+NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 PORT=3000
+NODE_ENV=production
+LOG_LEVEL=info
 NEXT_PUBLIC_API_URL=https://api.qrv.network
 API_BASE_URL=https://api.qrv.network
-NODE_ENV=development

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,45 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/onegodian-api
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,45 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
+      - master
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
-      - run: npm run check
-      - run: npm run validate:enforcement
-      - run: npm test
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Validate enforcement
+        run: npm run validate:enforcement
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run root tests
+        run: npm run test:root
+
+      - name: Build
+        run: npm run build
+
+      - name: Build Docker image
+        run: docker build -t onegodian-api:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
-FROM node:20-alpine
-
+FROM node:20-alpine AS deps
 WORKDIR /app
-
 COPY package*.json ./
-RUN npm install --omit=dev
+COPY onegodian-*/package.json ./
+RUN npm ci
 
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN npm run build
 
+FROM node:20-alpine AS runtime
+WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
-
+ENV LOG_LEVEL=info
+RUN npm install -g pm2
+COPY --from=build /app .
 EXPOSE 3000
-
-CMD ["npm", "start"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:${PORT}/health || exit 1
+CMD ["pm2-runtime", "ecosystem.config.cjs"]

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: "onegodian-api",
+      script: "server.js",
+      instances: "max",
+      exec_mode: "cluster",
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "300M",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3000,
+        LOG_LEVEL: "info"
+      }
+    }
+  ]
+};

--- a/onegodian-agent/package.json
+++ b/onegodian-agent/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "echo 'Build pipeline for onegodian-agent is scaffolded.'",
     "dev": "echo 'Dev workflow for onegodian-agent is scaffolded.'",
-    "test": "echo 'Test workflow for onegodian-agent is scaffolded.'"
+    "test": "echo 'Test workflow for onegodian-agent is scaffolded.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-algorithm/package.json
+++ b/onegodian-algorithm/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-algorithm yet.'"
+    "test": "echo 'No automated tests configured for onegodian-algorithm yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-community/package.json
+++ b/onegodian-community/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-community yet.'"
+    "test": "echo 'No automated tests configured for onegodian-community yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-core/package.json
+++ b/onegodian-core/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-core yet.'"
+    "test": "echo 'No automated tests configured for onegodian-core yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-docs/package.json
+++ b/onegodian-docs/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "echo 'Build pipeline for onegodian-docs is scaffolded.'",
     "dev": "echo 'Dev workflow for onegodian-docs is scaffolded.'",
-    "test": "echo 'Test workflow for onegodian-docs is scaffolded.'"
+    "test": "echo 'Test workflow for onegodian-docs is scaffolded.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-experience/package.json
+++ b/onegodian-experience/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-experience yet.'"
+    "test": "echo 'No automated tests configured for onegodian-experience yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-identity-engine/package.json
+++ b/onegodian-identity-engine/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"No tests configured\"",
+    "check": "npm run lint && npm run typecheck && npm run test"
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",
@@ -27,5 +29,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "zod": "^3.24.4"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/onegodian-identity/package.json
+++ b/onegodian-identity/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-identity yet.'"
+    "test": "echo 'No automated tests configured for onegodian-identity yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-orientation/package.json
+++ b/onegodian-orientation/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-orientation yet.'"
+    "test": "echo 'No automated tests configured for onegodian-orientation yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-protocol/package.json
+++ b/onegodian-protocol/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json",
-    "test": "echo 'No automated tests configured for onegodian-protocol yet.'"
+    "test": "echo 'No automated tests configured for onegodian-protocol yet.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-time/package.json
+++ b/onegodian-time/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "echo 'Build pipeline for onegodian-time is scaffolded.'",
     "dev": "echo 'Dev workflow for onegodian-time is scaffolded.'",
-    "test": "echo 'Test workflow for onegodian-time is scaffolded.'"
+    "test": "echo 'Test workflow for onegodian-time is scaffolded.'",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/onegodian-university-lms/package.json
+++ b/onegodian-university-lms/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "scripts": {
     "build": "echo 'Build pipeline placeholder'",
-    "lint": "echo 'Lint placeholder'"
+    "lint": "echo 'Lint placeholder'",
+    "test": "echo \"No tests configured\"",
+    "typecheck": "echo \"No typecheck configured\"",
+    "check": "npm run lint && npm run test"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check": "npm run validate:enforcement && npm run lint && npm run typecheck && npm run test && npm run test:root && npm run build",
     "lint": "node scripts/lint.mjs",
     "typecheck": "tsc --noEmit",
-    "test:root": "node --test test/*.test.js"
+    "test:root": "node --test test/*.test.js",
+    "dev": "node --watch server.js"
   },
   "engines": {
     "node": ">=20"

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,28 @@
+export type AppEnv = {
+  NODE_ENV: string;
+  PORT: number;
+  LOG_LEVEL: "debug" | "info" | "warn" | "error";
+};
+
+const parsePort = (value: string | undefined): number => {
+  const parsed = Number.parseInt(value ?? "3000", 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error(`Invalid PORT value: ${value ?? "undefined"}`);
+  }
+  return parsed;
+};
+
+const parseLogLevel = (value: string | undefined): AppEnv["LOG_LEVEL"] => {
+  const normalized = (value ?? "info").toLowerCase();
+  if (["debug", "info", "warn", "error"].includes(normalized)) {
+    return normalized as AppEnv["LOG_LEVEL"];
+  }
+
+  throw new Error(`Invalid LOG_LEVEL value: ${value ?? "undefined"}`);
+};
+
+export const env: AppEnv = {
+  NODE_ENV: process.env.NODE_ENV ?? "production",
+  PORT: parsePort(process.env.PORT),
+  LOG_LEVEL: parseLogLevel(process.env.LOG_LEVEL)
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,25 @@
 import express from "express";
 import cors from "cors";
+import { env } from "./config/env.js";
+import { logger } from "./utils/logger.js";
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const startedAt = new Date();
 
 app.disable("x-powered-by");
 app.set("trust proxy", true);
 
 app.use(cors());
 app.use(express.json({ limit: "1mb" }));
+
+app.use((req, _res, next) => {
+  logger.info("Incoming request", {
+    method: req.method,
+    path: req.path,
+    requestId: req.headers["x-request-id"] ?? null
+  });
+  next();
+});
 
 app.get("/", (_req, res) => {
   res.json({
@@ -26,12 +37,31 @@ app.get("/health", (_req, res) => {
   });
 });
 
+app.get("/health/live", (_req, res) => {
+  res.json({
+    ok: true,
+    status: "live",
+    uptimeSeconds: Math.floor(process.uptime()),
+    timestamp: new Date().toISOString()
+  });
+});
+
+app.get("/health/ready", (_req, res) => {
+  res.json({
+    ok: true,
+    status: "ready",
+    environment: env.NODE_ENV,
+    startedAt: startedAt.toISOString(),
+    timestamp: new Date().toISOString()
+  });
+});
+
 app.get("/v1/status", (_req, res) => {
   res.json({
     status: "ok",
     service: "onegodian-api",
     version: "1.0.0",
-    environment: process.env.NODE_ENV || "production",
+    environment: env.NODE_ENV,
     timestamp: new Date().toISOString()
   });
 });
@@ -54,7 +84,7 @@ app.post("/execute", (req, res) => {
     });
   }
 
-  console.log("Execution request:", {
+  logger.info("Execution request", {
     task,
     agent,
     metadata,
@@ -77,19 +107,19 @@ app.use((_req, res) => {
 });
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  console.error("Unhandled error:", err);
+  logger.error("Unhandled error", { message: err.message, stack: err.stack });
   res.status(500).json({
     success: false,
     error: "Internal server error"
   });
 });
 
-const server = app.listen(PORT, () => {
-  console.log(`OneGodian API running on port ${PORT}`);
+const server = app.listen(env.PORT, () => {
+  logger.info("OneGodian API started", { port: env.PORT, nodeEnv: env.NODE_ENV });
 });
 
 const shutdown = (signal: string) => {
-  console.log(`Received ${signal}. Shutting down gracefully...`);
+  logger.warn("Received shutdown signal", { signal });
   server.close(() => {
     process.exit(0);
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,43 @@
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+type LogContext = Record<string, unknown>;
+
+const levelPriority: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40
+};
+
+const currentLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || "info";
+
+const shouldLog = (level: LogLevel): boolean => levelPriority[level] >= levelPriority[currentLevel];
+
+const write = (level: LogLevel, message: string, context?: LogContext): void => {
+  if (!shouldLog(level)) {
+    return;
+  }
+
+  const payload = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(context ? { context } : {})
+  };
+
+  const line = JSON.stringify(payload);
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+};
+
+export const logger = {
+  debug: (message: string, context?: LogContext): void => write("debug", message, context),
+  info: (message: string, context?: LogContext): void => write("info", message, context),
+  warn: (message: string, context?: LogContext): void => write("warn", message, context),
+  error: (message: string, context?: LogContext): void => write("error", message, context)
+};


### PR DESCRIPTION
### Motivation

- Ensure consistent developer experience and CI validation by standardizing `package.json` scripts and Node engine across root and workspace packages.
- Centralize runtime configuration and observability with strict env parsing and a structured JSON logger to improve reliability in production.
- Provide production deployment artifacts (container, process manager, healthchecks, and CD) so the service can be built, monitored, and deployed reliably.

### Description

- Normalized workspace `package.json` entries (added `lint`, `typecheck`, `check`, `test` stubs where appropriate and enforced `engines.node >=20`) and updated root scripts (`build`, `dev`, `check`, etc.).
- Added environment parsing at `src/config/env.ts` with validated `PORT` and `LOG_LEVEL`, and updated `.env.example` for runtime defaults.
- Introduced a structured JSON logger at `src/utils/logger.ts` and integrated it into the API bootstrap (`src/index.ts`) for request logging, execution logs, lifecycle events, and error handling, plus added `/health/live` and `/health/ready` endpoints.
- Added deployment scaffolding: `ecosystem.config.cjs` (PM2 cluster config), multi-stage `Dockerfile` with container `HEALTHCHECK`, `.dockerignore`, and GitHub Actions workflows for CI (`.github/workflows/ci.yml`) and CD (`.github/workflows/cd.yml`).

### Testing

- Ran `npm ci` successfully to install dependencies.  
- Executed `npm run check` (which runs enforcement validation, lint, typecheck, tests, root tests, and build) and it completed successfully.  
- Ran `npm run typecheck` and `npm run lint` individually and both passed.  
- Attempted `docker build -t onegodian-api:test .` but it failed in this environment because the Docker CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea507b7b5c832d911afe9f0a1ef7a7)