### PR TITLE
Initialize ONEGODIAN Capital Portal plugin scaffold

### DIFF
--- a/onegodian-capital-plugin/CHANGELOG.md
+++ b/onegodian-capital-plugin/CHANGELOG.md
@@ -1,0 +1,4 @@
+v0.1.0 - Initial scaffold
+
+- Created plugin bootstrap, activation/deactivation hooks, and uninstall file.
+- Added core include classes, admin/public views, templates, docs, and test notes.

--- a/onegodian-capital-plugin/README.md
+++ b/onegodian-capital-plugin/README.md
@@ -1,0 +1,31 @@
+# ONEGODIAN Capital Portal (Private Plugin)
+
+## Purpose
+Standalone WordPress plugin for digital capital instrument records (notes, bonds), offerings, investor ledgers, disclosures, and verifiable certificates.
+
+## Private Repo Warning
+This plugin is intended for private repository use only. Do not publish source, investor records, or legal documents publicly.
+
+## Installation
+1. Copy plugin folder to `wp-content/plugins/onegodian-capital-plugin`.
+2. Activate **ONEGODIAN Capital Portal** in WordPress admin.
+3. Configure settings under the Capital Portal settings screen.
+
+## Shortcodes
+- `[onegodian_capital_offerings]`
+- `[onegodian_capital_offering id="123"]`
+- `[onegodian_investor_dashboard]`
+- `[onegodian_capital_certificate id="CERT-ID"]`
+- `[onegodian_capital_disclosure id="DISC-ID"]`
+
+## Data Model
+- CPT: `onegodian_offering`
+- Meta fields: instrument type, lifecycle status, purchase ranges, raise targets, dates, terms, use-of-funds, disclosure packet version.
+- Tables: instruments, ledger, disclosure acceptances, certificates.
+
+## Legal Review Warning
+The ONEGODIAN Capital Portal is software infrastructure for managing digital records related to private capital instruments. It does not itself create, approve, or validate any securities offering. All notes, bonds, repayment terms, investor eligibility rules, disclosures, exemptions, and offering documents must be reviewed by qualified legal counsel before public use.
+
+## Version Roadmap
+- v0.1.0: Initial scaffold.
+- v0.2.0: Purchase flow integration (order -> disclosure acceptance -> instrument -> ledger -> certificate -> dashboard).

--- a/onegodian-capital-plugin/SECURITY.md
+++ b/onegodian-capital-plugin/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+- No secrets in this repository.
+- No real investor data in this repository.
+- No KYC documents in this repository.
+- No signed agreements in this repository.
+- Report vulnerabilities internally through authorized ONEGODIAN channels.

--- a/onegodian-capital-plugin/admin/views/certificates.php
+++ b/onegodian-capital-plugin/admin/views/certificates.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/admin/views/dashboard.php
+++ b/onegodian-capital-plugin/admin/views/dashboard.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Admin dashboard disclaimer view.
+ */
+?>
+<div class="notice notice-warning">
+    <p><strong>Legal Review Required:</strong> The ONEGODIAN Capital Portal is software infrastructure for managing digital records related to private capital instruments. It does not itself create, approve, or validate any securities offering. All notes, bonds, repayment terms, investor eligibility rules, disclosures, exemptions, and offering documents must be reviewed by qualified legal counsel before public use.</p>
+</div>

--- a/onegodian-capital-plugin/admin/views/disclosures.php
+++ b/onegodian-capital-plugin/admin/views/disclosures.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/admin/views/investor-ledger.php
+++ b/onegodian-capital-plugin/admin/views/investor-ledger.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/admin/views/offering-edit.php
+++ b/onegodian-capital-plugin/admin/views/offering-edit.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/admin/views/offerings-list.php
+++ b/onegodian-capital-plugin/admin/views/offerings-list.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/admin/views/settings.php
+++ b/onegodian-capital-plugin/admin/views/settings.php
@@ -1,0 +1,1 @@
+<?php\n/** Legal review required before public use. */\n

--- a/onegodian-capital-plugin/assets/index.html
+++ b/onegodian-capital-plugin/assets/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body>Assets placeholder.</body></html>

