### PR TITLE
Initialize OneGodian Everything App foundation (Next.js, TypeScript, Tailwind, Prisma)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-PORT=3000
-NODE_ENV=development
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/onegodian_app?schema=public"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="replace-with-a-local-dev-secret"

--- a/README.md
+++ b/README.md
@@ -1,184 +1,38 @@
-# Wallet Core Engine (WCE) v0.1
+# OneGodian Everything App Foundation
 
-Config-driven, modular TypeScript monorepo for transaction intent evaluation and execution.
+Next.js + TypeScript + Tailwind + Prisma foundation for `app.onegodian.com`.
 
-## Monorepo Layout
+## Stack
+- Next.js (App Router)
+- TypeScript
+- Tailwind CSS (dark/futuristic baseline)
+- Prisma + PostgreSQL
+- Auth.js-ready dependencies and environment variables
 
-- `packages/keyvault`: deterministic key derivation + signing (no private key export)
-- `packages/chain-adapters-evm`: build/sign/broadcast EVM Send + Approve transactions
-- `packages/registry`: versioned chain/token registry bundle loader
-- `packages/verify`: signature verification for registry/policy bundles
-- `packages/rpc-router`: multi-provider JSON-RPC routing with health and failover
-- `packages/policy`: tx_intent policy evaluation to ALLOW/DENY/REQUIRE_CONFIRMATION with reason codes
-- `packages/audit`: append-only JSONL audit sink with correlation IDs
-- `packages/telemetry`: schema allowlisting + redaction + OTLP export targets
+## Local setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy env template:
+   ```bash
+   cp .env.example .env
+   ```
+3. Generate Prisma client:
+   ```bash
+   npm run prisma:generate
+   ```
+4. Create first migration:
+   ```bash
+   npm run prisma:migrate -- --name init
+   ```
+5. Run app:
+   ```bash
+   npm run dev
+   ```
 
