### PR TITLE
feat: add Capital Portal admin control layer (v0.2.5)

### DIFF
--- a/onegodian-capital-plugin/CHANGELOG.md
+++ b/onegodian-capital-plugin/CHANGELOG.md
@@ -9,3 +9,10 @@ v0.1.0 - Initial scaffold
 
 - Created plugin bootstrap, activation/deactivation hooks, and uninstall file.
 - Added core include classes, admin/public views, templates, docs, and test notes.
+
+## 0.2.5 - Admin Control Layer
+- Added Capital Portal operator admin console with Dashboard, Offerings, Disclosures, Certificates, Ledger, Investors, Readiness Checklist, and Settings sections.
+- Added capability-mapped menu routing using plugin-specific capabilities for role-safe access.
+- Added admin control-layer widgets and legal/compliance boundary notices across operator pages.
+- Added responsive admin CSS for the new control-layer layout.
+- Preserved legal-review boundary and kept live investment/payment workflows inactive pending readiness completion.

--- a/onegodian-capital-plugin/README.md
+++ b/onegodian-capital-plugin/README.md
@@ -57,3 +57,17 @@ The ONEGODIAN Capital Portal is software infrastructure for managing digital rec
 - Product edit screens display an admin warning clarifying Capital Portal-first presentation requirements.
 - Capital-linked products have comments/reviews disabled where possible through plugin hooks.
 - Recommended standards and implementation guidance are documented in `docs/WOOCOMMERCE_PRODUCT_STANDARD.md`.
+
+## Admin Control Layer
+
+The ONEGODIAN Capital Portal includes an administrative control layer for:
+
+- Offering records
+- Disclosure review
+- Certificate records
+- Investor ledger review
+- Investor account visibility
+- Readiness checklist tracking
+- Audit-oriented record review
+
+The admin layer is a recordkeeping and workflow control interface. It does not authorize live securities offerings, investment activity, payment activation, certificate issuance, or investor eligibility approval without qualified legal, compliance, tax/accounting, and operational review.

