### PR TITLE
Add Moons & Systems registry page and reusable components

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/app/(app)/moons-systems/page.tsx
+++ b/src/app/(app)/moons-systems/page.tsx
@@ -1,0 +1,24 @@
+import { MoonSystemCard } from '@/components/moon-system-card';
+import { ONEGODIAN_MOON_SYSTEMS } from '@/lib/moons-systems';
+
+export default function MoonsSystemsPage() {
+  return (
+    <main className="min-h-screen px-6 py-12 sm:py-16">
+      <div className="mx-auto max-w-6xl">
+        <header className="max-w-3xl">
+          <p className="text-sm uppercase tracking-[0.22em] text-neon">OneGodian Galaxy™</p>
+          <h1 className="mt-3 text-3xl font-bold leading-tight sm:text-4xl">Moons &amp; Systems Registry</h1>
+          <p className="mt-4 text-base leading-7 text-slate-300">
+            Explore active, survey, and queued moon systems across the OneGodian planetary network. This registry is modular by design so new moon clusters can be added without changing layout or structure.
+          </p>
+        </header>
+
+        <section aria-label="Moon systems" className="mt-10 grid gap-6 lg:grid-cols-2">
+          {ONEGODIAN_MOON_SYSTEMS.map((system) => (
+            <MoonSystemCard key={system.id} system={system} />
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/moon-system-card.tsx
+++ b/src/components/moon-system-card.tsx
@@ -1,0 +1,33 @@
+import { MoonSystem } from '@/lib/moons-systems';
+
+const categoryLabel: Record<MoonSystem['moons'][number]['category'], string> = {
+  'habitable-candidate': 'Habitable Candidate',
+  resource: 'Resource',
+  observatory: 'Observatory',
+  frontier: 'Frontier'
+};
+
+export function MoonSystemCard({ system }: { system: MoonSystem }) {
+  return (
+    <article className="rounded-2xl border border-cyan-500/20 bg-slate-900/70 p-6 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
+      <header>
+        <p className="text-xs uppercase tracking-[0.2em] text-neon">{system.id} · {system.hostPlanet}</p>
+        <h2 className="mt-2 text-2xl font-semibold text-slate-100">{system.systemName}</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">{system.description}</p>
+      </header>
+
+      <ul className="mt-6 space-y-4">
+        {system.moons.map((moon) => (
+          <li key={moon.designation} className="rounded-xl border border-slate-700 bg-slate-950/60 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h3 className="text-lg font-medium text-slate-100">{moon.name}</h3>
+              <span className="rounded-full border border-cyan-500/30 px-2 py-1 text-xs text-cyan-300">{moon.status}</span>
+            </div>
+            <p className="mt-1 text-xs uppercase tracking-wide text-slate-400">{moon.designation} · {categoryLabel[moon.category]} · Orbit {moon.orbitalPeriod}</p>
+            <p className="mt-2 text-sm text-slate-300">{moon.summary}</p>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/lib/moons-systems.ts
+++ b/src/lib/moons-systems.ts
@@ -1,0 +1,49 @@
+export type Moon = {
+  name: string;
+  designation: string;
+  orbitalPeriod: string;
+  category: 'habitable-candidate' | 'resource' | 'observatory' | 'frontier';
+  status: 'active' | 'survey' | 'queued';
+  summary: string;
+};
+
+export type MoonSystem = {
+  id: string;
+  hostPlanet: string;
+  systemName: string;
+  description: string;
+  moons: Moon[];
+};
+
+export const ONEGODIAN_MOON_SYSTEMS: MoonSystem[] = [
+  {
+    id: 'OG-MS-01',
+    hostPlanet: 'ODIN-PR-03',
+    systemName: 'Aether Crown',
+    description: 'Primary diplomatic corridor with synchronized relay moons for cultural, governance, and orientation missions.',
+    moons: [
+      { name: 'Seraph-1', designation: 'MS-01-A', orbitalPeriod: '9.2d', category: 'observatory', status: 'active', summary: 'Deep-space observatory and guidance beacon for academy fleets.' },
+      { name: 'Lyra-2', designation: 'MS-01-B', orbitalPeriod: '14.8d', category: 'habitable-candidate', status: 'survey', summary: 'Temperate moon under biosphere compatibility studies.' }
+    ]
+  },
+  {
+    id: 'OG-MS-02',
+    hostPlanet: 'ODIN-PR-08',
+    systemName: 'Heliox Belt',
+    description: 'Resource-forward system focused on long-horizon energy extraction and logistics stabilization.',
+    moons: [
+      { name: 'Brontes', designation: 'MS-02-A', orbitalPeriod: '6.1d', category: 'resource', status: 'active', summary: 'Helium-rich upper crust with autonomous extraction nodes.' },
+      { name: 'Nyx Relay', designation: 'MS-02-C', orbitalPeriod: '20.4d', category: 'frontier', status: 'queued', summary: 'Future expansion moon for outer-belt routing and defense.' }
+    ]
+  },
+  {
+    id: 'OG-MS-03',
+    hostPlanet: 'ODIN-PR-14',
+    systemName: 'Vigil Arc',
+    description: 'A security and education-aligned moon system supporting mentorship habitats and navigation sanctuaries.',
+    moons: [
+      { name: 'Ansel', designation: 'MS-03-A', orbitalPeriod: '11.5d', category: 'habitable-candidate', status: 'survey', summary: 'Low-radiation moon selected for youth orientation habitats.' },
+      { name: 'Ketra', designation: 'MS-03-B', orbitalPeriod: '18.9d', category: 'observatory', status: 'active', summary: 'Telemetry and protocol validation moon for guardian fleets.' }
+    ]
+  }
+];


### PR DESCRIPTION
### Motivation
- Implement the OneGodian Galaxy™ “Moons & Systems” feature as a production Next.js page so moon/system data can be presented in the app.
- Provide a modular data-first approach so new moon systems can be added without layout changes.
- Maintain the existing dark futuristic OneGodian styling and app-router architecture while using semantic, responsive HTML.

### Description
- Added a typed data module `src/lib/moons-systems.ts` that contains `Moon`/`MoonSystem` types and canonical moon-system content for easy expansion.
- Implemented a reusable UI component `src/components/moon-system-card.tsx` that renders a semantic `article` with moon list items and status/category metadata.
- Added the page `src/app/(app)/moons-systems/page.tsx` which composes the registry using `MoonSystemCard`, uses accessible semantics (`main`, `header`, `section`, `ul`, `li`) and responsive Tailwind styling, and exposes the public route `/moons-systems` under the app router.
- Styling follows the existing Tailwind-based dark/nebular theme (neon accents, slate palette) and keeps structure modular for future UI or data changes.

### Testing
- Ran `npm install` to install dependencies and prepare the environment, which completed successfully.
- Ran `npm run lint` and `next lint`, which passed with no ESLint warnings or errors.
- Ran `npm run build` and `next build`, which succeeded and produced a static route entry for `/moons-systems` during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f745160f60832d8336506adb41baef)