### PR TITLE
Enhance dashboard navigation identity: glyph cards, accents, and mobile nav

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,5 +1,37 @@
 import { AppShell } from '@/components/app-shell';
 
 export default function DashboardPage() {
-  return <AppShell title="Dashboard" modules={[{ title: 'Authenticated Area', description: 'Auth.js-ready shell for signed-in users.' }]} />;
+  return (
+    <AppShell
+      title="Dashboard"
+      modules={[
+        {
+          title: 'Planetary Registry',
+          description: 'Sovereign record index for worlds, civilizations, and governance mappings.',
+          href: '/planetary-registry',
+          accent: 'gold',
+          glyph: 'planet',
+          featured: true,
+          stats: ['25 Worlds Indexed', '94 Civilizations', 'ODIN Synced']
+        },
+        {
+          title: 'Moons & Systems',
+          description: 'Orbital catalog for moons, routes, and system-level observatory records.',
+          href: '/moons-systems',
+          accent: 'violet',
+          glyph: 'moons',
+          stats: ['73 Registered Moons', '12 Orbital Networks']
+        },
+        {
+          title: 'Ecosystem',
+          description: 'Connected infrastructure graph for gateways, services, and live interlinks.',
+          href: '/ecosystem',
+          accent: 'emerald',
+          glyph: 'ecosystem',
+          featured: true,
+          stats: ['18 Connected Systems', '4 Active Gateways', 'Realtime Sync']
+        }
+      ]}
+    />
+  );
 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,16 +1,44 @@
+import Link from 'next/link';
 import { ModuleCard } from '@/components/module-card';
 
-export function AppShell({ title, modules }: { title: string; modules: { title: string; description: string; href?: string }[] }) {
+type Module = {
+  title: string;
+  description: string;
+  href?: string;
+  accent?: 'cyan' | 'gold' | 'violet' | 'emerald' | 'magenta' | 'orange' | 'red' | 'silver';
+  stats?: string[];
+  glyph?: 'planet' | 'moons' | 'ecosystem' | 'registry' | 'media' | 'tools' | 'certificates' | 'dashboard';
+  featured?: boolean;
+};
+
+const mobileNav = [
+  { label: 'Home', href: '/dashboard' },
+  { label: 'Registry', href: '/planetary-registry' },
+  { label: 'Moons', href: '/moons-systems' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Profile', href: '/profile' }
+];
+
+export function AppShell({ title, modules }: { title: string; modules: Module[] }) {
   return (
-    <main className="min-h-screen px-6 py-10">
+    <main className="relative min-h-screen overflow-hidden px-6 py-10 pb-28">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(99,102,241,0.22),transparent_28%),radial-gradient(circle_at_85%_5%,rgba(34,211,238,0.2),transparent_30%),linear-gradient(to_bottom,rgba(2,6,23,1),rgba(2,6,23,.88))]" />
+      <div className="pointer-events-none absolute inset-0 opacity-30 [background-image:linear-gradient(rgba(148,163,184,.14)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,.1)_1px,transparent_1px)] [background-size:36px_36px]" />
       <div className="mx-auto max-w-6xl">
-        <h1 className="text-3xl font-bold tracking-wide text-slate-100">{title}</h1>
-        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <h1 className="relative text-3xl font-bold tracking-wide text-slate-100">{title}</h1>
+        <div className="relative mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {modules.map((module) => (
             <ModuleCard key={module.title} {...module} />
           ))}
         </div>
       </div>
+      <nav className="fixed inset-x-3 bottom-3 z-20 rounded-2xl border border-cyan-400/30 bg-slate-950/80 p-2 backdrop-blur md:hidden">
+        <ul className="grid grid-cols-5 gap-1 text-center text-[11px] text-slate-300">
+          {mobileNav.map((item) => (
+            <li key={item.label}><Link href={item.href} className="block rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">{item.label}</Link></li>
+          ))}
+        </ul>
+      </nav>
     </main>
   );
 }

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -1,10 +1,59 @@
-type ModuleCardProps = { title: string; description: string; href?: string };
+import Link from 'next/link';
 
