### PR TITLE
Add production status docs, live acceptance tests, and smoke test command

### DIFF
--- a/ohi-stack/onegodian-api/LIVE_ACCEPTANCE_TESTS.md
+++ b/ohi-stack/onegodian-api/LIVE_ACCEPTANCE_TESTS.md
@@ -1,0 +1,88 @@
+# Live Acceptance Tests
+
+Base URL used below:
+
+```bash
+export API_BASE_URL="https://api.onegodian.org"
+```
+
+> Do not paste multiple URLs together in a browser address bar. Run one command at a time.
+
+## 1) Health Check
+
+```bash
+curl -sS "$API_BASE_URL/health"
+```
+
+## 2) Readiness Check
+
+```bash
+curl -sS "$API_BASE_URL/ready"
+```
+
+## 3) Version Check
+
+```bash
+curl -sS "$API_BASE_URL/version"
+```
+
+## 4) Products Listing
+
+```bash
+curl -sS "$API_BASE_URL/api/products"
+```
+
+## 5) Member Signup
+
+```bash
+curl -sS -X POST "$API_BASE_URL/api/members/signup" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "tester+signup@example.com",
+    "password": "ChangeThisPassword123!",
+    "fullName": "Live Signup Tester"
+  }'
+```
+
+## 6) Member Login
+
+```bash
+curl -sS -X POST "$API_BASE_URL/api/members/login" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "tester+signup@example.com",
+    "password": "ChangeThisPassword123!"
+  }'
+```
+
+## 7) Product Checkout
+
+```bash
+curl -sS -X POST "$API_BASE_URL/api/products/checkout" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "productId": "prod_alignment_prompt",
+    "email": "buyer@example.com",
+    "successUrl": "https://onegodian.org/success",
+    "cancelUrl": "https://onegodian.org/cancel"
+  }'
+```
+
+## 8) Billing Checkout
+
+```bash
+curl -sS -X POST "$API_BASE_URL/api/billing/checkout" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "plan": "monthly",
+    "email": "buyer@example.com",
+    "successUrl": "https://onegodian.org/success",
+    "cancelUrl": "https://onegodian.org/cancel"
+  }'
+```
+
+## Automated Smoke Test
+
+```bash
+API_BASE_URL="https://api.onegodian.org" npm run smoke:live
+```

--- a/ohi-stack/onegodian-api/PRODUCTION_STATUS.md
+++ b/ohi-stack/onegodian-api/PRODUCTION_STATUS.md
@@ -1,0 +1,23 @@
+# Production Status
+
+## Deployment
+- **Host:** Hostinger
+- **Live domain:** `https://api.onegodian.org`
+- **Current API version:** `0.3.0`
+- **Status date:** April 29, 2026
+
+## Live Endpoint Verification (Passing)
+The following production endpoints are currently passing:
+
+- `GET /health` → `ok: true`
+- `GET /ready` → `ready: true` with `routes`, `billing`, `products`, and `members` checks passing
+- `GET /version` → `onegodian-api v0.3.0`
+- `GET /api/products` → returns 2 live digital products:
+  - OneGodian Alignment Prompt™ + Developer Kit — `$49`
+  - The OneGodian Algorithm™ PDF — `$29`
+
+## Known Browser Testing Issue
+When multiple URLs are pasted together into a browser address bar at once, browser-based testing may fail or produce invalid requests. Test each endpoint URL one at a time, or use the documented `curl` commands and automated smoke test script.
+
+## Notes
+- Do not include API keys, secrets, bearer tokens, or private credentials in documentation, test commands, logs, screenshots, or terminal history.

--- a/ohi-stack/onegodian-api/README.md
+++ b/ohi-stack/onegodian-api/README.md
@@ -30,3 +30,14 @@ npm start
 - `GET /health`
 - `GET /ready`
 - `GET /version`
+
+## Production status
+- Production deployment is live on Hostinger at `https://api.onegodian.org`.
+- Current verified API release: `v0.3.0`.
+- See [PRODUCTION_STATUS.md](./PRODUCTION_STATUS.md) for current live status and verification details.
+- See [LIVE_ACCEPTANCE_TESTS.md](./LIVE_ACCEPTANCE_TESTS.md) for copy-paste live endpoint checks.
+
+### Live smoke test
+```bash
+API_BASE_URL="https://api.onegodian.org" npm run smoke:live
+```

--- a/ohi-stack/onegodian-api/package.json
+++ b/ohi-stack/onegodian-api/package.json
@@ -20,7 +20,8 @@
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:seed": "tsx prisma/seed.ts",
-    "db:reset:dev": "prisma migrate reset --force"
+    "db:reset:dev": "prisma migrate reset --force",
+    "smoke:live": "node scripts/live-smoke-test.js"
   },
   "dependencies": {
     "@prisma/client": "6.19.3",

--- a/ohi-stack/onegodian-api/scripts/live-smoke-test.js
+++ b/ohi-stack/onegodian-api/scripts/live-smoke-test.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const API_BASE_URL = process.env.API_BASE_URL || 'https://api.onegodian.org';
+
+const endpoints = [
+  '/health',
+  '/ready',
+  '/version',
+  '/api/products',
+];
+
+async function checkEndpoint(path) {
+  const url = `${API_BASE_URL}${path}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${path} returned HTTP ${response.status}`);
+  }
+
+  const body = await response.json();
+  return { path, status: response.status, body };
+}
+
+(async () => {
+  console.log(`Running live smoke test against ${API_BASE_URL}`);
+
+  try {
+    for (const endpoint of endpoints) {
+      const result = await checkEndpoint(endpoint);
+      console.log(`✅ ${result.path} (${result.status})`);
+      console.log(JSON.stringify(result.body));
+    }
+
+    console.log('Live smoke test passed.');
+  } catch (error) {
+    console.error('❌ Live smoke test failed.');
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
### Motivation
- Record the live production deployment details and verified endpoints for `api.onegodian.org` so status is discoverable in-repo.
- Provide copy-paste live acceptance `curl` checks to allow quick, repeatable manual verification of the public API.
- Provide an automated smoke test script and npm command to enable CI or local verification of core public endpoints.

### Description
- Added `PRODUCTION_STATUS.md` documenting Hostinger deployment, live domain `https://api.onegodian.org`, current version `0.3.0`, passing endpoints, and a known browser multi-URL paste testing issue.
- Added `LIVE_ACCEPTANCE_TESTS.md` with copy-paste `curl` commands for `GET /health`, `GET /ready`, `GET /version`, `GET /api/products`, `POST /api/members/signup`, `POST /api/members/login`, `POST /api/products/checkout`, and `POST /api/billing/checkout`.
- Added `scripts/live-smoke-test.js` which reads `API_BASE_URL` and checks `/health`, `/ready`, `/version`, and `/api/products`, and exits non-zero on failure.
- Added `smoke:live` npm script to `package.json` and updated `README.md` with production status and the smoke-test command example; no secrets were added to the repo or docs.

### Testing
- Ran `npm ci` successfully to install dependencies.
- Ran `npm run check` (`tsc --noEmit`) and it passed after installing dev dependencies.
- Ran `API_BASE_URL=https://api.onegodian.org npm run smoke:live` in this environment and the smoke test failed with `fetch failed` (non-zero exit) due to network/runtime reachability limitations in this run rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e0714054832d97dce3a97782c573)