-## Design Constraints (Implemented)
-
-- **Config-driven with tenant overlays** in each module (`tenantOverlays` support)
-- **No client-specific core logic**: all behavior is driven by typed config/rules
-- **Strict telemetry separation**: distinct public and internal telemetry channels/config
-
-## Quick Start
-
-```bash
-npm install
-npm run build
-npm run typecheck
-```
-
-## Configuration Assets
-
-- Schema docs: `docs/schemas/wce-config-schema.md`
-- Example base config: `examples/configs/base.tenant-a.json`
-- Example overlay: `examples/configs/tenant-overlay.high-risk.json`
-
-## Package Notes
-
-### keyvault
-- Deterministic `keyId` derivation from tenant + derivation path.
-- Signing API only returns signatures and key references.
-- Private key material is never exported by API.
-
-### chain-adapters-evm
-- Supports two intent types: `SEND` and `APPROVE`.
-- `buildUnsignedTx` composes canonical tx shape.
-- `signTx` and `broadcastTx` are injected integrations.
-
-### policy
-- Evaluates intents against ordered rules.
-- Returns `{decision, reasonCode, matchedRuleId}`.
-- Defaults are explicit to avoid silent allowance.
-
-### telemetry
-- Enforces per-channel schema allowlist.
-- Redacts configured fields before export.
-- Uses separate OTLP endpoints for public/internal streams.
-# OneGodian Verify Portal
-
-`onegodian-verify-portal` is the public verification resolution interface for the OneGodian ecosystem and the QR-V™ Global Verification Network. It is designed to run at `https://verify.qrv.network` and resolve QRVID lookups against `https://api.qrv.network`.
-
-## What this service does
-
-- Resolves QRVIDs from direct URLs or manual input.
-- Calls the upstream verification API (`GET /verify/:qrvid`).
-- Renders deterministic states (`VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`, `UNAVAILABLE`).
-- Exposes governance APIs under `/api/omos` and verification core APIs under `/api/v1`.
-- Provides operational health and architecture views.
-
-## Routes
-
-### Auth/System
-- `GET /health`
-
-### API/Core
-- `POST /api/v1/records`
-- `GET /api/v1/verify/:qrvid`
-- `POST /api/v1/records/:qrvid/revoke`
-- `GET /api/omos/identity-definition`
-- `POST /api/omos/classify`
-- `POST /api/omos/align`
-- `POST /api/omos/timestamp/convert`
-- `POST /api/omos/decision/run`
-
-### Pages/UI
-- `GET /`
-- `GET /system-architecture`
-- `POST /verify`
-- `GET /verify/:qrvid`
-- `GET /:qrvid`
-
-## Quickstart
-
-### Requirements
-- Node.js 20+
-- npm 10+
-
-### Setup
-```bash
-npm install
-cp .env.example .env
-```
-
-### Run
-```bash
-npm run build
-npm start
-```
-Open `http://localhost:3000`.
-
-## Environment variables
-
-Use `.env.example` as your baseline:
-
-```env
-PORT=3000
-NEXT_PUBLIC_API_URL=https://api.qrv.network
-API_BASE_URL=https://api.qrv.network
-NODE_ENV=development
-CORS_ORIGINS=http://localhost:3000
-EXECUTE_API_KEY=replace_with_random_secret
-```
-
-## Quality gates
-
-```bash
-npm run lint
-npm run typecheck
-npm test
-npm run test:root
-npm run build
-npm run check
-```
-
-## Deployment
-
-### Standard Node runtime
-1. Build the app with `npm run build`.
-2. Install production deps with `npm install --omit=dev`.
-3. Set `NODE_ENV=production` and API URL env vars.
-4. Start using `npm start`.
-5. Verify `GET /health`.
-
-### Docker
-```bash
-docker build -t onegodian-verify-portal .
-docker run --rm -p 3000:3000 --env-file .env onegodian-verify-portal
-```
-
-## Troubleshooting
-
-- **`npm run build` fails with missing type declarations**: run `npm install` to ensure dev dependencies are present.
-- **`/verify/:qrvid` shows unavailable**: validate outbound network access and `NEXT_PUBLIC_API_URL`.
-- **Invalid identifier errors**: ensure values follow `QRV-123456789` format.
-- **Port collision**: set `PORT` to an open port.
-
-## Security notes
-
-- Input is sanitized server-side before outbound requests.
-- No direct database access is exposed in this service.
-- Unavailable upstream responses render deterministic safe defaults.
-
-## Canonical QR-V registry dependency
-
-`/api/v1/verify/:qrvid` now reads from the canonical QR-V registry tables, with `qr_objects` as the primary source.
-
-- Required: `qr_objects`, `qr_hash_registry`
-- Optional joins (graceful fallback if missing): `qr_certificates`, `qr_issuers`
-- Reference tables available in the registry schema: `qr_objects`, `qr_hash_registry`, `qr_certificates`, `qr_issuers`, `qr_audit_log`
-- `/readyz` performs a PostgreSQL readiness probe using `SELECT 1` and returns `503` when the registry DB is unavailable.
-
-## QuantumOHI portfolio blueprint
-
-For the proposed QuantumOHI multi-repository production layout, see `docs/quantumohi-repo-map.md`.
-
-## Delivery hardening
-
-- CI workflow: `.github/workflows/ci.yml`
-- Branch protection enforcement guide: `docs/branch-protection-enforcement.md`
-- WordPress bridge plugin scaffold: `wp-content/plugins/quantumohi-bridge/`
-
-## License
-
-- Execution endpoint (`POST /execute`) requires `x-api-key` matching `EXECUTE_API_KEY`.
-- Configure `CORS_ORIGINS` in production to a comma-separated allowlist.
+## Deployment notes
+- Set production `DATABASE_URL`, `NEXTAUTH_URL`, and `NEXTAUTH_SECRET` in the host environment.
+- Run Prisma migrations during CI/CD or release hook.
+- Add Auth.js route handlers and provider configuration before production sign-in.
+- Replace placeholders with module-specific APIs and authorization policies.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,19 +1,32 @@
 {
-  "name": "omos-site",
-  "version": "1.0.0",
-  "description": "Node website for OMOS.OneGodian.org — OneGodian Metaphysical Operating System public site, protocol specification, developer docs, and runtime-ready documentation pages.",
-  "main": "server.js",
+  "name": "onegodian-everything-app",
+  "version": "0.1.0",
+  "private": true,
   "scripts": {
-    "start": "node server.js",
-    "check": "node --check server.js",
-    "smoke": "node tests/smoke.test.js"
-  },
-  "engines": {
-    "node": ">=20"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
-    "compression": "^1.7.4",
-    "express": "^4.19.2",
-    "helmet": "^7.1.0"
+    "@auth/prisma-adapter": "^2.7.4",
+    "@prisma/client": "^5.18.0",
+    "next": "14.2.15",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.15",
+    "postcss": "^8.4.47",
+    "prisma": "^5.18.0",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.2"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,43 +7,92 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model DecisionLog {
-  decisionId     String   @id @default(uuid()) @map("decision_id")
-  executionId    String?  @map("execution_id")
-  workflowId     String?  @map("workflow_id")
-  tenantId       String?  @map("tenant_id")
-  actorType      String   @map("actor_type")
-  actorId        String   @map("actor_id")
-  agentId        String?  @map("agent_id")
-  role           String
-  action         String
-  resource       String?
-  environment    String
-  authorityScope Json     @map("authority_scope")
-  policyId       String?  @map("policy_id")
-  policyHash     String?  @map("policy_hash")
-  inputHash      String?  @map("input_hash")
-  outputHash     String?  @map("output_hash")
-  riskLevel      String   @map("risk_level")
-  decision       String
-  reason         String
-  approvalStatus String   @map("approval_status")
-  approvalLevel  String?  @map("approval_level")
-  requestId      String   @map("request_id")
-  timestampUtc   DateTime @map("timestamp_utc")
-  createdAt      DateTime @default(now()) @map("created_at")
-
-  @@map("decision_logs")
-  @@index([createdAt])
+model User {
+  id           String        @id @default(cuid())
+  email        String        @unique
+  name         String?
+  image        String?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  profile      Profile?
+  records      OdinRecord[]
+  certificates Certificate[]
+  auditLogs    AuditLog[]
 }
 
-model KillSwitchState {
-  scopeType String  @map("scope_type")
-  scopeId   String  @map("scope_id")
-  isActive  Boolean @default(false) @map("is_active")
-  reason    String?
-  updatedAt DateTime @updatedAt @map("updated_at")
+model Profile {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  bio       String?
+  timezone  String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
 
-  @@id([scopeType, scopeId])
-  @@map("kill_switch_state")
+model OdinRecord {
+  id          String   @id @default(cuid())
+  code        String   @unique
+  title       String
+  description String?
+  planetId    String?
+  createdById String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  planet      Planet?  @relation(fields: [planetId], references: [id])
+  createdBy   User?    @relation(fields: [createdById], references: [id])
+}
+
+model Planet {
+  id        String       @id @default(cuid())
+  code      String       @unique
+  name      String
+  status    String       @default("draft")
+  records   OdinRecord[]
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+}
+
+model Product {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  name        String
+  description String?
+  downloadUrl String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Certificate {
+  id          String   @id @default(cuid())
+  serial      String   @unique
+  title       String
+  status      String   @default("issued")
+  issuedToId  String?
+  verifierRef String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  issuedTo    User?    @relation(fields: [issuedToId], references: [id])
+}
+
+model MediaItem {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  title       String
+  mediaType   String
+  sourceUrl   String?
+  publishedAt DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model AuditLog {
+  id         String   @id @default(cuid())
+  action     String
+  actorId    String?
+  targetType String?
+  targetId   String?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  actor      User?    @relation(fields: [actorId], references: [id])
 }

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function AdminPage() {
+  return <AppShell title="Admin" modules={[{ title: 'Admin Controls', description: 'Placeholder for governance and operations tooling.' }]} />;
+}

--- a/src/app/(app)/certificates/page.tsx
+++ b/src/app/(app)/certificates/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function Page() {
+  return <AppShell title="Certificates" modules={[{ title: 'Certificates Placeholder', description: 'Foundation placeholder for certificates module.' }]} />;
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function DashboardPage() {
+  return <AppShell title="Dashboard" modules={[{ title: 'Authenticated Area', description: 'Auth.js-ready shell for signed-in users.' }]} />;
+}

--- a/src/app/(app)/learning/page.tsx
+++ b/src/app/(app)/learning/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function Page() {
+  return <AppShell title="Learning" modules={[{ title: 'Learning Placeholder', description: 'Foundation placeholder for learning module.' }]} />;
+}

--- a/src/app/(app)/media/page.tsx
+++ b/src/app/(app)/media/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function Page() {
+  return <AppShell title="Media" modules={[{ title: 'Media Placeholder', description: 'Foundation placeholder for media module.' }]} />;
+}

--- a/src/app/(app)/planets/page.tsx
+++ b/src/app/(app)/planets/page.tsx
@@ -1,0 +1,21 @@
+import { ODIN_PR_PLANETS } from '@/lib/planets';
+
+export default function PlanetsPage() {
+  return (
+    <main className="min-h-screen px-6 py-10">
+      <div className="mx-auto max-w-6xl">
+        <h1 className="text-3xl font-bold">Planetary Registry</h1>
+        <p className="mt-2 text-slate-300">25 ODIN-PR planets initialized.</p>
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {ODIN_PR_PLANETS.map((planet) => (
+            <div key={planet.code} className="rounded-lg border border-slate-700 bg-slate-900/70 p-4">
+              <p className="text-xs text-neon">{planet.code}</p>
+              <p className="font-medium">{planet.name}</p>
+              <p className="text-sm text-slate-400">Status: {planet.status}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function Page() {
+  return <AppShell title="Products" modules={[{ title: 'Products Placeholder', description: 'Foundation placeholder for products module.' }]} />;
+}

--- a/src/app/(app)/registry/page.tsx
+++ b/src/app/(app)/registry/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function RegistryPage() {
+  return <AppShell title="ODIN Registry" modules={[{ title: 'Registry Browser', description: 'Placeholder for ODIN record browsing and filters.' }]} />;
+}

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/components/app-shell';
+
+export default function Page() {
+  return <AppShell title="Tools" modules={[{ title: 'Tools Placeholder', description: 'Foundation placeholder for tools module.' }]} />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-abyss text-slate-100;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'OneGodian Everything App',
+  description: 'OneGodian command center for app.onegodian.com'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6">
+      <section className="max-w-3xl rounded-2xl border border-slate-700 bg-slate-900/60 p-10 text-center">
+        <p className="text-sm uppercase tracking-[0.2em] text-neon">app.onegodian.com</p>
+        <h1 className="mt-3 text-4xl font-bold">OneGodian Everything App</h1>
+        <p className="mt-4 text-slate-300">Unified access to registry, planetary records, products, certificates, tools, media, and learning modules.</p>
+        <div className="mt-8">
+          <Link href="/dashboard" className="rounded-lg bg-neon px-5 py-3 font-semibold text-slate-950">Enter Dashboard</Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,16 @@
+import { ModuleCard } from '@/components/module-card';
+
+export function AppShell({ title, modules }: { title: string; modules: { title: string; description: string; href?: string }[] }) {
+  return (
+    <main className="min-h-screen px-6 py-10">
+      <div className="mx-auto max-w-6xl">
+        <h1 className="text-3xl font-bold tracking-wide text-slate-100">{title}</h1>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {modules.map((module) => (
+            <ModuleCard key={module.title} {...module} />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -1,0 +1,10 @@
+type ModuleCardProps = { title: string; description: string; href?: string };
+
+export function ModuleCard({ title, description, href = '#' }: ModuleCardProps) {
+  return (
+    <a href={href} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5 hover:border-neon">
+      <h3 className="text-lg font-semibold text-neon">{title}</h3>
+      <p className="mt-2 text-sm text-slate-300">{description}</p>
+    </a>
+  );
+}

--- a/src/lib/planets.ts
+++ b/src/lib/planets.ts
@@ -1,0 +1,7 @@
+export type OdinPlanet = { code: string; name: string; status: 'draft' | 'active' | 'queued' };
+
+export const ODIN_PR_PLANETS: OdinPlanet[] = Array.from({ length: 25 }, (_, i) => ({
+  code: `ODIN-PR-${String(i + 1).padStart(2, '0')}`,
+  name: `Planet ${i + 1}`,
+  status: i < 5 ? 'active' : i < 15 ? 'queued' : 'draft'
+}));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        abyss: '#040816',
+        neon: '#67e8f9',
+        sovereign: '#a78bfa'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,23 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
-    "rootDir": "src",
-    "outDir": "dist",
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "declaration": true,
-    "sourceMap": true
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal, reusable foundation for `app.onegodian.com` using the requested stack and App Router architecture.
- Establish an Auth.js-ready structure and Prisma schema so authentication and persistence can be integrated later.
- Keep UI modular and reusable so pages are composed from shared components rather than one-off implementations. 

### Description
- Added Next.js + TypeScript app skeleton with `package.json`, `next.config.js`, `tsconfig.json`, `postcss.config.js`, and `tailwind.config.ts` along with `next-env.d.ts` and `globals.css` for a dark/futuristic baseline. 
- Implemented App Router pages and required routes including `src/app/page.tsx`, `src/app/(app)/{dashboard,registry,planets,products,certificates,tools,media,learning}/page.tsx`, and `src/app/(admin)/admin/page.tsx`. 
- Introduced reusable UI components `src/components/app-shell.tsx` and `src/components/module-card.tsx` and centralized 25-item ODIN-PR seed data in `src/lib/planets.ts`. 
- Replaced the Prisma schema at `prisma/schema.prisma` with foundation models (`User`, `Profile`, `OdinRecord`, `Planet`, `Product`, `Certificate`, `MediaItem`, `AuditLog`) and added `.env.example` plus a README with local setup and deployment notes. 

### Testing
- Verified repository file presence and layout with `find src/app src/components src/lib prisma -maxdepth 4 -type f | sort` which returned the new files. 
- Inspected key files (`README.md`, `prisma/schema.prisma`, `src/lib/planets.ts`, `src/components/*`, `src/app/*`) using paged file listing (`nl`) to confirm expected content was written. 
- No build or runtime tests were executed in this change; consumers should run `npm install` and `npm run dev` and perform `npm run build` in CI to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7428a615c832d9c8657f8650ede9f)