### PR TITLE
Fix Capital Web project structure for Hostinger deployment

### DIFF
--- a/onegodian-capital-web/.env.example
+++ b/onegodian-capital-web/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org

--- a/onegodian-capital-web/README.md
+++ b/onegodian-capital-web/README.md
@@ -1,0 +1,9 @@
+# Onegodian Capital Web
+
+## Hostinger Deployment Settings
+
+- **Framework:** Next.js
+- **Build command:** `npm run build`
+- **Start command:** `npm run start`
+- **Install command:** `npm ci`
+- **Environment variable:** `NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org`


### PR DESCRIPTION
### Motivation
- Ensure the Hostinger platform can detect and deploy the Next.js app by having required files and directories present at the repository root.
- Confirm scripts and core dependencies required by Next.js are available so Hostinger build/runtime steps succeed.

### Description
- Confirmed the Next.js application files are rooted at `onegodian-capital-web` so no app-folder relocation was necessary.
- Updated `onegodian-capital-web/.env.example` to `NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org` as required by deployment.
- Added `onegodian-capital-web/README.md` documenting Hostinger deployment settings (Framework, build/start/install commands, and environment variable).
- Created `onegodian-capital-web/public/.gitkeep` so the `public` directory exists for framework detection and deployment.
- Verified `onegodian-capital-web/package.json` already contains the required scripts (`dev`, `build`, `start`, `lint`) and includes `next`, `react`, `react-dom`, `typescript`, `eslint`, and `eslint-config-next` in dependencies/devDependencies.

### Testing
- Ran `npm install` which failed in this environment due to filesystem `ENOTEMPTY` errors while populating `node_modules` and could not fully complete.
- Ran `npm run lint` which could not complete because `next` was not available due to the failed install, resulting in `next: not found`.
- Ran `npm run build` which was blocked by the same install failure and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f219f5b974832dae29b04eead9438a)