### PR TITLE
Add /ecosystem directory module with static registry and responsive cards

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,5 +1,16 @@
 import { AppShell } from '@/components/app-shell';
 
+const DASHBOARD_MODULES = [
+  { title: 'Ecosystem Directory', description: 'Central listing of OneGodian systems, sync states, and actions.', href: '/ecosystem' },
+  { title: 'ODIN Registry', description: 'Browse protocol records and indexed entities.', href: '/registry' },
+  { title: 'Galaxy', description: 'Explore moon systems and planetary network modules.', href: '/moons-systems' },
+  { title: 'Products', description: 'Review digital product modules and commerce surfaces.', href: '/products' },
+  { title: 'Certificates', description: 'Access OBP-1 certificate and verification modules.', href: '/certificates' },
+  { title: 'Learning', description: 'Open education and knowledge modules.', href: '/learning' },
+  { title: 'Media', description: 'Launch media hubs and publishing modules.', href: '/media' },
+  { title: 'Tools', description: 'Open operational tools and utilities.', href: '/tools' }
+];
+
 export default function DashboardPage() {
-  return <AppShell title="Dashboard" modules={[{ title: 'Authenticated Area', description: 'Auth.js-ready shell for signed-in users.' }]} />;
+  return <AppShell title="Dashboard" modules={DASHBOARD_MODULES} />;
 }

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,0 +1,31 @@
+import { EcosystemSystemCard } from '@/components/ecosystem-system-card';
+import { ECOSYSTEM_CATEGORIES, ONEGODIAN_ECOSYSTEM_SYSTEMS } from '@/lib/ecosystem';
+
+export default function EcosystemPage() {
+  return (
+    <main className="min-h-screen px-6 py-12 sm:py-16">
+      <div className="mx-auto max-w-6xl">
+        <header className="max-w-3xl">
+          <p className="text-sm uppercase tracking-[0.22em] text-neon">OneGodian Ecosystem Directory</p>
+          <h1 className="mt-3 text-3xl font-bold leading-tight sm:text-4xl">Connected systems, sync-ready architecture.</h1>
+          <p className="mt-4 text-base leading-7 text-slate-300">WordPress markets it. Node manages it. ODIN indexes it. The app connects it.</p>
+        </header>
+
+        <section className="mt-8">
+          <h2 className="text-sm uppercase tracking-[0.16em] text-slate-400">Categories</h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {ECOSYSTEM_CATEGORIES.map((category) => (
+              <span key={category} className="rounded-full border border-slate-600 bg-slate-900/60 px-3 py-1 text-xs text-slate-200">{category}</span>
+            ))}
+          </div>
+        </section>
+
+        <section aria-label="Ecosystem systems" className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {ONEGODIAN_ECOSYSTEM_SYSTEMS.map((system) => (
+            <EcosystemSystemCard key={system.id} system={system} />
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/ecosystem-system-card.tsx
+++ b/src/components/ecosystem-system-card.tsx
@@ -1,0 +1,43 @@
+import type { EcosystemSystem } from '@/lib/ecosystem';
+
+const STATUS_STYLES: Record<EcosystemSystem['status'], string> = {
+  active: 'bg-emerald-500/20 text-emerald-200 border-emerald-400/30',
+  building: 'bg-amber-500/20 text-amber-200 border-amber-400/30',
+  planned: 'bg-slate-500/20 text-slate-200 border-slate-400/30'
+};
+
+const PRIORITY_STYLES: Record<EcosystemSystem['syncPriority'], string> = {
+  high: 'text-rose-300',
+  medium: 'text-amber-300',
+  low: 'text-cyan-300'
+};
+
+export function EcosystemSystemCard({ system }: { system: EcosystemSystem }) {
+  return (
+    <article className="flex h-full flex-col rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <h2 className="text-xl font-semibold text-neon">{system.name}</h2>
+        <span className={`rounded-full border px-2.5 py-1 text-xs capitalize ${STATUS_STYLES[system.status]}`}>{system.status}</span>
+      </div>
+
+      <p className="mt-3 text-sm text-slate-400">{system.domain}</p>
+      <p className="mt-1 text-sm text-slate-300">Category: {system.category}</p>
+      <p className="mt-1 text-sm">Sync priority: <span className={`font-semibold uppercase ${PRIORITY_STYLES[system.syncPriority]}`}>{system.syncPriority}</span></p>
+      <p className="mt-4 text-sm leading-6 text-slate-300">{system.description}</p>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {system.syncTypes.map((syncType) => (
+          <span key={syncType} className="rounded-md border border-slate-600 bg-slate-800/80 px-2 py-1 text-xs text-slate-200">
+            {syncType}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-5">
+        <a href={system.primaryActionHref} className="inline-flex rounded-lg bg-neon px-4 py-2 text-sm font-semibold text-slate-950">
+          {system.primaryActionLabel}
+        </a>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/ecosystem.ts
+++ b/src/lib/ecosystem.ts
@@ -1,0 +1,145 @@
+export const ECOSYSTEM_CATEGORIES = [
+  'Identity',
+  'ODIN Registry',
+  'Galaxy',
+  'Certificates',
+  'Commerce',
+  'Learning',
+  'Media',
+  'Members',
+  'Tools',
+  'Infrastructure',
+  'External Ventures'
+] as const;
+
+export const SYNC_TYPES = ['Link Sync', 'Content Sync', 'User Sync', 'Payment Sync', 'Verification Sync'] as const;
+
+export type EcosystemCategory = (typeof ECOSYSTEM_CATEGORIES)[number];
+export type SyncType = (typeof SYNC_TYPES)[number];
+
+export type EcosystemStatus = 'active' | 'building' | 'planned';
+export type SyncPriority = 'high' | 'medium' | 'low';
+
+export type EcosystemSystem = {
+  id: string;
+  name: string;
+  domain: string;
+  category: EcosystemCategory;
+  status: EcosystemStatus;
+  description: string;
+  syncPriority: SyncPriority;
+  syncTypes: SyncType[];
+  primaryActionLabel: string;
+  primaryActionHref: string;
+};
+
+export const ONEGODIAN_ECOSYSTEM_SYSTEMS: EcosystemSystem[] = [
+  {
+    id: 'onegodian-org',
+    name: 'OneGodian.org',
+    domain: 'https://onegodian.org',
+    category: 'Identity',
+    status: 'active',
+    description: 'Primary mission and identity layer for the OneGodian ecosystem.',
+    syncPriority: 'high',
+    syncTypes: ['Link Sync', 'Content Sync', 'Verification Sync'],
+    primaryActionLabel: 'Open Site',
+    primaryActionHref: 'https://onegodian.org'
+  },
+  {
+    id: 'quantumohi',
+    name: 'QuantumOHI',
+    domain: 'https://quantumohi.com',
+    category: 'Infrastructure',
+    status: 'building',
+    description: 'Operational infrastructure and bridge layer that supports orchestration across systems.',
+    syncPriority: 'high',
+    syncTypes: ['Link Sync', 'Content Sync', 'User Sync'],
+    primaryActionLabel: 'View Infrastructure',
+    primaryActionHref: 'https://quantumohi.com'
+  },
+  {
+    id: 'odin-registry',
+    name: 'ODIN Registry',
+    domain: 'https://app.onegodian.com/registry',
+    category: 'ODIN Registry',
+    status: 'active',
+    description: 'Canonical index of ODIN records, statuses, and protocol-addressable entities.',
+    syncPriority: 'high',
+    syncTypes: ['Link Sync', 'Verification Sync'],
+    primaryActionLabel: 'Open Registry',
+    primaryActionHref: '/registry'
+  },
+  {
+    id: 'onegodian-galaxy',
+    name: 'OneGodian Galaxy',
+    domain: 'https://app.onegodian.com/moons-systems',
+    category: 'Galaxy',
+    status: 'active',
+    description: 'Planetary and moon system exploration directory for the OneGodian network.',
+    syncPriority: 'medium',
+    syncTypes: ['Link Sync', 'Content Sync'],
+    primaryActionLabel: 'Explore Galaxy',
+    primaryActionHref: '/moons-systems'
+  },
+  {
+    id: 'obp1-certificates',
+    name: 'OBP-1 Certificates',
+    domain: 'https://app.onegodian.com/certificates',
+    category: 'Certificates',
+    status: 'building',
+    description: 'Certificate issuance, validation, and evidence lifecycle under OBP-1 standards.',
+    syncPriority: 'high',
+    syncTypes: ['Verification Sync', 'Content Sync'],
+    primaryActionLabel: 'Review Certificates',
+    primaryActionHref: '/certificates'
+  },
+  {
+    id: 'onegodian-members',
+    name: 'OneGodian Members',
+    domain: 'https://members.onegodian.com',
+    category: 'Members',
+    status: 'planned',
+    description: 'Member identity, onboarding, and access governance workspace.',
+    syncPriority: 'high',
+    syncTypes: ['User Sync', 'Verification Sync', 'Link Sync'],
+    primaryActionLabel: 'View Members',
+    primaryActionHref: 'https://members.onegodian.com'
+  },
+  {
+    id: 'digital-products',
+    name: 'Digital Products',
+    domain: 'https://app.onegodian.com/products',
+    category: 'Commerce',
+    status: 'building',
+    description: 'Digital offerings catalog and fulfillment pathways for ecosystem commerce.',
+    syncPriority: 'medium',
+    syncTypes: ['Content Sync', 'Payment Sync', 'Link Sync'],
+    primaryActionLabel: 'Browse Products',
+    primaryActionHref: '/products'
+  },
+  {
+    id: 'subjecttodeals',
+    name: 'SubjectToDeals',
+    domain: 'https://subjecttodeals.com',
+    category: 'External Ventures',
+    status: 'planned',
+    description: 'External venture connected to OneGodian commerce and partnership pipelines.',
+    syncPriority: 'medium',
+    syncTypes: ['Link Sync', 'Payment Sync'],
+    primaryActionLabel: 'Open Venture',
+    primaryActionHref: 'https://subjecttodeals.com'
+  },
+  {
+    id: 'homeera-beginagain',
+    name: 'HomeEra / BeginAgain',
+    domain: 'https://homeera.com',
+    category: 'External Ventures',
+    status: 'planned',
+    description: 'Housing-oriented venture stream aligned for future ecosystem referral and content syncing.',
+    syncPriority: 'low',
+    syncTypes: ['Link Sync', 'Content Sync'],
+    primaryActionLabel: 'Open Venture',
+    primaryActionHref: 'https://homeera.com'
+  }
+];


### PR DESCRIPTION
### Motivation
- Provide a central, static-first directory at `/ecosystem` to list, categorize, link, and track status for every OneGodian system before introducing a database or sync backend.  
- Seed a reusable data/typing surface and a UI that prepares the app for later Node/ODIN/WordPress sync integration without changing existing routes.

### Description
- Added a static data module `src/lib/ecosystem.ts` defining `EcosystemSystem` types, `ECOSYSTEM_CATEGORIES`, `SYNC_TYPES`, and seeded systems required by the spec.  
- Implemented a reusable responsive card component `src/components/ecosystem-system-card.tsx` that displays name, domain, category, status, description, sync priority, sync type badges, and a primary action.  
- Added the `/ecosystem` route at `src/app/(app)/ecosystem/page.tsx` which renders category chips and a grid of `EcosystemSystemCard` entries using existing app styling patterns.  
- Updated the dashboard modules in `src/app/(app)/dashboard/page.tsx` to include a navigation entry for the Ecosystem Directory and adjusted link rendering (switched to plain anchors for mixed internal/external hrefs to avoid a typed `Link` href error during build).

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors.  
- Ran `npm run build` which initially failed due to a `Link` href type mismatch, the rendering was adjusted to use an anchor for mixed internal/external URLs to resolve the type issue.  
- Re-ran `npm run build` and the production build completed successfully and the generated routes include `/ecosystem`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74f4e2f74832d9e3504d319cc8343)