--- a/onegodian-capital-plugin/docs/CAPITAL_PORTAL_OVERVIEW.md
+++ b/onegodian-capital-plugin/docs/CAPITAL_PORTAL_OVERVIEW.md
@@ -1,0 +1,5 @@
+# CAPITAL_PORTAL_OVERVIEW
+
+Scaffold placeholder for CAPITAL_PORTAL_OVERVIEW.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/DIGITAL_CERTIFICATE_STANDARD.md
+++ b/onegodian-capital-plugin/docs/DIGITAL_CERTIFICATE_STANDARD.md
@@ -1,0 +1,5 @@
+# DIGITAL_CERTIFICATE_STANDARD
+
+Scaffold placeholder for DIGITAL_CERTIFICATE_STANDARD.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/DISCLOSURE_REQUIREMENTS.md
+++ b/onegodian-capital-plugin/docs/DISCLOSURE_REQUIREMENTS.md
@@ -1,0 +1,5 @@
+# DISCLOSURE_REQUIREMENTS
+
+Scaffold placeholder for DISCLOSURE_REQUIREMENTS.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/INVESTOR_DATA_HANDLING.md
+++ b/onegodian-capital-plugin/docs/INVESTOR_DATA_HANDLING.md
@@ -1,0 +1,5 @@
+# INVESTOR_DATA_HANDLING
+
+Scaffold placeholder for INVESTOR_DATA_HANDLING.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/LEDGER_STANDARD.md
+++ b/onegodian-capital-plugin/docs/LEDGER_STANDARD.md
@@ -1,0 +1,5 @@
+# LEDGER_STANDARD
+
+Scaffold placeholder for LEDGER_STANDARD.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/LEGAL_REVIEW_REQUIRED.md
+++ b/onegodian-capital-plugin/docs/LEGAL_REVIEW_REQUIRED.md
@@ -1,0 +1,5 @@
+# LEGAL_REVIEW_REQUIRED
+
+Scaffold placeholder for LEGAL_REVIEW_REQUIRED.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/NO_SECRETS_POLICY.md
+++ b/onegodian-capital-plugin/docs/NO_SECRETS_POLICY.md
@@ -1,0 +1,5 @@
+# NO_SECRETS_POLICY
+
+Scaffold placeholder for NO_SECRETS_POLICY.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/RELEASE_CHECKLIST.md
+++ b/onegodian-capital-plugin/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,5 @@
+# RELEASE_CHECKLIST
+
+Scaffold placeholder for RELEASE_CHECKLIST.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/docs/SECURITIES_COMPLIANCE_NOTES.md
+++ b/onegodian-capital-plugin/docs/SECURITIES_COMPLIANCE_NOTES.md
@@ -1,0 +1,5 @@
+# SECURITIES_COMPLIANCE_NOTES
+
+Scaffold placeholder for SECURITIES_COMPLIANCE_NOTES.
+
+Legal review required before production or public use.

--- a/onegodian-capital-plugin/includes/class-activator.php
+++ b/onegodian-capital-plugin/includes/class-activator.php
@@ -1,0 +1,20 @@
+<?php
+
+class Onegodian_Capital_Activator {
+    public static function activate() {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset_collate = $wpdb->get_charset_collate();
+        $prefix = $wpdb->prefix;
+
+        $sql = [];
+        $sql[] = "CREATE TABLE {$prefix}onegodian_capital_instruments (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, offering_id BIGINT UNSIGNED NOT NULL, instrument_type VARCHAR(20) NOT NULL, status VARCHAR(20) NOT NULL, created_at DATETIME NOT NULL, PRIMARY KEY (id)) $charset_collate;";
+        $sql[] = "CREATE TABLE {$prefix}onegodian_capital_ledger (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, instrument_id BIGINT UNSIGNED NOT NULL, entry_type VARCHAR(50) NOT NULL, amount DECIMAL(18,2) NOT NULL DEFAULT 0.00, metadata LONGTEXT NULL, created_at DATETIME NOT NULL, PRIMARY KEY (id)) $charset_collate;";
+        $sql[] = "CREATE TABLE {$prefix}onegodian_capital_disclosure_acceptances (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, disclosure_id VARCHAR(100) NOT NULL, investor_ref VARCHAR(100) NOT NULL, accepted_at DATETIME NOT NULL, PRIMARY KEY (id)) $charset_collate;";
+        $sql[] = "CREATE TABLE {$prefix}onegodian_capital_certificates (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, certificate_id VARCHAR(100) NOT NULL, instrument_id BIGINT UNSIGNED NOT NULL, issued_at DATETIME NOT NULL, verification_hash VARCHAR(255) NULL, PRIMARY KEY (id), UNIQUE KEY certificate_id (certificate_id)) $charset_collate;";
+
+        foreach ($sql as $statement) {
+            dbDelta($statement);
+        }
+    }
+}

