### PR TITLE
Fix Capital Portal mobile responsiveness and contrast

### DIFF
--- a/onegodian-capital-plugin/docs/UI_STANDARD.md
+++ b/onegodian-capital-plugin/docs/UI_STANDARD.md
@@ -20,3 +20,14 @@ Use a navy/white/gold institutional visual system with readable, responsive card
 
 ## Disclosure-first UX rule
 Any offering or participant action flow must prioritize disclosure review and explicit acknowledgment before progression.
+
+
+## Navy Panel Contrast Rules
+- Any navy hero/card/dashboard panel must render headings in white.
+- Eyebrow and kicker labels in navy panels must render gold.
+- Body text inside navy panels must render white for readable contrast.
+
+## Mobile Table Rules
+- All dashboard, ledger, instrument, and certificate/disclosure tables must be wrapped in a mobile-scrollable container.
+- Use `.onegodian-capital-table-wrap` with `overflow-x: auto` and a `.onegodian-capital-responsive-table` `min-width` for wide data tables.
+- No Capital portal page may force horizontal page overflow at mobile breakpoints.

--- a/onegodian-capital-plugin/public/css/onegodian-capital-public.css
+++ b/onegodian-capital-plugin/public/css/onegodian-capital-public.css
@@ -14,6 +14,11 @@
 .og-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 .og-card, .og-panel { background: var(--og-white); border: 1px solid var(--og-border); border-radius: 12px; box-shadow: 0 2px 10px rgba(11, 31, 58, .06); padding: 1rem; }
 .og-card h3, .og-panel h2, .og-panel h3 { color: var(--og-navy); margin-top: 0; }