--- a/onegodian-capital-plugin/assets/css/admin.css
+++ b/onegodian-capital-plugin/assets/css/admin.css
@@ -1,0 +1,15 @@
+.ogc-admin-wrap { max-width: 1200px; }
+.og-admin-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 20px; margin: 24px 0; }
+.ogc-admin-card, .ogc-widget-card { background: #ffffff; border: 1px solid #dce4ef; border-radius: 18px; box-shadow: 0 14px 36px rgba(9, 29, 54, 0.08); padding: 22px; }
+.ogc-admin-card { background: #061a33; color: #ffffff; }
+.ogc-admin-card h3 { color: #d9b24c; font-size: 13px; letter-spacing: 0.12em; margin: 0 0 12px; text-transform: uppercase; }
+.ogc-admin-stat { color: #ffffff; font-size: 42px; font-weight: 800; line-height: 1; margin: 0; }
+.ogc-admin-warning { background: #fff6e8; border-left: 6px solid #d9b24c; color: #7a2d1b; font-size: 17px; font-weight: 700; line-height: 1.55; margin: 18px 0 24px; padding: 20px 24px; }
+.og-admin-actions { display: flex; flex-wrap: wrap; gap: 10px; margin: 24px 0; }
+.ogc-dashboard-grid { display: grid; gap: 20px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 24px 0; }
+.ogc-admin-table { margin-top: 20px; }
+.ogc-admin-table code { background: #061a33; border-radius: 6px; color: #ffffff; display: inline-block; max-width: 280px; overflow: hidden; padding: 4px 8px; text-overflow: ellipsis; vertical-align: middle; white-space: nowrap; }
+.ogc-workflow-strip { display: grid; gap: 12px; grid-template-columns: repeat(7, minmax(0, 1fr)); margin: 24px 0; }
+.ogc-workflow-step { background: #061a33; border: 1px solid #d9b24c; border-radius: 14px; color: #ffffff; font-weight: 800; padding: 14px; text-align: center; }
+@media (max-width: 1100px) { .og-admin-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .ogc-workflow-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 760px) { .og-admin-grid, .ogc-dashboard-grid, .ogc-workflow-strip { grid-template-columns: 1fr; } .ogc-admin-card, .ogc-widget-card, .ogc-admin-warning { padding: 18px; } }

--- a/onegodian-capital-plugin/docs/ADMIN_CONTROL_LAYER.md
+++ b/onegodian-capital-plugin/docs/ADMIN_CONTROL_LAYER.md
@@ -1,0 +1,18 @@
+# Admin Control Layer (v0.2.5)
+
+The ONEGODIAN Capital Portal includes an operator-facing admin control layer for managing private capital recordkeeping workflows:
+
+1. Dashboard
+2. Offerings
+3. Disclosures
+4. Certificates
+5. Ledger
+6. Investors
+7. Readiness Checklist
+8. Settings
+
+## Compliance Boundary
+
+No live capital workflow, public offering checkout, investor onboarding, paid-order certificate issuance, or repayment/return workflow may be enabled until legal review, disclosure approval, investor eligibility rules, Stripe live-mode review, refund/cancellation policy, data retention policy, backup/export testing, admin permissions testing, certificate verification testing, and tax/accounting review are completed and documented.
+
+This control layer is an administrative workflow console and audit-oriented recordkeeping interface. It is not legal approval, securities authorization, or investor eligibility adjudication.

--- a/onegodian-capital-plugin/includes/class-admin-controller.php
+++ b/onegodian-capital-plugin/includes/class-admin-controller.php
@@ -1,0 +1,143 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+class Onegodian_Capital_Admin_Controller {
+    public static function register_menu(): void {
+        add_menu_page(
+            'ONEGODIAN Capital',
+            'Capital Portal',
+            'manage_onegodian_capital',
+            'onegodian-capital',
+            [self::class, 'dashboard'],
+            'dashicons-bank',
+            3
+        );
+
+        add_submenu_page('onegodian-capital', 'Dashboard', 'Dashboard', 'manage_onegodian_capital', 'onegodian-capital', [self::class, 'dashboard']);
+        add_submenu_page('onegodian-capital', 'Offerings', 'Offerings', 'issue_onegodian_instruments', 'onegodian-capital-offerings', [self::class, 'offerings']);
+        add_submenu_page('onegodian-capital', 'Disclosures', 'Disclosures', 'manage_onegodian_disclosures', 'onegodian-capital-disclosures', [self::class, 'disclosures']);
+        add_submenu_page('onegodian-capital', 'Certificates', 'Certificates', 'issue_onegodian_instruments', 'onegodian-capital-certificates', [self::class, 'certificates']);
+        add_submenu_page('onegodian-capital', 'Ledger', 'Ledger', 'view_onegodian_ledger', 'onegodian-capital-ledger', [self::class, 'ledger']);
+        add_submenu_page('onegodian-capital', 'Investors', 'Investors', 'manage_onegodian_capital', 'onegodian-capital-investors', [self::class, 'investors']);
+        add_submenu_page('onegodian-capital', 'Readiness Checklist', 'Readiness Checklist', 'manage_onegodian_capital', 'onegodian-capital-readiness', [self::class, 'readiness']);
+        add_submenu_page('onegodian-capital', 'Settings', 'Settings', 'manage_onegodian_capital', 'onegodian-capital-settings', ['Onegodian_Capital_Settings', 'render_settings_page']);
+    }
+
+    public static function table_exists(string $table): bool {
+        global $wpdb;
+
+        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table;
+    }
+
+    public static function count_table(string $table): int {
+        global $wpdb;
+
+        if (!self::table_exists($table)) {
+            return 0;
+        }
+
+        return (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}");
+    }
+
+    public static function dashboard(): void {
+        global $wpdb;
+
+        $instruments = self::count_table($wpdb->prefix . 'onegodian_capital_instruments');
+        $certificates = self::count_table($wpdb->prefix . 'onegodian_capital_certificates');
+        $ledger = self::count_table($wpdb->prefix . 'onegodian_capital_ledger');
+        $disclosures = self::count_table($wpdb->prefix . 'onegodian_capital_disclosure_acceptances');
+        $published_offerings = wp_count_posts('onegodian_offering');
+
+        echo '<div class="wrap ogc-admin-wrap"><h1>ONEGODIAN Capital Portal — Admin</h1>';
+        self::legal_notice();
+        echo '<div class="og-admin-grid">';
+        self::stat_card('Published Offerings', isset($published_offerings->publish) ? (int) $published_offerings->publish : 0);
+        self::stat_card('Instruments', $instruments);
+        self::stat_card('Certificates', $certificates);
+        self::stat_card('Ledger Entries', $ledger);
+        self::stat_card('Disclosure Acceptances', $disclosures);
+        echo '</div><div class="og-admin-actions">';
+        echo '<a href="' . esc_url(admin_url('edit.php?post_type=onegodian_offering')) . '" class="button button-primary">Manage Offerings</a> ';
+        echo '<a href="' . esc_url(admin_url('admin.php?page=onegodian-capital-certificates')) . '" class="button">View Certificates</a> ';
+        echo '<a href="' . esc_url(admin_url('admin.php?page=onegodian-capital-disclosures')) . '" class="button">Review Disclosures</a> ';
+        echo '<a href="' . esc_url(admin_url('admin.php?page=onegodian-capital-ledger')) . '" class="button">Open Ledger</a></div>';
+        echo '<div class="ogc-dashboard-grid">';
+        echo Onegodian_Capital_Widgets::render_readiness_checklist();
+        echo Onegodian_Capital_Widgets::render_shortcode_reference();
+        echo Onegodian_Capital_Widgets::render_help_panel();
+        echo '</div></div>';
+    }
+
+    private static function stat_card(string $label, int $value): void {
+        echo '<div class="ogc-admin-card"><h3>' . esc_html($label) . '</h3><p class="ogc-admin-stat">' . esc_html((string) $value) . '</p></div>';
+    }
+
+    private static function legal_notice(): void {
+        echo '<div class="ogc-admin-warning"><strong>Legal review required:</strong> The ONEGODIAN Capital Portal is software infrastructure for managing digital records related to private capital instruments. It does not itself create, approve, or validate any securities offering. All notes, bonds, repayment terms, investor eligibility rules, disclosures, exemptions, and offering documents must be reviewed by qualified legal counsel before public use.</div>';
+    }
+
+    public static function offerings(): void { /* trimmed for brevity in generation */
+        $query = new WP_Query(['post_type' => 'onegodian_offering', 'post_status' => ['publish', 'draft', 'pending', 'private'], 'posts_per_page' => 100]);
+        echo '<div class="wrap ogc-admin-wrap"><h1>Offerings</h1>'; self::legal_notice();
+        echo '<p><a href="' . esc_url(admin_url('post-new.php?post_type=onegodian_offering')) . '" class="button button-primary">Add New Capital Offering</a></p>';
+        echo '<table class="widefat striped ogc-admin-table"><thead><tr><th>Name</th><th>Instrument Type</th><th>Status</th><th>Disclosure Version</th><th>Minimum</th><th>Maximum</th><th>Actions</th></tr></thead><tbody>';
+        if ($query->have_posts()) {
+            while ($query->have_posts()) { $query->the_post(); $id = get_the_ID();
+                $type = get_post_meta($id, '_onegodian_capital_instrument_type', true);
+                $status = get_post_meta($id, '_onegodian_capital_status', true);
+                $disclosure = get_post_meta($id, '_onegodian_capital_disclosure_packet_version', true);
+                $minimum = get_post_meta($id, '_onegodian_capital_minimum_purchase', true);
+                $maximum = get_post_meta($id, '_onegodian_capital_maximum_purchase', true);
+                echo '<tr><td><strong>' . esc_html(get_the_title()) . '</strong></td><td>' . esc_html($type ?: '—') . '</td><td>' . esc_html($status ?: get_post_status()) . '</td><td>' . esc_html($disclosure ?: '—') . '</td><td>' . esc_html($minimum ?: '—') . '</td><td>' . esc_html($maximum ?: '—') . '</td><td><a href="' . esc_url(get_edit_post_link($id)) . '">Edit</a></td></tr>';
+            }
+            wp_reset_postdata();
+        } else {
+            echo '<tr><td colspan="7">No capital offerings found.</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public static function disclosures(): void { global $wpdb; $table = $wpdb->prefix . 'onegodian_capital_disclosure_acceptances';
+        echo '<div class="wrap ogc-admin-wrap"><h1>Disclosure Review</h1><div class="ogc-admin-warning"><strong>Disclosure approval gate:</strong> All disclosures must be reviewed and approved before investor access, payment workflows, or instrument issuance.</div><div class="ogc-workflow-strip">';
+        foreach (['Draft', 'Internal Review', 'Legal Review', 'Approval', 'Publish', 'Investor Acknowledgement', 'Recorded & Audited'] as $step) { echo '<div class="ogc-workflow-step">' . esc_html($step) . '</div>'; }
+        echo '</div>'; if (!self::table_exists($table)) { echo '<p>Disclosure acceptance table not found.</p></div>'; return; }
+        $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 100");
+        echo '<table class="widefat striped ogc-admin-table"><thead><tr><th>ID</th><th>User</th><th>Offering</th><th>Disclosure</th><th>Accepted At</th></tr></thead><tbody>';
+        if ($rows) { foreach ($rows as $row) { echo '<tr><td>' . esc_html((string) ($row->id ?? '—')) . '</td><td>' . esc_html((string) ($row->user_id ?? '—')) . '</td><td>' . esc_html((string) ($row->offering_id ?? '—')) . '</td><td>' . esc_html((string) ($row->disclosure_id ?? '—')) . '</td><td>' . esc_html((string) ($row->created_at ?? '—')) . '</td></tr>'; } } else { echo '<tr><td colspan="5">No disclosure acceptances recorded.</td></tr>'; }
+        echo '</tbody></table></div>';
+    }
+
+    public static function certificates(): void { global $wpdb; $table = $wpdb->prefix . 'onegodian_capital_certificates';
+        echo '<div class="wrap ogc-admin-wrap"><h1>Certificates</h1><div class="ogc-admin-warning"><strong>Certificate issuance control:</strong> Certificate records must be tied to approved disclosures, ledger entries, and instrument records before investor-facing use.</div>';
+        if (!self::table_exists($table)) { echo '<p>Certificate table not found.</p></div>'; return; }
+        $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 100");
+        echo '<table class="widefat striped ogc-admin-table"><thead><tr><th>Certificate ID</th><th>Instrument</th><th>User</th><th>Status</th><th>Verification Hash</th><th>Date</th></tr></thead><tbody>';
+        if ($rows) { foreach ($rows as $row) { echo '<tr><td>' . esc_html((string) ($row->certificate_id ?? '—')) . '</td><td>' . esc_html((string) ($row->instrument_id ?? '—')) . '</td><td>' . esc_html((string) ($row->user_id ?? '—')) . '</td><td>' . esc_html((string) ($row->status ?? '—')) . '</td><td><code>' . esc_html((string) ($row->verification_hash ?? '—')) . '</code></td><td>' . esc_html((string) ($row->created_at ?? '—')) . '</td></tr>'; } } else { echo '<tr><td colspan="6">No certificates recorded.</td></tr>'; }
+        echo '</tbody></table></div>';
+    }
+
+    public static function ledger(): void { global $wpdb; $table = $wpdb->prefix . 'onegodian_capital_ledger';
+        echo '<div class="wrap ogc-admin-wrap"><h1>Ledger</h1><div class="ogc-admin-warning"><strong>Audit layer:</strong> Ledger records must be preserved for review, reconciliation, export, and backup testing.</div>';
+        if (!self::table_exists($table)) { echo '<p>Ledger table not found.</p></div>'; return; }
+        $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 100");
+        echo '<table class="widefat striped ogc-admin-table"><thead><tr><th>Type</th><th>Amount</th><th>Status</th><th>Instrument</th><th>User</th><th>Date</th></tr></thead><tbody>';
+        if ($rows) { foreach ($rows as $row) { echo '<tr><td>' . esc_html((string) ($row->type ?? '—')) . '</td><td>' . esc_html((string) ($row->amount ?? '—')) . '</td><td>' . esc_html((string) ($row->status ?? '—')) . '</td><td>' . esc_html((string) ($row->instrument_id ?? '—')) . '</td><td>' . esc_html((string) ($row->user_id ?? '—')) . '</td><td>' . esc_html((string) ($row->created_at ?? '—')) . '</td></tr>'; } } else { echo '<tr><td colspan="6">No ledger entries recorded.</td></tr>'; }
+        echo '</tbody></table></div>';
+    }
+
+    public static function investors(): void {
+        $users = get_users(['number' => 200, 'orderby' => 'registered', 'order' => 'DESC']);
+        echo '<div class="wrap ogc-admin-wrap"><h1>Investors</h1><div class="ogc-admin-warning"><strong>Investor eligibility required:</strong> A user account alone does not establish investor eligibility or approval.</div><table class="widefat striped ogc-admin-table"><thead><tr><th>Name</th><th>Email</th><th>Registered</th><th>Roles</th></tr></thead><tbody>';
+        foreach ($users as $user) {
+            echo '<tr><td>' . esc_html($user->display_name) . '</td><td>' . esc_html($user->user_email) . '</td><td>' . esc_html($user->user_registered) . '</td><td>' . esc_html(implode(', ', $user->roles)) . '</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public static function readiness(): void {
+        echo '<div class="wrap ogc-admin-wrap"><h1>Production Readiness Checklist</h1><div class="ogc-admin-warning"><strong>No live activation:</strong> Public offering checkout, investor onboarding, live payment processing, and certificate issuance tied to paid orders must remain inactive until readiness review is complete.</div>';
+        echo Onegodian_Capital_Widgets::render_readiness_checklist();
+        echo '</div>';
+    }
+}

--- a/onegodian-capital-plugin/includes/class-plugin.php
+++ b/onegodian-capital-plugin/includes/class-plugin.php
@@ -16,6 +16,7 @@ require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-woocommerce.php';
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-permissions.php';
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-settings.php';
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-visual-widgets.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-widgets.php';
 
 class Onegodian_Capital_Plugin {
     private static $instance;
@@ -31,7 +32,8 @@ class Onegodian_Capital_Plugin {
         add_action('init', ['Onegodian_Capital_Post_Types', 'register']);
         add_action('init', ['Onegodian_Capital_Shortcodes', 'register']);
         add_action('init', ['Onegodian_Capital_Meta_Boxes', 'register_meta']);
-        add_action('admin_init', ['Onegodian_Capital_Settings', 'register']);
+        add_action('admin_menu', ['Onegodian_Capital_Admin_Controller', 'register_menu']);
+        add_action('admin_init', ['Onegodian_Capital_Settings', 'register_settings']);
         add_action('init', ['Onegodian_Capital_Permissions', 'register_caps']);
         add_action('init', ['Onegodian_Capital_WooCommerce', 'register']);
         add_action('init', ['Onegodian_Capital_Visual_Widgets', 'register']);
@@ -53,8 +55,7 @@ class Onegodian_Capital_Plugin {
             return;
         }
         wp_enqueue_style('onegodian-capital-admin', ONEGODIAN_CAPITAL_URL . 'admin/css/onegodian-capital-admin.css', [], ONEGODIAN_CAPITAL_VERSION);
+        wp_enqueue_style('onegodian-capital-admin-control-layer', ONEGODIAN_CAPITAL_URL . 'assets/css/admin.css', [], ONEGODIAN_CAPITAL_VERSION);
         wp_enqueue_style('onegodian-capital-visual-widgets', ONEGODIAN_CAPITAL_URL . 'assets/css/visual-widgets.css', [], ONEGODIAN_CAPITAL_VERSION);
-        add_action('woocommerce_order_status_completed', ['Onegodian_Capital_Instruments', 'handle_paid_order']);
-        add_action('woocommerce_payment_complete', ['Onegodian_Capital_Instruments', 'handle_paid_order']);
     }
 }

--- a/onegodian-capital-plugin/includes/class-settings.php
+++ b/onegodian-capital-plugin/includes/class-settings.php
@@ -1,8 +1,11 @@
 <?php
+
+defined('ABSPATH') || exit;
+
 class Onegodian_Capital_Settings {
-    public static function register() {
-        $text_settings = ['company_name','compliance_disclaimer','certificate_signature_name','certificate_signature_title'];
-        $url_settings = ['verification_base_url','certificate_workflow_image_url','disclosure_workflow_image_url','operating_boundary_image_url','dashboard_preview_image_url','offerings_preview_image_url','founder_note_certificate_image_url','infrastructure_bond_certificate_image_url','platform_growth_note_certificate_image_url','capital_hero_image_url'];
+    public static function register_settings() {
+        $text_settings = ['company_name', 'compliance_disclaimer', 'certificate_signature_name', 'certificate_signature_title'];
+        $url_settings = ['verification_base_url', 'certificate_workflow_image_url', 'disclosure_workflow_image_url', 'operating_boundary_image_url', 'dashboard_preview_image_url', 'offerings_preview_image_url', 'founder_note_certificate_image_url', 'infrastructure_bond_certificate_image_url', 'platform_growth_note_certificate_image_url', 'capital_hero_image_url'];
 
         foreach ($text_settings as $setting) {
             register_setting('onegodian_capital', $setting, ['type' => 'string', 'sanitize_callback' => 'sanitize_text_field']);
@@ -11,5 +14,19 @@ class Onegodian_Capital_Settings {
         foreach ($url_settings as $setting) {
             register_setting('onegodian_capital', $setting, ['type' => 'string', 'sanitize_callback' => 'esc_url_raw']);
         }
+    }
+
+    public static function render_settings_page() {
+        if (!current_user_can('manage_onegodian_capital')) {
+            wp_die(esc_html__('You do not have permission to access this page.', 'onegodian-capital'));
+        }
+
+        echo '<div class="wrap ogc-admin-wrap"><h1>Capital Portal Settings</h1>';
+        echo '<div class="ogc-admin-warning"><strong>Compliance boundary:</strong> Settings in this portal configure recordkeeping behavior only. Live capital workflows must remain inactive until readiness review is complete.</div>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('onegodian_capital');
+        do_settings_sections('onegodian_capital');
+        submit_button('Save Settings');
+        echo '</form></div>';
     }
 }

--- a/onegodian-capital-plugin/includes/class-widgets.php
+++ b/onegodian-capital-plugin/includes/class-widgets.php
@@ -1,0 +1,35 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+class Onegodian_Capital_Widgets {
+    public static function render_readiness_checklist(): string {
+        $items = [
+            'Legal review complete',
+            'Disclosure approval complete',
+            'Investor eligibility rules documented',
+            'Stripe live-mode reviewed and approved',
+            'Refund and cancellation policy approved',
+            'Data retention policy approved',
+            'Backup/export testing completed',
+            'Admin permissions testing completed',
+            'Certificate verification testing completed',
+            'Tax/accounting review completed',
+        ];
+
+        $html = '<section class="ogc-widget-card"><h2>Readiness Checklist</h2><p>No live capital workflow may be activated until every item below is completed and documented.</p><ul>';
+        foreach ($items as $item) {
+            $html .= '<li>⬜ ' . esc_html($item) . '</li>';
+        }
+
+        return $html . '</ul></section>';
+    }
+
+    public static function render_shortcode_reference(): string {
+        return '<section class="ogc-widget-card"><h2>Operational Boundary</h2><p>This admin layer is for recordkeeping and workflow controls only. Do not enable public offering checkout, live investment intake, paid-order issuance, or repayment workflows before readiness approval.</p></section>';
+    }
+
+    public static function render_help_panel(): string {
+        return '<section class="ogc-widget-card"><h2>Admin Guidance</h2><p>Use Offerings, Disclosures, Certificates, Ledger, and Investors to validate records before any legal/compliance activation. Keep legal-review warnings in place across all workflows.</p></section>';
+    }
+}

--- a/onegodian-capital-plugin/onegodian-capital.php
+++ b/onegodian-capital-plugin/onegodian-capital.php
@@ -20,6 +20,7 @@ define('ONEGODIAN_CAPITAL_URL', plugin_dir_url(__FILE__));
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-plugin.php';
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-activator.php';
 require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-deactivator.php';
+require_once ONEGODIAN_CAPITAL_PATH . 'includes/class-admin-controller.php';
 
 register_activation_hook(__FILE__, ['Onegodian_Capital_Activator', 'activate']);
 register_deactivation_hook(__FILE__, ['Onegodian_Capital_Deactivator', 'deactivate']);


### PR DESCRIPTION
### Motivation
- Promote the existing admin placeholders into a real operator console to manage offerings, disclosures, certificates, ledger, investors, readiness gates, and settings while preserving compliance boundaries. 
- Enforce capability-scoped access using plugin-specific capabilities instead of relying on `manage_options`. 
- Keep all live capital/payment/investment flows disabled until legal/compliance readiness is validated and documented.

### Description
- Added `includes/class-admin-controller.php` implementing the `Onegodian_Capital_Admin_Controller` with the full menu and pages: Dashboard, Offerings, Disclosures, Certificates, Ledger, Investors, Readiness Checklist, and Settings and mapped to the requested capabilities. 
- Added `includes/class-widgets.php` with `Onegodian_Capital_Widgets` to render readiness, operational-boundary, and admin guidance panels used by the dashboard and readiness pages. 
- Added admin stylesheet `assets/css/admin.css` and enqueued it for plugin/admin screens in `includes/class-plugin.php`, and removed admin hooks that would enable paid-order issuance (`woocommerce_*` hooks) to avoid activating live workflows. 
- Updated `includes/class-settings.php` to expose `register_settings()` and added `render_settings_page()` which is capability-guarded; wired the settings page into the admin submenu via the admin controller. 
- Wired the controller and widgets into bootstrap by requiring `includes/class-admin-controller.php` from `onegodian-capital.php` and loading `includes/class-widgets.php` from `includes/class-plugin.php`. 
- Added documentation and changelog updates: `README.md`, `CHANGELOG.md`, and new `docs/ADMIN_CONTROL_LAYER.md` describing the admin control layer and the compliance boundary.

### Testing
- Ran the PHP lint check across plugin PHP files with `find onegodian-capital-plugin -name '*.php' -print0 | xargs -0 -n1 php -l` and received no syntax errors for all scanned files (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37ea5a1c0832da94d252add421a49)