--- a/onegodian-capital-plugin/includes/class-certificates.php
+++ b/onegodian-capital-plugin/includes/class-certificates.php
@@ -1,0 +1,2 @@
+<?php
+class Onegodian_Capital_Certificates {}

--- a/onegodian-capital-plugin/includes/class-deactivator.php
+++ b/onegodian-capital-plugin/includes/class-deactivator.php
@@ -1,0 +1,7 @@
+<?php
+
+class Onegodian_Capital_Deactivator {
+    public static function deactivate() {
+        // Reserved for scheduled cleanup and flush operations.
+    }
+}

--- a/onegodian-capital-plugin/includes/class-disclosures.php
+++ b/onegodian-capital-plugin/includes/class-disclosures.php
@@ -1,0 +1,2 @@
+<?php
+class Onegodian_Capital_Disclosures {}

--- a/onegodian-capital-plugin/includes/class-ledger.php
+++ b/onegodian-capital-plugin/includes/class-ledger.php
@@ -1,0 +1,2 @@
+<?php
+class Onegodian_Capital_Ledger {}

--- a/onegodian-capital-plugin/includes/class-meta-boxes.php
+++ b/onegodian-capital-plugin/includes/class-meta-boxes.php
@@ -1,0 +1,9 @@
+<?php
+class Onegodian_Capital_Meta_Boxes {
+    public static function register_meta() {
+        $fields = ['instrument_type','status','minimum_purchase','maximum_purchase','raise_target','issue_date','maturity_date','term_months','repayment_terms','use_of_funds','disclosure_packet_version'];
+        foreach ($fields as $field) {
+            register_post_meta('onegodian_offering', $field, ['show_in_rest' => true, 'single' => true, 'type' => 'string']);
+        }
+    }
+}

--- a/onegodian-capital-plugin/includes/class-permissions.php
+++ b/onegodian-capital-plugin/includes/class-permissions.php
@@ -1,0 +1,9 @@
+<?php
+class Onegodian_Capital_Permissions {
+    public static function register_caps() {
+        $role = get_role('administrator');
+        if (!$role) { return; }
+        $caps = ['manage_onegodian_capital','view_onegodian_ledger','issue_onegodian_instruments','manage_onegodian_disclosures','export_onegodian_capital_records'];
+        foreach ($caps as $cap) { $role->add_cap($cap); }
+    }
+}

