### PR TITLE
Add persistent app navigation shell with live OneGodian time header

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,5 @@
+import { AppFrame } from '@/components/app-frame';
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return <AppFrame>{children}</AppFrame>;
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,8 @@
+export default function SettingsPage() {
+  return (
+    <main className="px-6 py-8">
+      <h1 className="text-3xl font-semibold text-slate-100">Settings</h1>
+      <p className="mt-3 max-w-2xl text-slate-300">Configure your OneGodian app preferences, module defaults, and notification settings.</p>
+    </main>
+  );
+}

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { gregorianToOT } from '@/lib/onegodian-time';
+
+const navItems = [
+  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'ODIN', href: '/odin' },
+  { label: 'Time', href: '/time' },
+  { label: 'Planets', href: '/planets' },
+  { label: 'Moons', href: '/moons-systems' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Media', href: '/media' },
+  { label: 'Products', href: '/products' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Profile', href: '/profile' },
+  { label: 'Settings', href: '/settings' }
+];
+
+function useLiveTimes() {
+  const [now, setNow] = useState<Date>(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const utc = now.toISOString();
+  const local = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  const ot = useMemo(() => gregorianToOT(now).display, [now]);
+
+  return { utc, local, ot };
+}
+
+export function AppFrame({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { utc, local, ot } = useLiveTimes();
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="flex min-h-screen">
+        <aside className="hidden w-64 shrink-0 border-r border-slate-800/80 bg-slate-950/95 p-4 lg:block">
+          <div className="mb-6 text-lg font-semibold text-cyan-300">OneGodian</div>
+          <nav className="space-y-1">
+            {navItems.map((item) => {
+              const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+              return (
+                <Link key={item.href} href={item.href} className={`block rounded-lg px-3 py-2 text-sm ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300 hover:bg-slate-800'}`}>
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
+            <div className="flex items-center gap-3">
+              <div className="font-semibold text-cyan-300">OneGodian</div>
+              <input className="h-9 flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 text-sm" placeholder="Search planets, ODIN, systems, modules..." />
+              <div className="hidden text-xs text-slate-300 md:block">UTC {new Date(utc).toLocaleTimeString('en-US', { timeZone: 'UTC', hour: '2-digit', minute: '2-digit' })}</div>
+              <div className="hidden text-xs text-slate-300 md:block">OT {ot}</div>
+              <div className="rounded-full border border-slate-700 px-2 py-1 text-xs">🔔</div>
+              <div className="rounded-full border border-slate-700 px-2 py-1 text-xs">👤</div>
+            </div>
+            <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-300 sm:grid-cols-3">
+              <span>UTC: {utc}</span>
+              <span>Local: {local}</span>
+              <span>OT: {ot}</span>
+            </div>
+          </header>
+
+          <div className="flex-1 pb-20">{children}</div>
+        </div>
+      </div>
+
+      <nav className="fixed inset-x-3 bottom-3 z-40 rounded-2xl border border-cyan-400/30 bg-slate-950/90 p-2 backdrop-blur lg:hidden">
+        <ul className="grid grid-cols-5 gap-1 text-center text-[11px] text-slate-300">
+          {navItems.slice(0, 5).map((item) => (
+            <li key={item.href}>
+              <Link href={item.href} className="block rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">{item.label}</Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { ModuleCard } from '@/components/module-card';
 
 type Module = {
@@ -11,17 +10,9 @@ type Module = {
   featured?: boolean;
 };
 
-const mobileNav = [
-  { label: 'Home', href: '/dashboard' },
-  { label: 'Registry', href: '/planetary-registry' },
-  { label: 'Moons', href: '/moons-systems' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Profile', href: '/profile' }
-];
-
 export function AppShell({ title, modules }: { title: string; modules: Module[] }) {
   return (
-    <main className="relative min-h-screen overflow-hidden px-6 py-10 pb-28">
+    <main className="relative min-h-screen overflow-hidden px-6 py-10">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(99,102,241,0.22),transparent_28%),radial-gradient(circle_at_85%_5%,rgba(34,211,238,0.2),transparent_30%),linear-gradient(to_bottom,rgba(2,6,23,1),rgba(2,6,23,.88))]" />
       <div className="pointer-events-none absolute inset-0 opacity-30 [background-image:linear-gradient(rgba(148,163,184,.14)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,.1)_1px,transparent_1px)] [background-size:36px_36px]" />
       <div className="mx-auto max-w-6xl">
@@ -32,13 +23,6 @@ export function AppShell({ title, modules }: { title: string; modules: Module[] 
           ))}
         </div>
       </div>
-      <nav className="fixed inset-x-3 bottom-3 z-20 rounded-2xl border border-cyan-400/30 bg-slate-950/80 p-2 backdrop-blur md:hidden">
-        <ul className="grid grid-cols-5 gap-1 text-center text-[11px] text-slate-300">
-          {mobileNav.map((item) => (
-            <li key={item.label}><Link href={item.href} className="block rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">{item.label}</Link></li>
-          ))}
-        </ul>
-      </nav>
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a persistent application frame so dashboard-style pages become a continuous operational UI shell.
- Surface live time context (UTC, local, OT) and a top command/search bar for global navigation and continuity.
- Prevent duplicate mobile navigation layers so route-level shells don't conflict with a single global shell.

### Description
- Add a client `AppFrame` component that implements a desktop left sidebar, top command bar (logo, search, UTC/OT indicators, notifications/profile), and a mobile bottom navigation with the requested menu items, and a live time mini-widget using `gregorianToOT` for OT display (`src/components/app-frame.tsx`).
- Introduce a grouped `(app)` layout that wraps app routes with the new `AppFrame` (`src/app/(app)/layout.tsx`).
- Add a lightweight `/settings` route so the settings navigation item resolves (`src/app/(app)/settings/page.tsx`).
- Remove the duplicate mobile nav from `AppShell` and adjust padding to avoid overlapping navigation layers (`src/components/app-shell.tsx`).

### Testing
- Ran `npm run lint`, which failed due to a pre-existing parse error in `src/app/(app)/odin/page.tsx` and not due to the new changes.
- Addressed a React Hook lint warning by switching to `gregorianToOT(now)` in the live-time hook, and no new lint errors were introduced by the modified files aside from the existing parse error.
- No automated unit tests were added or run for these UI changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77ec62d30832d8db93abf35212082)