+.og-navy-panel { background: var(--og-navy); border-color: var(--og-navy-soft); color: var(--og-white); }
+.og-navy-panel h1, .og-navy-panel h2, .og-navy-panel h3, .og-navy-panel h4, .og-navy-panel h5, .og-navy-panel h6, .og-navy-panel .og-heading { color: var(--og-white); }
+.og-navy-panel .og-eyebrow, .og-navy-panel .og-kicker { color: var(--og-gold); font-weight: 700; }
+.og-navy-panel p, .og-navy-panel li, .og-navy-panel td, .og-navy-panel th, .og-navy-panel dd, .og-navy-panel dt, .og-navy-panel .og-meta { color: var(--og-white); }
+.og-navy-panel .og-warning { color: var(--og-text); }
 .og-meta { color: var(--og-muted); font-size: .92rem; }
 .og-badge { display: inline-block; border-radius: 999px; padding: .2rem .6rem; font-size: .75rem; font-weight: 700; }
 .og-badge--active { background: #e9f7ef; color: #116639; }
@@ -21,6 +26,8 @@
 .og-badge--draft { background: #edf1f7; color: #344054; }
 .og-warning { border-left: 4px solid var(--og-gold); background: var(--og-warning-bg); border-radius: 8px; padding: .75rem 1rem; margin-bottom: 1rem; }
 .og-table { width: 100%; border-collapse: collapse; font-size: .95rem; }
+.onegodian-capital-table-wrap { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.onegodian-capital-responsive-table { min-width: 640px; }
 .og-table th { background: var(--og-navy); color: var(--og-white); text-align: left; }
 .og-table th, .og-table td { border: 1px solid var(--og-border); padding: .65rem; vertical-align: top; }
 .og-kv { margin: 0; display: grid; grid-template-columns: minmax(140px, 180px) 1fr; gap: .4rem .9rem; }
@@ -31,5 +38,8 @@
 
 @media (max-width: 760px) {
   .og-kv { grid-template-columns: 1fr; }
-  .og-table { display: block; overflow-x: auto; white-space: nowrap; }
+  .og-grid { grid-template-columns: minmax(0, 1fr); }
+  .og-card, .og-panel { width: 100%; box-sizing: border-box; }
+  .onegodian-capital-table-wrap { margin: 0 -.25rem; padding: 0 .25rem; }
+  .onegodian-capital-responsive-table { min-width: 560px; }
 }

--- a/onegodian-capital-plugin/public/views/certificate-view.php
+++ b/onegodian-capital-plugin/public/views/certificate-view.php
@@ -1,11 +1,12 @@
-<div class="onegodian-capital-portal og-panel og-certificate">
+<div class="onegodian-capital-portal og-panel og-certificate og-navy-panel">
+    <p class="og-eyebrow">Certificate</p>
     <h2 class="og-heading">Certificate Record</h2>
-    <table class="og-table">
+    <div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table">
         <tr><th>certificate number</th><td>placeholder</td></tr>
         <tr><th>instrument number</th><td>placeholder</td></tr>
         <tr><th>status</th><td><span class="og-badge og-badge--draft">Unverified</span></td></tr>
         <tr><th>verification hash</th><td>hash_placeholder</td></tr>
         <tr><th>verification URL placeholder</th><td>https://example.invalid/verify/placeholder</td></tr>
         <tr><th>signature block placeholder</th><td>Authorized signer block placeholder</td></tr>
-    </table>
+    </table></div>
 </div>

--- a/onegodian-capital-plugin/public/views/disclosure-consent.php
+++ b/onegodian-capital-plugin/public/views/disclosure-consent.php
@@ -1,10 +1,11 @@
-<div class="onegodian-capital-portal og-panel">
+<div class="onegodian-capital-portal og-panel og-navy-panel">
+    <p class="og-eyebrow">Disclosure</p>
     <h2 class="og-heading">Disclosure Consent</h2>
     <div class="og-warning">Disclosure packet consent is required before progression in the scaffolded purchase flow.</div>
-    <table class="og-table">
+    <div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table">
         <thead><tr><th>disclosure_packet_version</th><th>status</th><th>accepted_on</th></tr></thead>
         <tbody><tr><td>v0.0.0 placeholder</td><td><span class="og-badge og-badge--pending">Awaiting Acceptance</span></td><td>—</td></tr></tbody>
-    </table>
+    </table></div>
 </div>
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <form method="post">

--- a/onegodian-capital-plugin/public/views/investor-dashboard.php
+++ b/onegodian-capital-plugin/public/views/investor-dashboard.php
@@ -1,11 +1,11 @@
 <div class="onegodian-capital-portal">
     <h2 class="og-heading">Investor Dashboard</h2>
     <div class="og-grid">
-        <section class="og-panel"><h3>My Capital Instruments</h3><table class="og-table"><tr><th>Instrument</th><th>Status</th></tr><tr><td>Placeholder</td><td><span class="og-badge og-badge--draft">Draft</span></td></tr></table></section>
-        <section class="og-panel"><h3>Certificates</h3><table class="og-table"><tr><th>Certificate</th><th>Status</th></tr><tr><td>Placeholder</td><td><span class="og-badge og-badge--pending">Pending</span></td></tr></table></section>
-        <section class="og-panel"><h3>Disclosure Acceptances</h3><table class="og-table"><tr><th>Packet</th><th>Acceptance</th></tr><tr><td>v0.0.0</td><td>Not yet accepted</td></tr></table></section>
-        <section class="og-panel"><h3>Ledger History</h3><table class="og-table"><tr><th>Entry</th><th>Date</th></tr><tr><td>Placeholder ledger row</td><td>—</td></tr></table></section>
-        <section class="og-panel"><h3>Account Notices</h3><div class="og-warning">No active notices. Compliance notices appear here when configured.</div></section>
+        <section class="og-panel og-navy-panel"><p class="og-eyebrow">Dashboard</p><h3>My Capital Instruments</h3><div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table"><tr><th>Instrument</th><th>Status</th></tr><tr><td>Placeholder</td><td><span class="og-badge og-badge--draft">Draft</span></td></tr></table></div></section>
+        <section class="og-panel og-navy-panel"><p class="og-eyebrow">Dashboard</p><h3>Certificates</h3><div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table"><tr><th>Certificate</th><th>Status</th></tr><tr><td>Placeholder</td><td><span class="og-badge og-badge--pending">Pending</span></td></tr></table></div></section>
+        <section class="og-panel og-navy-panel"><p class="og-eyebrow">Dashboard</p><h3>Disclosure Acceptances</h3><div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table"><tr><th>Packet</th><th>Acceptance</th></tr><tr><td>v0.0.0</td><td>Not yet accepted</td></tr></table></div></section>
+        <section class="og-panel og-navy-panel"><p class="og-eyebrow">Dashboard</p><h3>Ledger History</h3><div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table"><tr><th>Entry</th><th>Date</th></tr><tr><td>Placeholder ledger row</td><td>—</td></tr></table></div></section>
+        <section class="og-panel og-navy-panel"><p class="og-eyebrow">Dashboard</p><h3>Account Notices</h3><div class="og-warning">No active notices. Compliance notices appear here when configured.</div></section>
     </div>
 </div>
 <?php
@@ -19,7 +19,7 @@ $table = $wpdb->prefix . 'onegodian_capital_instruments';
 $cert_table = $wpdb->prefix . 'onegodian_capital_certificates';
 $rows = $wpdb->get_results($wpdb->prepare("SELECT i.instrument_number, i.instrument_type, i.principal_amount, i.status, i.issue_date, i.maturity_date, c.id AS certificate_id FROM {$table} i LEFT JOIN {$cert_table} c ON c.instrument_id = i.id WHERE i.user_id = %d ORDER BY i.created_at DESC", get_current_user_id()), ARRAY_A);
 ?>
-<table>
+<div class="onegodian-capital-table-wrap"><table class="og-table onegodian-capital-responsive-table">
     <thead><tr><th>Instrument #</th><th>Type</th><th>Principal</th><th>Status</th><th>Issue Date</th><th>Maturity Date</th><th>Certificate ID</th></tr></thead>
     <tbody>
         <?php foreach ($rows as $row) : ?>

--- a/onegodian-capital-plugin/public/views/offerings-grid.php
+++ b/onegodian-capital-plugin/public/views/offerings-grid.php
@@ -12,7 +12,8 @@ $offering = [
 <div class="onegodian-capital-portal">
     <div class="og-warning"><strong><?php esc_html_e('Disclosure-first notice:', 'onegodian-capital'); ?></strong> <?php esc_html_e('This portal displays records and disclosures only. Review disclosure materials before any workflow continuation.', 'onegodian-capital'); ?></div>
     <div class="og-grid">
-        <article class="og-card">
+        <article class="og-card og-navy-panel">
+            <p class="og-eyebrow">Offering</p>
             <h3><?php echo esc_html($offering['title']); ?></h3>
             <dl class="og-kv">
                 <dt>instrument_type</dt><dd><?php echo esc_html($offering['instrument_type']); ?></dd>


### PR DESCRIPTION
### Motivation
- Improve readability of navy-themed panels by enforcing high-contrast text colors for headings, labels, and body copy so navy-on-navy text is avoided. 
- Prevent dashboard and offering tables from causing horizontal overflow on mobile by making tables scrollable and setting sensible minimum widths. 
- Bring templates and documentation into alignment with the UI standards for contrast and mobile behavior.

### Description
- Added an `.og-navy-panel` rule set in `public/css/onegodian-capital-public.css` to force white headings/body text and gold eyebrow/kicker labels, and to tune navy panel borders. 
- Introduced responsive table helpers: `.onegodian-capital-table-wrap` (scroll container) and `.onegodian-capital-responsive-table` (min-width) in `public/css/onegodian-capital-public.css`. 
- Updated mobile breakpoint rules to enforce single-column grid behavior and ensure cards/panels are box-sized to avoid page overflow. 
- Wrapped dashboard/ledger/instrument/certificate/disclosure tables with `onegodian-capital-table-wrap` and added `onegodian-capital-responsive-table` to table elements in `public/views/investor-dashboard.php`, `public/views/offerings-grid.php`, `public/views/certificate-view.php`, and `public/views/disclosure-consent.php`, and added eyebrow labels where appropriate. 
- Documented the navy contrast and mobile table rules in `docs/UI_STANDARD.md` with explicit guidance and examples using the new classes. 

### Testing
- Ran PHP lint across plugin PHP files with: `find onegodian-capital-plugin -name '*.php' -print0 | xargs -0 -n1 php -l`; the traversal reported a parse error in `onegodian-capital-plugin/includes/class-shortcodes.php` that is pre-existing and unrelated to these edits, and other modified templates linted clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fde9735c832d9f8db9d505935d63)