### PR TITLE
Add capital-linked WooCommerce product handling

### DIFF
--- a/onegodian-capital-plugin/README.md
+++ b/onegodian-capital-plugin/README.md
@@ -49,3 +49,10 @@ The ONEGODIAN Capital Portal is software infrastructure for managing digital rec
 - Disclosure acceptance must be recorded before an instrument can be issued from a paid order.
 - Paid WooCommerce order items linked with `_onegodian_capital_offering_id` can create instrument, ledger, and certificate records.
 - Issuance records are bookkeeping artifacts; legal review remains required before any public offering use.
+
+## WooCommerce Product Handling (Capital-Linked)
+- Products with `_onegodian_capital_offering_id` are treated as checkout-only items, not ordinary retail catalog listings.
+- Capital-linked product pages display a frontend notice directing buyers to official offering and disclosure pages before checkout.
+- Product edit screens display an admin warning clarifying Capital Portal-first presentation requirements.
+- Capital-linked products have comments/reviews disabled where possible through plugin hooks.
+- Recommended standards and implementation guidance are documented in `docs/WOOCOMMERCE_PRODUCT_STANDARD.md`.

--- a/onegodian-capital-plugin/docs/WOOCOMMERCE_PRODUCT_STANDARD.md
+++ b/onegodian-capital-plugin/docs/WOOCOMMERCE_PRODUCT_STANDARD.md
@@ -1,0 +1,19 @@
+# WooCommerce Product Standard (Capital-Linked Products)
+
+## Standard
+- WooCommerce product records are used for checkout execution only.
+- Capital offering presentation belongs in Capital Portal pages (offering pages and disclosure-backed views).
+- Capital-linked products should be hidden from normal storefront browsing.
+- Disclosure acceptance must occur before instrument issuance.
+
+## Product Setup Guidance
+For WooCommerce products linked to `_onegodian_capital_offering_id`, use the following baseline:
+
+1. **Catalog visibility:** `hidden`
+2. **Reviews:** disabled
+3. **Category:** `Capital Test Products` (or equivalent restricted internal category)
+4. **Copy constraints:** do not use investment, yield, or guarantee language in product descriptions
+
+## Implementation Notes
+- Use `Onegodian_Capital_WooCommerce::is_capital_product($product_id)` to detect product linkage.
+- Use `Onegodian_Capital_WooCommerce::get_recommended_product_settings()` and the `onegodian_capital_product_recommended_settings` filter to customize operational standards in local deployments.