--- a/onegodian-capital-plugin/includes/class-plugin.php
+++ b/onegodian-capital-plugin/includes/class-plugin.php
@@ -1,0 +1,35 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-post-types.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-meta-boxes.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-shortcodes.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-rest-api.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-certificates.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-ledger.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-disclosures.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-permissions.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-settings.php';
+
+class Onegodian_Capital_Plugin {
+    private static $instance;
+
+    public static function instance() {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function init() {
+        add_action('init', ['Onegodian_Capital_Post_Types', 'register']);
+        add_action('init', ['Onegodian_Capital_Shortcodes', 'register']);
+        add_action('init', ['Onegodian_Capital_Meta_Boxes', 'register_meta']);
+        add_action('admin_init', ['Onegodian_Capital_Settings', 'register']);
+        add_action('init', ['Onegodian_Capital_Permissions', 'register_caps']);
+        add_action('rest_api_init', ['Onegodian_Capital_REST_API', 'register_routes']);
+    }
+}

--- a/onegodian-capital-plugin/includes/class-post-types.php
+++ b/onegodian-capital-plugin/includes/class-post-types.php
@@ -1,0 +1,16 @@
+<?php
+class Onegodian_Capital_Post_Types {
+    public static function register() {
+        register_post_type('onegodian_offering', [
+            'labels' => [
+                'name' => __('Capital Offerings', 'onegodian-capital'),
+                'singular_name' => __('Capital Offering', 'onegodian-capital'),
+            ],
+            'public' => false,
+            'show_ui' => true,
+            'show_in_menu' => true,
+            'supports' => ['title', 'editor', 'excerpt', 'thumbnail'],
+            'has_archive' => false,
+        ]);
+    }
+}

--- a/onegodian-capital-plugin/includes/class-rest-api.php
+++ b/onegodian-capital-plugin/includes/class-rest-api.php
@@ -1,0 +1,6 @@
+<?php
+class Onegodian_Capital_REST_API {
+    public static function register_routes() {
+        // Placeholder REST routes for future milestones.
+    }
+}

--- a/onegodian-capital-plugin/includes/class-settings.php
+++ b/onegodian-capital-plugin/includes/class-settings.php
@@ -1,0 +1,9 @@
+<?php
+class Onegodian_Capital_Settings {
+    public static function register() {
+        $settings = ['company_name','compliance_disclaimer','certificate_signature_name','certificate_signature_title','verification_base_url'];
+        foreach ($settings as $setting) {
+            register_setting('onegodian_capital', $setting, ['type' => 'string', 'sanitize_callback' => 'sanitize_text_field']);
+        }
+    }
+}

--- a/onegodian-capital-plugin/includes/class-shortcodes.php
+++ b/onegodian-capital-plugin/includes/class-shortcodes.php
@@ -1,0 +1,18 @@
+<?php
+class Onegodian_Capital_Shortcodes {
+    public static function register() {
+        add_shortcode('onegodian_capital_offerings', [__CLASS__, 'offerings']);
+        add_shortcode('onegodian_capital_offering', [__CLASS__, 'offering']);
+        add_shortcode('onegodian_investor_dashboard', [__CLASS__, 'investor_dashboard']);
+        add_shortcode('onegodian_capital_certificate', [__CLASS__, 'certificate']);
+        add_shortcode('onegodian_capital_disclosure', [__CLASS__, 'disclosure']);
+    }
+    public static function offerings() { return self::view('public/views/offerings-grid.php'); }
+    public static function offering() { return self::view('public/views/offering-single.php'); }
+    public static function investor_dashboard() { return self::view('public/views/investor-dashboard.php'); }
+    public static function certificate() { return self::view('public/views/certificate-view.php'); }
+    public static function disclosure() { return self::view('public/views/disclosure-consent.php'); }
+    private static function view($rel) {
+        ob_start(); include ONEGODIAN_CAPITAL_PATH . $rel; return ob_get_clean();
+    }
+}

--- a/onegodian-capital-plugin/onegodian-capital.php
+++ b/onegodian-capital-plugin/onegodian-capital.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: ONEGODIAN Capital Portal
+ * Description: Private infrastructure plugin for managing digital records related to private capital instruments.
+ * Version: 0.1.0
+ * Author: ONEGODIAN
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Text Domain: onegodian-capital
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('ONEGODIAN_CAPITAL_VERSION', '0.1.0');
+define('ONEGODIAN_CAPITAL_PATH', plugin_dir_path(__FILE__));
+define('ONEGODIAN_CAPITAL_URL', plugin_dir_url(__FILE__));
+
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-plugin.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-activator.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-deactivator.php';
+
+register_activation_hook(__FILE__, ['Onegodian_Capital_Activator', 'activate']);
+register_deactivation_hook(__FILE__, ['Onegodian_Capital_Deactivator', 'deactivate']);
+
+Onegodian_Capital_Plugin::instance()->init();

--- a/onegodian-capital-plugin/public/views/certificate-view.php
+++ b/onegodian-capital-plugin/public/views/certificate-view.php
@@ -1,0 +1,1 @@
+<div>ONEGODIAN Capital Portal placeholder: certificate-view</div>

--- a/onegodian-capital-plugin/public/views/disclosure-consent.php
+++ b/onegodian-capital-plugin/public/views/disclosure-consent.php
@@ -1,0 +1,1 @@
+<div>ONEGODIAN Capital Portal placeholder: disclosure-consent</div>

--- a/onegodian-capital-plugin/public/views/investor-dashboard.php
+++ b/onegodian-capital-plugin/public/views/investor-dashboard.php
@@ -1,0 +1,1 @@
+<div>ONEGODIAN Capital Portal placeholder: investor-dashboard</div>

--- a/onegodian-capital-plugin/public/views/offering-single.php
+++ b/onegodian-capital-plugin/public/views/offering-single.php
@@ -1,0 +1,1 @@
+<div>ONEGODIAN Capital Portal placeholder: offering-single</div>

--- a/onegodian-capital-plugin/public/views/offerings-grid.php
+++ b/onegodian-capital-plugin/public/views/offerings-grid.php
@@ -1,0 +1,1 @@
+<div>ONEGODIAN Capital Portal placeholder: offerings-grid</div>

--- a/onegodian-capital-plugin/templates/certificate-bond.php
+++ b/onegodian-capital-plugin/templates/certificate-bond.php
@@ -1,0 +1,1 @@
+<div>Template placeholder: certificate-bond</div>

--- a/onegodian-capital-plugin/templates/certificate-note.php
+++ b/onegodian-capital-plugin/templates/certificate-note.php
@@ -1,0 +1,1 @@
+<div>Template placeholder: certificate-note</div>

--- a/onegodian-capital-plugin/templates/disclosure-packet.php
+++ b/onegodian-capital-plugin/templates/disclosure-packet.php
@@ -1,0 +1,1 @@
+<div>Template placeholder: disclosure-packet</div>

--- a/onegodian-capital-plugin/templates/receipt.php
+++ b/onegodian-capital-plugin/templates/receipt.php
@@ -1,0 +1,1 @@
+<div>Template placeholder: receipt</div>

--- a/onegodian-capital-plugin/tests/README.md
+++ b/onegodian-capital-plugin/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+This scaffold currently includes manual and syntax validation checks.

--- a/onegodian-capital-plugin/uninstall.php
+++ b/onegodian-capital-plugin/uninstall.php
@@ -1,0 +1,6 @@
+<?php
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+// Intentionally does not delete records by default.


### PR DESCRIPTION
### Motivation
- Provide a private, standalone WordPress plugin scaffold for managing digital capital instrument records (notes, bonds), offerings, investor ledgers, disclosures, and verifiable certificates.
- Keep capital functionality separate from identity/members concerns and ensure all financial terms are configurable and disclosure-backed.
- Include clear legal-review warnings and policies to prevent accidental publication of investor data or secrets.

### Description
- Added plugin bootstrap `onegodian-capital.php` with constants and activation/deactivation/uninstall hooks and a central includes loader in `includes/class-plugin.php`.
- Registered a custom post type `onegodian_offering` and offering meta fields (`instrument_type`, `status`, `minimum_purchase`, `maximum_purchase`, `raise_target`, `issue_date`, `maturity_date`, `term_months`, `repayment_terms`, `use_of_funds`, `disclosure_packet_version`) via `register_post_meta`.
- Implemented plugin settings (`company_name`, `compliance_disclaimer`, `certificate_signature_name`, `certificate_signature_title`, `verification_base_url`) and shortcode stubs for public views (`[onegodian_capital_offerings]`, `[onegodian_capital_offering]`, `[onegodian_investor_dashboard]`, `[onegodian_capital_certificate]`, `[onegodian_capital_disclosure]`).
- Added activation-time DB table creation for instruments, ledger, disclosure acceptances, and certificates, admin capability registration, lightweight admin/public view and template placeholders, docs (`README.md`, `CHANGELOG.md`, `SECURITY.md`, `docs/*`) and a tests README; admin dashboard includes the required legal disclaimer.

### Testing
- Ran a PHP syntax check across plugin PHP files with `find onegodian-capital-plugin -name '*.php' -print0 | xargs -0 -n1 php -l`, and there were no syntax errors detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f0db71ac832da51ff30f1fc4c8c3)