### PR TITLE
Add ecosystem route and typed ecosystem module for deployment mirror

### DIFF
--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,0 +1,30 @@
+import { ONEGODIAN_ECOSYSTEM } from '@/lib/ecosystem';
+
+export default function EcosystemPage() {
+  return (
+    <main className="min-h-screen px-6 py-12 sm:py-16">
+      <div className="mx-auto max-w-6xl">
+        <header className="max-w-3xl">
+          <p className="text-sm uppercase tracking-[0.22em] text-neon">OneGodian Galaxy™</p>
+          <h1 className="mt-3 text-3xl font-bold leading-tight sm:text-4xl">Ecosystem</h1>
+          <p className="mt-4 text-base leading-7 text-slate-300">
+            Core production modules mirrored for deployment while preserving compatibility with the current Hostinger build.
+          </p>
+        </header>
+
+        <section aria-label="Ecosystem modules" className="mt-10 grid gap-4 sm:grid-cols-2">
+          {ONEGODIAN_ECOSYSTEM.map((module) => (
+            <article key={module.id} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5">
+              <p className="text-xs uppercase tracking-[0.2em] text-neon">{module.id}</p>
+              <h2 className="mt-2 text-xl font-semibold text-slate-100">{module.name}</h2>
+              <p className="mt-2 text-sm text-slate-300">{module.summary}</p>
+              <p className="mt-3 text-xs text-slate-400">
+                {module.category} · {module.status}
+              </p>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/ecosystem.ts
+++ b/src/lib/ecosystem.ts
@@ -1,0 +1,38 @@
+export type EcosystemModule = {
+  id: string;
+  name: string;
+  category: 'infrastructure' | 'identity' | 'commerce' | 'governance';
+  status: 'active' | 'beta' | 'queued';
+  summary: string;
+};
+
+export const ONEGODIAN_ECOSYSTEM: EcosystemModule[] = [
+  {
+    id: 'OG-ECO-01',
+    name: 'OneGodian Identity Engine',
+    category: 'identity',
+    status: 'active',
+    summary: 'Unified identity profiles, session trust, and role-ready account surfaces for app.onegodian.com.'
+  },
+  {
+    id: 'OG-ECO-02',
+    name: 'ODIN Registry Core',
+    category: 'governance',
+    status: 'active',
+    summary: 'Canonical registration, validation, and indexing for ODIN records across all routes.'
+  },
+  {
+    id: 'OG-ECO-03',
+    name: 'Capital + Products Exchange',
+    category: 'commerce',
+    status: 'beta',
+    summary: 'Commerce and product rails for delivery, licensing, and member-grade monetization.'
+  },
+  {
+    id: 'OG-ECO-04',
+    name: 'Planetary Infra Layer',
+    category: 'infrastructure',
+    status: 'queued',
+    summary: 'Operational infrastructure for planets, moon systems, and cross-route data mirroring.'
+  }
+];


### PR DESCRIPTION
### Motivation
- Mirror missing production app routes and data into the deployment repo root by adding a production-safe `/ecosystem` view. 
- Ensure additions preserve the existing Hostinger-compatible app structure and do not break the current successful deployment.

### Description
- Added `src/app/(app)/ecosystem/page.tsx` which implements a static, production-safe Ecosystem page following existing UI and layout patterns. 
- Added `src/lib/ecosystem.ts` exporting the `EcosystemModule` type and `ONEGODIAN_ECOSYSTEM` dataset consumed by the new route. 
- Kept styling and component usage consistent with the app shell so runtime and build behavior remain compatible with the current deployment.

### Testing
- Ran `npm install` which completed successfully. 
- Ran `npm run lint` which reported no ESLint warnings or errors. 
- Ran `npm run build` which compiled successfully and generated static routes including `/`, `/ecosystem`, `/moons-systems`, `/planets`, and all main app routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76bbd8184832d9910935591140ccb)