### PR TITLE
feat: expand app navigation and command center modules

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,16 @@
 import Link from 'next/link';
 
-type CommandModule = {
-  title: string;
-  href: string;
-  description: string;
-  icon: string;
-  status: 'Live' | 'In Development' | 'Needs Setup' | 'Planned';
-};
-
 type SystemStatus = {
   title: string;
   status: 'Live' | 'In Development' | 'Needs Setup' | 'Planned';
 };
 
-const commandModules: CommandModule[] = [
-  { title: 'Algorithm', href: '/algorithm', description: 'Four-layer operational model for protocol, experience, community, and orientation.', icon: '◈', status: 'Live' },
-  { title: 'OMOS', href: '/omos', description: 'Operational module index for command workflows and system alignment.', icon: '◎', status: 'In Development' },
-  { title: 'Time', href: '/time', description: 'OTS-V5 timing reference, conversion tools, and legal-time guidance.', icon: '⏣', status: 'Live' },
-  { title: 'Protocol', href: '/protocol', description: 'Protocol governance references and implementation placeholders.', icon: '⌬', status: 'In Development' },
-  { title: 'AI Prompt', href: '/ai-system-prompt', description: 'Behavioral and classification standards for AI system usage.', icon: '✦', status: 'Live' },
-  { title: 'Identity', href: '/identity', description: 'Identity model, records, and LLC/INO separation references.', icon: '▣', status: 'Live' },
-  { title: 'Pipeline', href: '/pipeline', description: 'Compare, Filter, Normalize, and Output workflow specification.', icon: '⇄', status: 'In Development' },
-  { title: 'Gen Alpha', href: '/gen-alpha', description: 'Belief Mapper Lite stages for guided user progression.', icon: '△', status: 'Planned' },
-  { title: 'Docs', href: '/docs', description: 'Document library cards for system records and milestones.', icon: '☰', status: 'Needs Setup' },
-];
+type QuickLinkCard = {
+  title: string;
+  href: string;
+  description: string;
+  external?: boolean;
+};
 
 const systemStatuses: SystemStatus[] = [
   { title: 'Node App Live', status: 'Live' },
@@ -34,6 +21,26 @@ const systemStatuses: SystemStatus[] = [
   { title: 'API Gateway', status: 'Needs Setup' },
   { title: 'GitHub Repo Matrix', status: 'In Development' },
   { title: 'Alignment Demo', status: 'Planned' },
+];
+
+const commandCenterModules: QuickLinkCard[] = [
+  { title: 'ODIN Registry', href: '/odin', description: 'Open ODIN command pages and governance modules.' },
+  { title: 'Planetary Registry', href: '/odin/planetary-registry', description: 'Browse PR worlds and linked platform endpoints.' },
+  { title: 'Moons & Systems', href: '/moons-systems', description: 'Review moon, systems, and orbital mapping tools.' },
+  { title: 'Learn Portal', href: '/learn', description: 'Access learning pathways and onboarding content.' },
+  { title: 'Identity Wallet', href: '/identity', description: 'Manage identity records and wallet references.' },
+  { title: 'Verification Tools', href: '/verification', description: 'Validate records, trust states, and verification workflows.' },
+  { title: 'Capital Access', href: '/capital', description: 'Explore financing pathways and capital-facing modules.' },
+  { title: 'Media Center', href: '/media', description: 'Find media publications and communication assets.' },
+  { title: 'Storefront', href: '/store', description: 'Open commerce modules and storefront operations.' },
+  { title: 'OneGodian Time', href: '/time', description: 'Launch OTS-V5 time conversion and timing references.' },
+];
+
+const externalPlatformBridges: QuickLinkCard[] = [
+  { title: 'Student Portal', href: 'https://u.onegodian.org/dashboard', description: 'Open the external student dashboard.', external: true },
+  { title: 'Courses', href: 'https://u.onegodian.org/courses', description: 'View active and archived learning courses.', external: true },
+  { title: 'Onegodianese™ Curriculum', href: 'https://u.onegodian.org/curriculum', description: 'Open curriculum paths and lesson maps.', external: true },
+  { title: 'Developer/API Access', href: '/developer', description: 'Enter developer tooling and API access modules.' },
 ];
 
 const statusStyles: Record<SystemStatus['status'], string> = {
@@ -50,34 +57,10 @@ export default function HomePage() {
         <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_0_0_1px_rgba(34,211,238,0.08)] sm:p-8">
           <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">ONEGODIAN COMMAND DASHBOARD</p>
           <h1 className="mt-3 text-3xl font-bold sm:text-4xl lg:text-5xl">OneGodian System Control Surface</h1>
-          <p className="mt-4 max-w-4xl text-base leading-relaxed text-slate-300 sm:text-lg">
-            Command access for operational modules, records, timing systems, and documentation. Status tags indicate current implementation maturity.
-          </p>
-          <div className="mt-7 flex flex-wrap gap-3">
-            <Link href="/dashboard" className="rounded-xl bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 sm:text-base">Open Dashboard</Link>
-            <Link href="/algorithm" className="rounded-xl border border-cyan-400/60 bg-slate-950/60 px-5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-300 sm:text-base">View Algorithm</Link>
-            <Link href="/docs" className="rounded-xl border border-slate-600 bg-slate-950/60 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300 sm:text-base">Open Docs</Link>
-          </div>
         </section>
 
         <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
-          <h2 className="text-xl font-semibold text-slate-50 sm:text-2xl">Command Modules</h2>
-          <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {commandModules.map((module) => (
-              <Link key={module.title} href={module.href} className="group rounded-xl border border-slate-700 bg-slate-950/70 p-5 transition hover:border-cyan-400/60 hover:bg-slate-900">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-2xl text-cyan-300">{module.icon}</span>
-                  <span className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${statusStyles[module.status]}`}>{module.status}</span>
-                </div>
-                <h3 className="mt-4 text-lg font-semibold text-slate-50">{module.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-300">{module.description}</p>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
-          <h2 className="text-xl font-semibold sm:text-2xl">System Status</h2>
+          <h2 className="text-xl font-semibold sm:text-2xl">Production Status</h2>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {systemStatuses.map((item) => (
               <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-950/70 p-4">
@@ -86,6 +69,36 @@ export default function HomePage() {
                   {item.status}
                 </span>
               </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+          <h2 className="text-xl font-semibold text-slate-50 sm:text-2xl">Command Center Modules</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {commandCenterModules.map((module) => (
+              <Link key={module.title} href={module.href} className="group rounded-xl border border-slate-700 bg-slate-950/70 p-5 transition hover:border-cyan-400/60 hover:bg-slate-900">
+                <h3 className="text-lg font-semibold text-slate-50">{module.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-300">{module.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+          <h2 className="text-xl font-semibold text-slate-50 sm:text-2xl">External Platform Bridges</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {externalPlatformBridges.map((bridge) => (
+              <Link
+                key={bridge.title}
+                href={bridge.href}
+                target={bridge.external ? '_blank' : undefined}
+                rel={bridge.external ? 'noreferrer noopener' : undefined}
+                className="group rounded-xl border border-slate-700 bg-slate-950/70 p-5 transition hover:border-cyan-400/60 hover:bg-slate-900"
+              >
+                <h3 className="text-lg font-semibold text-slate-50">{bridge.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-300">{bridge.description}</p>
+              </Link>
             ))}
           </div>
         </section>

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,21 +5,27 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const desktopNavItems = [
-  { label: 'Dashboard', href: '/dashboard' },
+const mainNavItems = [
+  { label: 'Dashboard', href: '/' },
   { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Time', href: '/time' },
   { label: 'Registry', href: '/registry' },
-  { label: 'Docs', href: '/docs' },
-  { label: 'Planets', href: '/planets' }
+  { label: 'Planets', href: '/odin/planetary-registry' },
+  { label: 'ODIN', href: '/odin' },
+  { label: 'Learn', href: '/learn' },
+  { label: 'Identity', href: '/identity' },
+  { label: 'Verification', href: '/verification' },
+  { label: 'Capital', href: '/capital' },
+  { label: 'Media', href: '/media' },
+  { label: 'Store', href: '/store' },
+  { label: 'Time', href: '/time' },
 ];
 
 const mobileNavItems = [
-  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Home', href: '/' },
   { label: 'Systems', href: '/ecosystem' },
-  { label: 'Time', href: '/time' },
-  { label: 'Docs', href: '/docs' }
+  { label: 'Learn', href: '/learn' },
+  { label: 'Community', href: '/community' },
+  { label: 'Identity', href: '/identity' },
 ];
 
 function useLiveTimes() {
@@ -47,7 +53,7 @@ export function AppFrame({ children }: { children: React.ReactNode }) {
         <aside className="hidden w-64 shrink-0 border-r border-slate-800/80 bg-slate-950/95 p-4 lg:block">
           <div className="mb-6 text-lg font-semibold text-cyan-300">OneGodian</div>
           <nav className="space-y-1">
-            {desktopNavItems.map((item) => {
+            {mainNavItems.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link key={item.href} href={item.href} className={`block rounded-lg px-3 py-2 text-sm ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300 hover:bg-slate-800'}`}>
@@ -68,6 +74,22 @@ export function AppFrame({ children }: { children: React.ReactNode }) {
               <div className="rounded-full border border-slate-700 px-2 py-1 text-xs">🔔</div>
               <div className="rounded-full border border-slate-700 px-2 py-1 text-xs">👤</div>
             </div>
+            <div className="mt-3 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              <nav className="flex min-w-max items-center gap-2 pb-1" aria-label="Main navigation">
+                {mainNavItems.map((item) => {
+                  const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                  return (
+                    <Link
+                      key={`top-${item.href}`}
+                      href={item.href}
+                      className={`rounded-full border px-3 py-1.5 text-xs transition ${active ? 'border-cyan-400/70 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </div>
             <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-300 sm:grid-cols-3">
               <span>UTC: {utc}</span>
               <span>Local: {local}</span>
@@ -80,12 +102,17 @@ export function AppFrame({ children }: { children: React.ReactNode }) {
       </div>
 
       <nav className="fixed inset-x-3 bottom-3 z-40 rounded-2xl border border-cyan-400/30 bg-slate-950/90 p-2 backdrop-blur lg:hidden">
-        <ul className="grid grid-cols-4 gap-1 text-center text-[11px] text-slate-300">
-          {mobileNavItems.map((item) => (
-            <li key={item.href}>
-              <Link href={item.href} className="block rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">{item.label}</Link>
-            </li>
-          ))}
+        <ul className="grid grid-cols-5 gap-1 text-center text-[11px] text-slate-300">
+          {mobileNavItems.map((item) => {
+            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <li key={item.href}>
+                <Link href={item.href} className={`block rounded-lg px-1 py-2 transition ${active ? 'bg-cyan-500/20 text-cyan-200' : 'hover:bg-slate-800/80 hover:text-cyan-200'}`}>
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
### Motivation
- Expand the main navigation to match the new Command Center surface and make navigation easier to use on mobile. 
- Surface the Command Center modules and external learning bridges on the homepage for faster access. 
- Provide a mobile-first experience with a horizontally scrollable top nav and a bottom tab bar for small screens. 

### Description
- Replaced and extended the navigation data and rendering in `src/components/app-frame.tsx` to include Dashboard -> `/`, Ecosystem -> `/ecosystem`, Registry -> `/registry`, Planets -> `/odin/planetary-registry`, ODIN -> `/odin`, Learn -> `/learn`, Identity -> `/identity`, Verification -> `/verification`, Capital -> `/capital`, Media -> `/media`, Store -> `/store`, and Time -> `/time`, and added a horizontally scrollable top nav row with hidden scrollbar styling and preserved active/hover states. 
- Updated the mobile bottom navigation in `src/components/app-frame.tsx` to a 5-tab bar: Home `/`, Systems `/ecosystem`, Learn `/learn`, Community `/community`, and Identity `/identity`, including active-state highlighting. 
- Reworked the homepage at `src/app/page.tsx` to add a `Production Status` section, `Command Center Modules` cards (all requested internal links), and `External Platform Bridges` cards with external `https://u.onegodian.org/...` links and `/developer`. 
- Preserved the existing visual style by reusing Tailwind classes (dark background, cyan accents, large headings, rounded dark cards, mobile-first spacing). 

### Testing
- Ran `npm run check` which failed because a `check` script is not defined in `package.json`. 
- Ran `npm run build` which failed due to pre-existing duplicate export/syntax errors in several ODIN route files (e.g. `src/app/(app)/odin/*.tsx`) not introduced by these navigation/homepage changes. 
- Ran `npm run lint` which failed with a parse error originating in `src/app/(app)/odin/page.tsx`, consistent with the build failures and pre-existing routing export issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78676b788832d94b301fa4f3fa942)