### PR TITLE
feat(acc): build ACC dashboard v1 at /dashboard

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -372,3 +372,201 @@ dd {
 .mobile-first-grid {
   grid-template-columns: 1fr;
 }
+
+.dashboard-body {
+  margin: 0;
+  background: #090f1d;
+  color: #e6edf7;
+}
+
+.dashboard-layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 250px 1fr;
+}
+
+.dashboard-sidebar {
+  background: #0f172a;
+  border-right: 1px solid #1d2a44;
+  padding: 1.5rem 1rem;
+}
+
+.dashboard-sidebar h1 {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+}
+
+.dashboard-sidebar nav {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.dashboard-sidebar a {
+  color: #9fb3d9;
+  text-decoration: none;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+}
+
+.dashboard-sidebar a.active,
+.dashboard-sidebar a:hover {
+  background: #17233b;
+  color: #f8fbff;
+}
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-topnav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #1d2a44;
+  background: #0b1324;
+  position: sticky;
+  top: 0;
+}
+
+.topnav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.dashboard-content {
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.kpi-card,
+.panel,
+.health-card {
+  background: #111c31;
+  border: 1px solid #1f304f;
+  border-radius: 14px;
+}
+
+.kpi-card {
+  padding: 1rem;
+}
+
+.kpi-label,
+.kpi-delta,
+.health-detail,
+.dash-time {
+  color: #9fb3d9;
+  margin: 0;
+}
+
+.kpi-value {
+  margin: 0.2rem 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.panel {
+  padding: 1rem;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.health-card {
+  padding: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.health-warn {
+  border-color: #5c3a1b;
+}
+
+.health-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.pill {
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.76rem;
+  border: 1px solid #2f446d;
+}
+
+.pill-ok {
+  background: #143322;
+  color: #8de0b2;
+  border-color: #1d5335;
+}
+
+.pill-warn {
+  background: #402b14;
+  color: #ffd79a;
+  border-color: #5f441f;
+}
+
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 1rem;
+}
+
+.activity-feed {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 580px;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.6rem;
+  border-bottom: 1px solid #1f304f;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid #1d2a44;
+  }
+
+  .kpi-grid,
+  .health-grid,
+  .two-col {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -1,0 +1,5 @@
+import { renderDashboardView } from '../views/dashboardView.js';
+
+export const renderDashboardPage = (_req, res) => {
+  res.status(200).send(renderDashboardView());
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,7 @@ import {
   renderPricingPage,
 } from '../controllers/marketingController.js';
 import { healthHandler, metricsHandler, readyHandler, versionHandler } from '../controllers/healthController.js';
+import { renderDashboardPage } from '../controllers/dashboardController.js';
 
 const router = Router();
 
@@ -49,6 +50,7 @@ router.get('/pricing', renderPricingPage);
 router.get('/book-demo', renderBookDemoPage);
 router.get('/certificate-verification', renderCertificateVerificationPage);
 router.get('/membership-verification', renderMembershipVerificationPage);
+router.get('/dashboard', renderDashboardPage);
 router.use('/verify', verificationRoutes);
 router.get('/:qrvid', renderVerificationResult);
 

--- a/src/views/dashboardView.js
+++ b/src/views/dashboardView.js
@@ -1,0 +1,142 @@
+import { escapeHtml } from './layout.js';
+
+const kpis = [
+  { label: 'Active Agents', value: '12', delta: '+2 today' },
+  { label: 'Tasks Completed (24h)', value: '438', delta: '+8.4%' },
+  { label: 'Mean Response Time', value: '182ms', delta: '-14ms' },
+  { label: 'System Uptime', value: '99.98%', delta: '30 day rolling' },
+];
+
+const healthWidgets = [
+  { name: 'API Gateway', status: 'Healthy', detail: 'Latency 43ms', tone: 'ok' },
+  { name: 'Queue Workers', status: 'Healthy', detail: '8 workers online', tone: 'ok' },
+  { name: 'Policy Engine', status: 'Degraded', detail: '1 delayed shard', tone: 'warn' },
+  { name: 'Audit Stream', status: 'Healthy', detail: 'No dropped events', tone: 'ok' },
+];
+
+const agents = [
+  { id: 'AG-1001', name: 'Atlas', role: 'Coordinator', zone: 'us-east-1', health: 'Healthy', tasks: 118 },
+  { id: 'AG-1002', name: 'Nova', role: 'Classifier', zone: 'us-west-2', health: 'Healthy', tasks: 94 },
+  { id: 'AG-1003', name: 'Helix', role: 'Verifier', zone: 'eu-central-1', health: 'Degraded', tasks: 71 },
+  { id: 'AG-1004', name: 'Orion', role: 'Policy Guard', zone: 'us-east-2', health: 'Healthy', tasks: 87 },
+  { id: 'AG-1005', name: 'Vega', role: 'Router', zone: 'ap-south-1', health: 'Healthy', tasks: 68 },
+];
+
+const initialFeed = [
+  'Atlas completed workflow WF-3029.',
+  'Policy update POL-88 propagated to all workers.',
+  'Helix retried verification batch B-901.',
+  'Nova classified 14 new records.',
+];
+
+export const renderDashboardView = ({ pageTitle = 'ACC Dashboard v1' } = {}) => {
+  const kpiCards = kpis.map((item) => `
+    <article class="kpi-card">
+      <p class="kpi-label">${escapeHtml(item.label)}</p>
+      <p class="kpi-value">${escapeHtml(item.value)}</p>
+      <p class="kpi-delta">${escapeHtml(item.delta)}</p>
+    </article>
+  `).join('');
+
+  const healthCards = healthWidgets.map((widget) => `
+    <article class="health-card health-${escapeHtml(widget.tone)}">
+      <div>
+        <p class="health-name">${escapeHtml(widget.name)}</p>
+        <p class="health-detail">${escapeHtml(widget.detail)}</p>
+      </div>
+      <span class="pill">${escapeHtml(widget.status)}</span>
+    </article>
+  `).join('');
+
+  const feedItems = initialFeed.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+
+  const rows = agents.map((agent) => `
+    <tr>
+      <td>${escapeHtml(agent.id)}</td>
+      <td>${escapeHtml(agent.name)}</td>
+      <td>${escapeHtml(agent.role)}</td>
+      <td>${escapeHtml(agent.zone)}</td>
+      <td><span class="pill ${agent.health === 'Healthy' ? 'pill-ok' : 'pill-warn'}">${escapeHtml(agent.health)}</span></td>
+      <td>${escapeHtml(agent.tasks)}</td>
+    </tr>
+  `).join('');
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(pageTitle)}</title>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="dashboard-body">
+    <div class="dashboard-layout">
+      <aside class="dashboard-sidebar">
+        <h1>ACC</h1>
+        <nav aria-label="Dashboard">
+          <a href="/dashboard" class="active">Overview</a>
+          <a href="/health">Health API</a>
+          <a href="/readyz">Readiness</a>
+          <a href="/metrics">Metrics</a>
+          <a href="/">Verification Portal</a>
+        </nav>
+      </aside>
+      <div class="dashboard-main">
+        <header class="dashboard-topnav">
+          <strong>ACC Dashboard v1</strong>
+          <div class="topnav-actions">
+            <span class="pill pill-ok">Production</span>
+            <span class="dash-time" id="dash-time"></span>
+          </div>
+        </header>
+        <main class="dashboard-content">
+          <section class="kpi-grid">${kpiCards}</section>
+          <section class="panel">
+            <h2>Health Status</h2>
+            <div class="health-grid">${healthCards}</div>
+          </section>
+          <section class="two-col">
+            <article class="panel">
+              <h2>Live Activity Feed</h2>
+              <ul class="activity-feed" id="activity-feed">${feedItems}</ul>
+            </article>
+            <article class="panel">
+              <h2>Agent Fleet</h2>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr><th>ID</th><th>Name</th><th>Role</th><th>Zone</th><th>Health</th><th>Tasks</th></tr>
+                  </thead>
+                  <tbody>${rows}</tbody>
+                </table>
+              </div>
+            </article>
+          </section>
+        </main>
+      </div>
+    </div>
+    <script>
+      const feedEl = document.getElementById('activity-feed');
+      const timeEl = document.getElementById('dash-time');
+      const events = [
+        'Orion accepted routing batch RB-449.',
+        'Vega acknowledged failover drill.',
+        'Atlas synced policy cache.',
+        'Audit stream flushed event window.'
+      ];
+      let index = 0;
+      const tick = () => {
+        timeEl.textContent = new Date().toLocaleString();
+        if (feedEl && index < events.length) {
+          const li = document.createElement('li');
+          li.textContent = events[index++];
+          feedEl.prepend(li);
+          if (feedEl.children.length > 8) feedEl.removeChild(feedEl.lastElementChild);
+        }
+      };
+      tick();
+      setInterval(tick, 7000);
+    </script>
+  </body>
+</html>`;
+};


### PR DESCRIPTION
### Motivation
- Provide a lightweight, production-ready ACC dashboard (v1) served from the existing server so operators can inspect KPIs and agent health without adding infrastructure or a DB. 
- Ensure the dashboard is deployable on Hostinger (no DB required) and does not disrupt existing health and readiness endpoints. 

### Description
- Added a server-rendered dashboard view at `src/views/dashboardView.js` that includes a responsive dark UI, sidebar + top nav, KPI cards, health widgets, live activity feed, and an agent table populated with mock data. 
- Added `src/controllers/dashboardController.js` exposing `renderDashboardPage` to return the dashboard HTML. 
- Wired the page to the router with a new `GET /dashboard` route in `src/routes/index.js` while preserving `GET /health`, `GET /healthz`, and `GET /readyz`. 
- Added scoped dashboard styling to `public/css/styles.css` to support dark theme, responsive layout, and UI components; no database or additional runtime services introduced. 

### Testing
- Ran `npm run check` and it completed successfully. 
- Ran the automated test suite with `npm test` which completed successfully (17 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3490a8b0832da53128d0ca44484d)