-export function ModuleCard({ title, description, href = '#' }: ModuleCardProps) {
+type ModuleCardProps = {
+  title: string;
+  description: string;
+  href?: string;
+  accent?: 'cyan' | 'gold' | 'violet' | 'emerald' | 'magenta' | 'orange' | 'red' | 'silver';
+  stats?: string[];
+  glyph?: 'planet' | 'moons' | 'ecosystem' | 'registry' | 'media' | 'tools' | 'certificates' | 'dashboard';
+  featured?: boolean;
+};
+
+const accentStyles = {
+  cyan: 'from-cyan-400/80 to-cyan-500/30 border-cyan-400/35',
+  gold: 'from-amber-300/80 to-amber-500/20 border-amber-300/35',
+  violet: 'from-violet-400/80 to-violet-600/20 border-violet-400/35',
+  emerald: 'from-emerald-400/80 to-emerald-600/20 border-emerald-400/35',
+  magenta: 'from-fuchsia-400/80 to-fuchsia-600/20 border-fuchsia-400/35',
+  orange: 'from-orange-400/80 to-orange-600/20 border-orange-400/35',
+  red: 'from-red-400/80 to-red-600/20 border-red-400/35',
+  silver: 'from-slate-300/70 to-slate-400/20 border-slate-300/35'
+};
+
+function Glyph({ glyph = 'dashboard' }: { glyph?: ModuleCardProps['glyph'] }) {
+  const common = 'h-14 w-14 stroke-[1.5] text-cyan-200/80 transition-transform duration-300 group-hover:scale-105 group-hover:rotate-3';
+  if (glyph === 'planet') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="12" cy="12" r="4.5" /><ellipse cx="12" cy="12" rx="9" ry="3.2" /><path d="M3 14c1.8 1.2 4.2 2 9 2s7.2-.8 9-2" /></svg>;
+  if (glyph === 'moons') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="12" cy="12" r="2.8" /><circle cx="6.5" cy="8" r="1.6" /><circle cx="18" cy="15.5" r="1.8" /><path d="M4 12a8 8 0 0 1 8-8" /><path d="M20 12a8 8 0 0 1-8 8" /></svg>;
+  if (glyph === 'ecosystem') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="6" cy="7" r="2" /><circle cx="18" cy="6" r="2" /><circle cx="12" cy="17" r="2" /><path d="M7.8 8.1 10.2 15" /><path d="M16.2 7.1 13.8 15" /><path d="M8 7h8" /></svg>;
+  return <svg viewBox="0 0 24 24" fill="none" className={common}><rect x="4" y="4" width="16" height="16" rx="3" /><path d="M8 9h8M8 13h8M8 17h5" /></svg>;
+}
+
+export function ModuleCard({ title, description, href = '#', accent = 'cyan', stats = [], glyph = 'dashboard', featured = false }: ModuleCardProps) {
   return (
-    <a href={href} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5 hover:border-neon">
-      <h3 className="text-lg font-semibold text-neon">{title}</h3>
-      <p className="mt-2 text-sm text-slate-300">{description}</p>
-    </a>
+    <Link
+      href={href}
+      className={`group relative overflow-hidden rounded-2xl border bg-slate-900/70 p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(34,211,238,0.18)] active:translate-y-0.5 ${accentStyles[accent]} ${
+        featured ? 'sm:col-span-2 lg:col-span-1 lg:min-h-64' : ''
+      }`}
+    >
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(103,232,249,0.13),transparent_50%),linear-gradient(135deg,rgba(15,23,42,0.85),rgba(2,6,23,0.95))]" />
+      <div className="absolute right-2 top-2 opacity-90">
+        <Glyph glyph={glyph} />
+      </div>
+      <div className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${accentStyles[accent].split(' ').slice(0, 2).join(' ')}`} />
+      <div className="relative">
+        <h3 className="text-lg font-semibold text-slate-100">{title}</h3>
+        <p className="mt-2 max-w-[85%] text-sm text-slate-300">{description}</p>
+        {stats.length > 0 && (
+          <ul className="mt-4 space-y-1 text-xs text-slate-300/90">
+            {stats.slice(0, 3).map((item) => (
+              <li key={item} className="flex items-center gap-2"><span className="h-1.5 w-1.5 rounded-full bg-cyan-300" />{item}</li>
+            ))}
+          </ul>
+        )}
+        <span className="mt-4 inline-block text-xs font-medium uppercase tracking-[0.2em] text-cyan-200/80">Open Module →</span>
+      </div>
+    </Link>
   );
 }


### PR DESCRIPTION
### Motivation
- The dashboard cards were visually uniform and acted as a text directory, making it hard for users (especially on mobile) to quickly distinguish sections. 
- The goal is to introduce a layered navigation language so sections are immediately identifiable by iconography, color, and subtle motion. 

### Description
- Reworked module card UI in `src/components/module-card.tsx` to introduce section glyphs, per-category `accentStyles`, a top accent stripe, subtle radial/linear backgrounds, hover/press interaction states, and optional mini `stats` to make cards feel operational. 
- Added a `Glyph` renderer for inline SVG icons and expanded `ModuleCard` props to include `accent`, `glyph`, `stats`, and `featured` flags to control layout and visual identity. 
- Updated the app shell in `src/components/app-shell.tsx` to add cinematic spatial depth (radial gradients and a faint grid overlay), a small type `Module` definition for modules, and a persistent bottom mobile navigation bar (`mobileNav`) for app-like behavior on small screens. 
- Replaced the dashboard content in `src/app/(app)/dashboard/page.tsx` to surface `Planetary Registry`, `Moons & Systems`, and `Ecosystem` as distinct hero modules with glyphs, accents, featured sizing, and example stats. 

### Testing
- Ran `npm run lint` which executes `next lint`, and it completed with `✔ No ESLint warnings or errors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77229b3f8832dbb02aaa8499004ee)