### PR TITLE
onegodian-capital-web: set API URL, add Hostinger README, add node engine and public placeholder

### DIFF
--- a/onegodian-capital-web/.env.example
+++ b/onegodian-capital-web/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org

--- a/onegodian-capital-web/README.md
+++ b/onegodian-capital-web/README.md
@@ -1,0 +1,9 @@
+# Onegodian Capital Web
+
+## Hostinger Deployment Settings
+
+- **Framework:** Next.js
+- **Build command:** `npm run build`
+- **Start command:** `npm run start`
+- **Install command:** `npm ci`
+- **Environment variable:** `NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org`

--- a/onegodian-capital-web/package.json
+++ b/onegodian-capital-web/package.json
@@ -23,5 +23,8 @@
     "postcss": "8.4.39",
     "tailwindcss": "3.4.4",
     "typescript": "5.5.3"
+  },
+  "engines": {
+    "node": ">=18.18.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Point the frontend to the production API by updating the example environment variable to `https://api.onegodian.org`.
- Provide Hostinger deployment guidance and build/install commands for the project via a new README.
- Ensure the project declares a minimum Node.js version and keep the `public` directory tracked in the repo.

### Description
- Updated `onegodian-capital-web/.env.example` to set `NEXT_PUBLIC_API_BASE_URL=https://api.onegodian.org`.
- Added `onegodian-capital-web/README.md` documenting Hostinger deployment settings and commands (`npm run build`, `npm run start`, `npm ci`) and the required env var.
- Modified `onegodian-capital-web/package.json` to include an `engines` entry with `node: ">=18.18.0"`.
- Added `onegodian-capital-web/public/.gitkeep` to ensure the `public` directory is tracked.

### Testing
- No automated test suite was detected for this project.
- Performed a local verification of package metadata and build scripts by running `npm run build` and `npm run lint`, which completed without changes to source files (no automated test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f219f5b974832dae29b04eead9438a)