### PR TITLE
Add OneGodian Time dashboard and deterministic OTS‑V5 conversion utilities

### DIFF
--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { formatOTDate, gregorianToOT } from '@/lib/onegodian-time';
+
+export default function TimePage() {
+  const [now, setNow] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(() => new Date().toISOString().slice(0, 10));
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const liveOT = useMemo(() => gregorianToOT(now), [now]);
+  const converted = useMemo(() => gregorianToOT(selectedDate), [selectedDate]);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-slate-100">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+        <section className="rounded-3xl border border-blue-400/30 bg-gradient-to-br from-slate-900 via-blue-950 to-slate-900 p-8 shadow-2xl shadow-blue-900/30">
+          <p className="text-sm uppercase tracking-[0.24em] text-blue-300">OTS-V5 Dual-Date Governance System</p>
+          <h1 className="mt-2 text-4xl font-bold text-slate-50">OneGodian Time™</h1>
+          <p className="mt-4 max-w-4xl text-slate-300">
+            OneGodian Time converts Gregorian/UTC dates into a deterministic internal dual-date governance format.
+            Gregorian Time controls legally. OneGodian Time is supplemental for internal governance, historical sequencing,
+            and platform display.
+          </p>
+        </section>
+
+        <section className="grid gap-5 lg:grid-cols-2">
+          <article className="rounded-2xl border border-blue-300/20 bg-slate-900/70 p-6">
+            <h2 className="text-xl font-semibold text-blue-200">Live Dual-Date Clock</h2>
+            <div className="mt-4 space-y-2 text-sm text-slate-300">
+              <p><span className="text-slate-400">Local Gregorian:</span> {now.toLocaleString()}</p>
+              <p><span className="text-slate-400">UTC Timestamp:</span> {now.toISOString()}</p>
+              <p><span className="text-slate-400">OneGodian Time:</span> {formatOTDate(liveOT)}</p>
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-blue-300/20 bg-slate-900/70 p-6">
+            <h2 className="text-xl font-semibold text-blue-200">Gregorian → OneGodian Converter</h2>
+            <label className="mt-4 block text-sm text-slate-300">
+              Gregorian Date
+              <input
+                type="date"
+                value={selectedDate}
+                onChange={(event) => setSelectedDate(event.target.value)}
+                min="2025-03-18"
+                className="mt-2 w-full rounded-xl border border-blue-300/20 bg-slate-950 p-2 text-slate-100"
+              />
+            </label>
+            <div className="mt-4 space-y-2 text-sm text-slate-300">
+              <p>Gregorian date: {converted.gregorianISODate}</p>
+              <p>OneGodian date: {converted.display}</p>
+              <p>OT year: {String(converted.year).padStart(4, '0')}</p>
+              <p>OT month: {converted.monthName} ({converted.monthIndex})</p>
+              <p>OT day: {converted.day}</p>
+              <p>System format: {converted.gregorianISODate} | {converted.display}</p>
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-amber-300/20 bg-slate-900/70 p-6">
+            <h3 className="text-lg font-semibold text-amber-200">Epoch Anchor Card</h3>
+            <p className="mt-3 text-sm text-slate-300">March 18, 2025 Gregorian</p>
+            <p className="text-sm text-slate-300">Genesis 01, 0000 OT</p>
+            <p className="mt-2 text-xs text-slate-400">Immutable conversion anchor.</p>
+          </article>
+
+          <article className="rounded-2xl border border-blue-300/20 bg-slate-900/70 p-6">
+            <h3 className="text-lg font-semibold text-blue-200">Calendar Structure Card</h3>
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-300">
+              <li>13 months total</li>
+              <li>12 months × 30 days</li>
+              <li>Ascension = 5 or 6 days</li>
+              <li>Year length = 365 or 366 days</li>
+            </ul>
+          </article>
+
+          <article className="rounded-2xl border border-blue-300/20 bg-slate-900/70 p-6">
+            <h3 className="text-lg font-semibold text-blue-200">Database Governance Card</h3>
+            <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-950/80 p-3 text-xs text-slate-300">{`timestamp_utc = primary truth
+timestamp_local = display/local context
+timestamp_ot = computed derivative
+timezone = required`}</pre>
+          </article>
+
+          <article className="rounded-2xl border border-amber-300/20 bg-slate-900/70 p-6">
+            <h3 className="text-lg font-semibold text-amber-200">Legal-Safe Format Card</h3>
+            <p className="mt-3 text-sm text-slate-300">Date: March 24, 2025</p>
+            <p className="text-sm text-slate-300">OneGodian Date: Genesis 07, 0000 OT</p>
+            <p className="mt-3 text-sm text-slate-300">
+              Recorded on Genesis 07, 0000 OT (March 24, 2025), at 8:45 PM EST, Waterbury, Connecticut.
+            </p>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/onegodian-time.ts
+++ b/src/lib/onegodian-time.ts
@@ -1,0 +1,103 @@
+const OT_EPOCH_UTC_MS = Date.UTC(2025, 2, 18);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const OT_MONTHS = [
+  'Genesis',
+  'Wisdom',
+  'Planting',
+  'Justice',
+  'Freedom',
+  'Prosperity',
+  'Innovation',
+  'Transformation',
+  'Remembrance',
+  'Covenant',
+  'Invention',
+  'Independence',
+  'Ascension'
+] as const;
+
+export type OTResult = {
+  monthName: (typeof OT_MONTHS)[number];
+  monthIndex: number;
+  day: number;
+  year: number;
+  gregorianISODate: string;
+  display: string;
+};
+
+export function isGregorianLeapYear(year: number) {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+export function isOTLeapYear(otYear: number) {
+  const gregorianEndYear = 2025 + otYear + 1;
+  return isGregorianLeapYear(gregorianEndYear);
+}
+
+export function daysInOTYear(otYear: number) {
+  return isOTLeapYear(otYear) ? 366 : 365;
+}
+
+function toUTCDateOnly(value: Date) {
+  return Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+function normalizeInput(input: string | Date) {
+  if (input instanceof Date) return input;
+  return new Date(`${input}T00:00:00.000Z`);
+}
+
+export function gregorianToOT(input: string | Date): OTResult {
+  const parsed = normalizeInput(input);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid Gregorian date input.');
+  }
+
+  const utcDateOnly = toUTCDateOnly(parsed);
+  const deltaDays = Math.floor((utcDateOnly - OT_EPOCH_UTC_MS) / DAY_MS);
+
+  if (deltaDays < 0) {
+    throw new Error('Gregorian date must be on or after 2025-03-18.');
+  }
+
+  let remainingDays = deltaDays;
+  let otYear = 0;
+
+  while (remainingDays >= daysInOTYear(otYear)) {
+    remainingDays -= daysInOTYear(otYear);
+    otYear += 1;
+  }
+
+  const monthLengths = new Array(12).fill(30);
+  monthLengths.push(isOTLeapYear(otYear) ? 6 : 5);
+
+  let monthIndex = 0;
+  while (remainingDays >= monthLengths[monthIndex]) {
+    remainingDays -= monthLengths[monthIndex];
+    monthIndex += 1;
+  }
+
+  const day = remainingDays + 1;
+  const monthName = OT_MONTHS[monthIndex];
+  const yearLabel = String(otYear).padStart(4, '0');
+  const gregorianISODate = new Date(utcDateOnly).toISOString().slice(0, 10);
+  const display = `${monthName} ${String(day).padStart(2, '0')}, ${yearLabel} OT`;
+
+  return {
+    monthName,
+    monthIndex: monthIndex + 1,
+    day,
+    year: otYear,
+    gregorianISODate,
+    display
+  };
+}
+
+export function formatOTDate(result: OTResult) {
+  return result.display;
+}
+
+export function getCurrentOTDate() {
+  return gregorianToOT(new Date());
+}


### PR DESCRIPTION
### Motivation
- Provide a production-ready OneGodian Time™ page and library to display and compute a deterministic internal dual-date governance overlay (OTS‑V5) while keeping Gregorian/UTC as legal truth.
- Ensure conversions are UTC-safe, deterministic, and usable server/client-side without introducing new dependencies.

### Description
- Add a responsive dashboard route at `src/app/(app)/time/page.tsx` that implements the hero and required widgets: Live Dual-Date Clock, Gregorian → OneGodian Converter, Epoch Anchor Card, Calendar Structure Card, Database Governance Card, and Legal-Safe Format Card with OneGodian-themed styling (dark navy/blue/gold, rounded cards, subtle gradients).
- Implement deterministic conversion utilities in `src/lib/onegodian-time.ts` exporting `OT_MONTHS`, `isGregorianLeapYear`, `isOTLeapYear`, `daysInOTYear`, `gregorianToOT`, `formatOTDate`, and `getCurrentOTDate` using UTC date-only math anchored to the canonical epoch of `2025-03-18`.
- Apply OT rules per spec: OT year 0000 spans 2025-03-18 → 2026-03-17, year increments on March 18, Gregorian controls legally, OT leap-year computed from the Gregorian year in which the OT year ends (`2025 + otYear + 1`).
- Provide production-safe behavior: input normalization, validation for dates before the epoch, structured return values (month name/index, day, year, Gregorian ISO, formatted display), and example/legal-safe text outputs on the page.

### Testing
- Ran `next lint` for the modified files (`src/app/(app)/time/page.tsx` and `src/lib/onegodian-time.ts`) and it reported no ESLint errors for those files (passed).
- Running the repository-wide `npm run lint` surfaced unrelated pre-existing syntax/export issues in other ODIN pages (these are outside the scope of this change and caused full lint to fail).
- `npm run build` failed due to unrelated existing module export/syntax problems in other files (not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f776bf48d0832db82336a86f7737e3)