--- a/onegodian-capital-plugin/includes/class-woocommerce.php
+++ b/onegodian-capital-plugin/includes/class-woocommerce.php
@@ -7,6 +7,15 @@ if (!defined('ABSPATH')) {
 class Onegodian_Capital_WooCommerce {
     public static function register() {
         add_action('admin_notices', [__CLASS__, 'maybe_show_missing_notice']);
+
+        if (!self::is_active()) {
+            return;
+        }
+
+        add_filter('comments_open', [__CLASS__, 'maybe_disable_product_comments'], 10, 2);
+        add_filter('pings_open', [__CLASS__, 'maybe_disable_product_comments'], 10, 2);
+        add_action('admin_notices', [__CLASS__, 'maybe_show_capital_product_admin_notice']);
+        add_action('woocommerce_single_product_summary', [__CLASS__, 'render_capital_product_frontend_notice'], 6);
     }
 
     public static function is_active() {
@@ -21,5 +30,78 @@ class Onegodian_Capital_WooCommerce {
         echo '<div class="notice notice-warning"><p>';
         echo esc_html__('ONEGODIAN Capital Portal purchase flow requires WooCommerce for paid-order integration. The plugin remains active without WooCommerce.', 'onegodian-capital');
         echo '</p></div>';
+    }
+
+    public static function is_capital_product($product_id) {
+        $product_id = absint($product_id);
+        if ($product_id <= 0) {
+            return false;
+        }
+
+        $offering_id = get_post_meta($product_id, '_onegodian_capital_offering_id', true);
+        return !empty($offering_id);
+    }
+
+    public static function maybe_disable_product_comments($open, $post_id) {
+        if (get_post_type($post_id) !== 'product') {
+            return $open;
+        }
+
+        if (!self::is_capital_product($post_id)) {
+            return $open;
+        }
+
+        return false;
+    }
+
+    public static function maybe_show_capital_product_admin_notice() {
+        if (!is_admin() || !current_user_can('edit_products')) {
+            return;
+        }
+
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if (!$screen || $screen->id !== 'product' || $screen->base !== 'post') {
+            return;
+        }
+
+        $product_id = isset($_GET['post']) ? absint(wp_unslash($_GET['post'])) : 0;
+        if (!self::is_capital_product($product_id)) {
+            return;
+        }
+
+        echo '<div class="notice notice-warning"><p>';
+        echo esc_html__('This product is linked to a ONEGODIAN Capital Offering and should be used for checkout only. Public offering presentation should occur through Capital Portal pages and disclosure-backed views.', 'onegodian-capital');
+        echo '</p></div>';
+    }
+
+    public static function render_capital_product_frontend_notice() {
+        if (!is_product()) {
+            return;
+        }
+
+        global $product;
+        if (!$product || !self::is_capital_product($product->get_id())) {
+            return;
+        }
+
+        echo '<div class="woocommerce-info onegodian-capital-product-notice">';
+        echo esc_html__('This checkout item is connected to a Capital Offering record. Review the official Capital Offering and disclosure page before checkout.', 'onegodian-capital');
+        echo '</div>';
+    }
+
+    /**
+     * Returns recommended WooCommerce configuration defaults for capital-linked products.
+     *
+     * Filter hook: onegodian_capital_product_recommended_settings
+     */
+    public static function get_recommended_product_settings() {
+        $settings = [
+            'catalog_visibility' => 'hidden',
+            'reviews_enabled' => false,
+            'recommended_category' => __('Capital Test Products', 'onegodian-capital'),
+            'content_guidance' => __('Avoid investment, yield, or guarantee language in product descriptions.', 'onegodian-capital'),
+        ];
+
+        return apply_filters('onegodian_capital_product_recommended_settings', $settings);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure WooCommerce products that represent ONEGODIAN Capital Offerings (marked by `_onegodian_capital_offering_id`) are treated as checkout-only instruments and not ordinary retail products.
- Reduce public-facing retail affordances (reviews/comments and storefront exposure) that could misrepresent offering presentation and disclosure flows.
- Provide a simple detection helper and recommended operational defaults so deployments can enforce catalog and content guidance consistently.

### Description
- Added WooCommerce integration hooks in `Onegodian_Capital_WooCommerce::register()` to register filters/actions for comments/pings, product admin notices, and a frontend single-product notice when WooCommerce is active.
- Implemented `Onegodian_Capital_WooCommerce::is_capital_product($product_id)` to detect `_onegodian_capital_offering_id` post meta and used it to gate behavior.
- Implemented `maybe_disable_product_comments()`, `maybe_show_capital_product_admin_notice()`, and `render_capital_product_frontend_notice()` to disable reviews where possible and display admin and frontend warnings for capital-linked products.
- Added `get_recommended_product_settings()` and the `onegodian_capital_product_recommended_settings` filter to document recommended defaults (hidden catalog visibility, reviews disabled, recommended category, and content guidance).
- Added `docs/WOOCOMMERCE_PRODUCT_STANDARD.md` with standards and setup guidance and updated `README.md` with a WooCommerce product handling note.

### Testing
- Ran a repository-wide PHP syntax check with `find onegodian-capital-plugin -name '*.php' -print0 | xargs -0 -n1 php -l`, which surfaced an existing parse error in `includes/class-shortcodes.php` (unrelated to these changes).
- Ran a targeted syntax check on the modified file with `php -l onegodian-capital-plugin/includes/class-woocommerce.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fc5079c8832db80f70a1db574070)