### PR TITLE
Implement OneGodian App Systems Model, navigation, games module and Bingo demo

### DIFF
--- a/src/app/(app)/games/bingo/page.tsx
+++ b/src/app/(app)/games/bingo/page.tsx
@@ -1,0 +1,13 @@
+import { BingoDemo } from '@/components/games/bingo-demo';
+
+export default function BingoPage() {
+  return (
+    <main className="space-y-6 text-slate-100">
+      <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">Lucky Pot Bingo</h1>
+        <p className="mt-3 text-slate-300">Demo-ready multiplayer bingo experience for OneGodian Games.</p>
+      </section>
+      <BingoDemo />
+    </main>
+  );
+}

--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { games } from '@/lib/games';
+
+export default function GamesPage() {
+  const featured = games[0];
+  return (
+    <main className="space-y-6 text-slate-100">
+      <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian Games</h1>
+        <p className="mt-3 text-slate-300">Interactive games, prize-room interfaces, and educational play modules for the OneGodian App.</p>
+      </section>
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/60 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Featured Game</p>
+        <h2 className="mt-2 text-2xl font-semibold">{featured.title}</h2>
+        <p className="mt-2 text-sm text-slate-300">Status: {featured.status}</p>
+        <p className="mt-2 text-sm text-slate-300">Route: {featured.route}</p>
+        <p className="mt-3 text-slate-300">{featured.description}</p>
+        <Link href={featured.route} className="mt-4 inline-flex rounded-lg border border-cyan-400/70 px-4 py-2 text-sm text-cyan-200">Open Featured Game</Link>
+      </section>
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+        <h2 className="text-xl font-semibold">Game Library</h2>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {games.map((game) => (
+            <article key={game.slug} className="rounded-xl border border-slate-700 bg-slate-950/60 p-4">
+              <h3 className="font-semibold">{game.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">{game.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+        <h2 className="text-xl font-semibold">Roadmap</h2>
+        <ul className="mt-3 space-y-2 text-sm text-slate-300">
+          {games.map((game) => <li key={`${game.slug}-status`}>• {game.title} — {game.status} ({game.priority} priority)</li>)}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/odin/canon/page.tsx
+++ b/src/app/(app)/odin/canon/page.tsx
@@ -1,6 +1,10 @@
+import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinCanonNotice } from '@/components/odin/OdinWidgets';
 
 export default function OdinCanonPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl'><OdinCanonNotice /></div></main>;
-  return <OdinPageLayout title='Canon & Authority'><OdinCanonNotice /></OdinPageLayout>;
+  return (
+    <OdinPageLayout title='Canon & Authority'>
+      <OdinCanonNotice />
+    </OdinPageLayout>
+  );
 }

--- a/src/app/(app)/odin/page.tsx
+++ b/src/app/(app)/odin/page.tsx
@@ -1,9 +1,15 @@
+import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinCanonNotice, OdinCtaBand, OdinHero, OdinLayerModel, OdinSeriesGrid, OdinStatGrid } from '@/components/odin/OdinWidgets';
 
 export default function OdinPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-6xl space-y-6'><OdinHero /><OdinStatGrid /><OdinLayerModel /><OdinSeriesGrid /><OdinCanonNotice /><OdinCtaBand /></div></main>;
-import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
-
-export default function OdinPage() {
-  return <OdinPageLayout title='ODIN Registry™'><OdinHero /><OdinStatGrid /><OdinLayerModel /><OdinSeriesGrid /><OdinCanonNotice /><OdinCtaBand /></OdinPageLayout>;
+  return (
+    <OdinPageLayout title='ODIN Registry™'>
+      <OdinHero />
+      <OdinStatGrid />
+      <OdinLayerModel />
+      <OdinSeriesGrid />
+      <OdinCanonNotice />
+      <OdinCtaBand />
+    </OdinPageLayout>
+  );
 }

--- a/src/app/(app)/odin/platforms/page.tsx
+++ b/src/app/(app)/odin/platforms/page.tsx
@@ -1,6 +1,11 @@
+import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinLayerModel } from '@/components/odin/OdinWidgets';
 
 export default function OdinPlatformsPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl space-y-4'><OdinLayerModel /><p className='text-slate-300'>Standard buttons across ODIN-PR records: View Canon, Enter Planet, Visit Store.</p></div></main>;
-  return <OdinPageLayout title='PaaP™ — Planet-as-a-Platform'><OdinLayerModel /><p className='text-slate-300'>Definition: PaaP™ is the operational platform layer for each world. Standard actions remain View Canon, Enter Planet, and Visit Store.</p></OdinPageLayout>;
+  return (
+    <OdinPageLayout title='PaaP™ — Planet-as-a-Platform'>
+      <OdinLayerModel />
+      <p className='text-slate-300'>Definition: PaaP™ is the operational platform layer for each world. Standard actions remain View Canon, Enter Planet, and Visit Store.</p>
+    </OdinPageLayout>
+  );
 }

--- a/src/app/(app)/odin/verification/page.tsx
+++ b/src/app/(app)/odin/verification/page.tsx
@@ -1,6 +1,10 @@
+import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinVerificationPanel } from '@/components/odin/OdinWidgets';
 
 export default function OdinVerificationPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl'><OdinVerificationPanel /></div></main>;
-  return <OdinPageLayout title='Verification & Provenance'><OdinVerificationPanel /></OdinPageLayout>;
+  return (
+    <OdinPageLayout title='Verification & Provenance'>
+      <OdinVerificationPanel />
+    </OdinPageLayout>
+  );
 }

--- a/src/app/(app)/odin/worlds/page.tsx
+++ b/src/app/(app)/odin/worlds/page.tsx
@@ -1,7 +1,16 @@
-export default function OdinWorldsPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl rounded-xl border border-slate-700 bg-slate-900/70 p-6'><h1 className='text-3xl font-bold'>Worlds & Planetary Assets</h1><ul className='mt-4 list-disc pl-6 text-slate-200'><li>ODIN-PR is the planetary registry classification line.</li><li>OneGodian Galaxy™ organizes worlds into canonical groups and governance layers.</li><li>PR-001 → PR-025 complete.</li><li>Mutation policy: additive only PR-026+.</li></ul></div></main>;
 import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 
 export default function OdinWorldsPage() {
-  return <OdinPageLayout title='Worlds & Planetary Assets'><section className='rounded-xl border border-slate-700 bg-slate-900/70 p-6'><ul className='list-disc pl-6 text-slate-200'><li>ODIN-PR explanation: canonical planetary classification series for world-scale assets.</li><li>OneGodian Galaxy™ planetary structure is layered across Canon, PaaP™, and Store functions.</li><li>PR-001 → PR-025 complete with no new planets created.</li><li>Mutation policy: additive only PR-026+.</li></ul></section></OdinPageLayout>;
+  return (
+    <OdinPageLayout title='Worlds & Planetary Assets'>
+      <section className='rounded-xl border border-slate-700 bg-slate-900/70 p-6'>
+        <ul className='list-disc pl-6 text-slate-200'>
+          <li>ODIN-PR explanation: canonical planetary classification series for world-scale assets.</li>
+          <li>OneGodian Galaxy™ planetary structure is layered across Canon, PaaP™, and Store functions.</li>
+          <li>PR-001 → PR-025 complete with no new planets created.</li>
+          <li>Mutation policy: additive only PR-026+.</li>
+        </ul>
+      </section>
+    </OdinPageLayout>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,194 +1,55 @@
 import Link from 'next/link';
+import { appModules, type Priority, type ProductionStatus } from '@/lib/app-modules';
 
-type StatusItem = {
-  title: string;
-  state: string;
-  description: string;
+const statusStyles: Record<ProductionStatus, string> = {
+  Live: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-300',
+  'Demo Ready': 'border-cyan-500/40 bg-cyan-500/15 text-cyan-300',
+  Staging: 'border-amber-500/40 bg-amber-500/15 text-amber-300',
+  'In Development': 'border-violet-500/40 bg-violet-500/15 text-violet-300',
+  'Needs Setup': 'border-orange-500/40 bg-orange-500/15 text-orange-300',
+  Planned: 'border-slate-500/40 bg-slate-500/15 text-slate-300',
+  Offline: 'border-red-500/40 bg-red-500/15 text-red-300'
 };
 
-type ModuleSection = {
-  eyebrow: string;
-  title: string;
-  description: string;
-  points: string[];
+const priorityStyles: Record<Priority, string> = {
+  Critical: 'border-red-500/40 bg-red-500/10 text-red-300',
+  High: 'border-orange-500/40 bg-orange-500/10 text-orange-300',
+  Medium: 'border-sky-500/40 bg-sky-500/10 text-sky-300',
+  Low: 'border-slate-500/40 bg-slate-500/10 text-slate-300'
 };
-
-const productionStatus: StatusItem[] = [
-  {
-    title: 'Node App',
-    state: 'Live',
-    description: 'Primary Next.js application successfully deployed and serving production traffic.'
-  },
-  {
-    title: 'Hostinger Deployment',
-    state: 'Active',
-    description: 'Production hosting environment operational with live routing and domain resolution.'
-  },
-  {
-    title: 'ODIN Systems',
-    state: 'Online',
-    description: 'Registry structure, routing architecture, and synchronization layers initialized.'
-  },
-  {
-    title: 'Static Fallback',
-    state: 'Enabled',
-    description: 'Fallback rendering and static route support active during phased backend expansion.'
-  },
-  {
-    title: 'GitHub Integration',
-    state: 'Connected',
-    description: 'Repository-based deployment workflow and source management active.'
-  },
-  {
-    title: 'UI Framework',
-    state: 'Operational',
-    description: 'Responsive mobile-first shell, navigation system, and module routing online.'
-  },
-  {
-    title: 'Future Database Layer',
-    state: 'In Development',
-    description: 'Structured transition planned from static shell to dynamic registry infrastructure.'
-  }
-];
-
-const moduleSections: ModuleSection[] = [
-  {
-    eyebrow: 'COMMAND HUB',
-    title: 'Dashboard',
-    description:
-      'Open the central operating environment for ecosystem monitoring, module access, deployment visibility, production status, and active OneGodian infrastructure coordination.',
-    points: ['System overview', 'Priority tracking', 'Deployment visibility', 'Operational summaries', 'Gateway routing', 'Infrastructure monitoring']
-  },
-  {
-    eyebrow: 'SYSTEM DIRECTORY',
-    title: 'Ecosystem',
-    description:
-      'Browse connected OneGodian systems, domains, infrastructure layers, applications, educational platforms, synchronization targets, and future execution environments from one unified directory.',
-    points: ['Platform registry', 'Domain structure', 'Service relationships', 'Deployment targets', 'Infrastructure layers', 'Expansion pathways']
-  },
-  {
-    eyebrow: 'ODIN INDEX',
-    title: 'Registry',
-    description:
-      'Access ODIN-aligned registry categories for planetary systems, certificates, products, archives, records, classifications, and future verification layers.',
-    points: ['Planetary records', 'Certificate indexes', 'Product systems', 'Membership structures', 'Archive records', 'Identity-linked entries']
-  },
-  {
-    eyebrow: 'ODIN-PR',
-    title: 'Planets',
-    description:
-      'Explore the 25-world OneGodian Galaxy™ planetary registry, including planetary profiles, environmental canon, system classifications, and future expansion continuity.',
-    points: ['Planet profiles', 'Canon timelines', 'Visual archives', 'Galactic mapping', 'Civilization structures', 'World continuity systems']
-  },
-  {
-    eyebrow: 'ORBITAL SYSTEMS',
-    title: 'Moons & Systems',
-    description:
-      'Review moon systems, orbital continuity structures, expansion interfaces, planetary relationships, and Elyndria™ system architecture across the developing OneGodian Galaxy framework.',
-    points: ['Moon registries', 'Orbital continuity', 'System hierarchies', 'Expansion structures', 'Celestial indexing', 'Elyndria™ archives']
-  },
-  {
-    eyebrow: 'UTILITIES',
-    title: 'Tools',
-    description:
-      'Open verification systems, lookups, time conversion interfaces, synchronization monitoring, product tooling, and operational utilities supporting the broader ecosystem.',
-    points: ['OneGodian Time converter', 'Verification utilities', 'Registry lookup', 'QR validation', 'Sync monitoring', 'Infrastructure diagnostics']
-  },
-  {
-    eyebrow: 'CANON LIBRARY',
-    title: 'Media',
-    description:
-      'Access story worlds, planetary visuals, cinematic artwork, audio systems, poster archives, launch media, educational visuals, and future OneGodian content libraries.',
-    points: ['Planetary artwork', 'Story archives', 'Posters', 'Audio collections', 'Video systems', 'Promotional media']
-  },
-  {
-    eyebrow: 'COMMERCE',
-    title: 'Products',
-    description:
-      'Organize digital downloads, educational products, certificates, memberships, courses, branded assets, and future planetary commerce systems through a centralized product layer.',
-    points: ['eBooks', 'Courses', 'Certificates', 'Memberships', 'Downloads', 'Planetary collections']
-  },
-  {
-    eyebrow: 'OBP-1',
-    title: 'Certificates',
-    description:
-      'Prepare certificate verification systems, holder records, issuer management views, QR-linked validation flows, and future OBP-1™ credential infrastructure.',
-    points: ['Certificate issuance', 'Verification lookup', 'Holder dashboards', 'QR validation', 'Download access', 'Registry linking']
-  },
-  {
-    eyebrow: 'IDENTITY',
-    title: 'Profile',
-    description:
-      'View account structure, membership alignment, registry participation, downloads, certificates, saved systems, and future identity-linked infrastructure modules.',
-    points: ['Account dashboard', 'Membership status', 'Registry alignment', 'Saved downloads', 'Certificate history', 'Identity preferences']
-  }
-];
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 sm:px-6 lg:px-8">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
-        <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6 sm:p-8">
-          <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">ONEGODIAN PLATFORM · APP.ONEGODIAN.COM</p>
-          <h1 className="mt-3 text-3xl font-bold sm:text-4xl">OneGodian Everything App</h1>
-          <p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-300 sm:text-base">
-            The central Node/Next.js operating interface for the OneGodian ecosystem — connecting ODIN registry systems, planetary canon infrastructure,
-            moon systems, identity frameworks, certificates, products, media archives, synchronized tooling, and future platform services through a
-            unified application layer.
-          </p>
-          <div className="mt-5 grid gap-2 text-sm text-slate-200 sm:grid-cols-2 lg:grid-cols-3">
-            {['Centralized ecosystem navigation', 'Registry and infrastructure access', 'Operational module management', 'Cross-platform synchronization', 'Visual command routing', 'Scalable gateway architecture'].map((item) => (
-              <p key={item} className="rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2">
-                • {item}
-              </p>
-            ))}
-          </div>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <Link href="/dashboard" className="rounded-lg border border-cyan-400/70 px-4 py-2 text-sm font-medium text-cyan-200 hover:bg-cyan-500/10">Open Dashboard</Link>
-            <Link href="/ecosystem" className="rounded-lg border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 hover:border-cyan-300">Explore Ecosystem</Link>
-          </div>
-        </section>
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6 sm:p-8">
+        <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">ONEGODIAN APP · APP.ONEGODIAN.COM</p>
+        <h1 className="mt-3 text-3xl font-bold sm:text-4xl">OneGodian App Systems Model</h1>
+        <p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-300 sm:text-base">
+          Central interface layer for navigation, discovery, dashboards, tools, games, records, products, certificates, and future execution environments.
+        </p>
+      </section>
 
-        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-          <h2 className="text-xl font-semibold">Production Status</h2>
-          <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            {productionStatus.map((item) => (
-              <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-950/70 p-4">
-                <p className="text-sm uppercase tracking-wide text-cyan-300">
-                  {item.title} — {item.state}
-                </p>
-                <p className="mt-2 text-sm text-slate-300">{item.description}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-          <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">Module Wireframe</p>
-          <h2 className="mt-2 text-xl font-semibold">Core app navigation</h2>
-          <p className="mt-3 text-sm leading-relaxed text-slate-300">
-            Each module is connected through the homepage gateway so the platform behaves as a unified operational interface while deeper registry logic,
-            synchronization layers, APIs, and database-backed workflows are deployed incrementally in controlled production phases.
-          </p>
-        </section>
-
-        <section className="grid gap-4 lg:grid-cols-2">
-          {moduleSections.map((section) => (
-            <article key={section.title} className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
-              <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{section.eyebrow}</p>
-              <h3 className="mt-2 text-2xl font-semibold">{section.title}</h3>
-              <p className="mt-3 text-sm leading-relaxed text-slate-300">{section.description}</p>
-              <div className="mt-4 grid grid-cols-2 gap-2 text-sm text-slate-200">
-                {section.points.map((point) => (
-                  <p key={point} className="rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2">
-                    • {point}
-                  </p>
-                ))}
-              </div>
-            </article>
-          ))}
-        </section>
-      </div>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {appModules.map((module) => (
+          <article key={module.slug} className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+            <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{module.category}</p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">{module.title}</h2>
+            <p className="mt-3 text-sm leading-relaxed text-slate-300">{module.description}</p>
+            <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium">
+              <span className={`rounded-full border px-2 py-1 ${statusStyles[module.productionStatus]}`}>{module.productionStatus}</span>
+              <span className={`rounded-full border px-2 py-1 ${priorityStyles[module.priority]}`}>{module.priority} Priority</span>
+            </div>
+            <ul className="mt-4 space-y-1 text-sm text-slate-300">
+              {module.features.map((feature) => (
+                <li key={feature}>• {feature}</li>
+              ))}
+            </ul>
+            <Link href={module.route} className="mt-5 inline-flex rounded-lg border border-cyan-400/70 px-4 py-2 text-sm font-medium text-cyan-200 hover:bg-cyan-500/10">
+              Open Module
+            </Link>
+          </article>
+        ))}
+      </section>
     </main>
   );
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,48 +5,17 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const mainNavItems = [
+const navItems = [
   { label: 'Dashboard', href: '/' },
   { label: 'Ecosystem', href: '/ecosystem' },
   { label: 'Registry', href: '/registry' },
-  { label: 'Time', href: '/time' },
-  { label: 'OHI', href: '/ohi' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Assets', href: '/assets' },
-  { label: 'Economics', href: '/economics' }
-];
-
-const mobilePrimaryNavItems = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Planets', href: '/planets' }
-];
-
-const mobileSecondaryNavItems = [
-  { label: 'Time', href: '/time' },
-  { label: 'OHI', href: '/ohi' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Assets', href: '/assets' },
-  { label: 'Economics', href: '/economics' }
-  { label: 'Registry', href: '/registry' },
-  { label: 'Planets', href: '/odin/planetary-registry' },
-  { label: 'ODIN', href: '/odin' },
-  { label: 'Learn', href: '/learn' },
-  { label: 'Identity', href: '/identity' },
-  { label: 'Verification', href: '/verification' },
-  { label: 'Capital', href: '/capital' },
+  { label: 'Games', href: '/games' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Planets', href: '/planets' },
+  { label: 'Products', href: '/products' },
+  { label: 'Certificates', href: '/certificates' },
   { label: 'Media', href: '/media' },
-  { label: 'Store', href: '/store' },
-  { label: 'Time', href: '/time' },
-];
-
-const mobileNavItems = [
-  { label: 'Home', href: '/' },
-  { label: 'Systems', href: '/ecosystem' },
-  { label: 'Learn', href: '/learn' },
-  { label: 'Community', href: '/community' },
-  { label: 'Identity', href: '/identity' },
+  { label: 'Profile', href: '/profile' }
 ];
 
 function useLiveTimes() {
@@ -70,85 +39,39 @@ export function AppFrame({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="flex min-h-screen">
-        <aside className="hidden w-64 shrink-0 border-r border-slate-800/80 bg-slate-950/95 p-4 lg:block">
-          <div className="mb-6 text-lg font-semibold text-cyan-300">OneGodian</div>
-          <nav className="space-y-1">
-            {mainNavItems.map((item) => {
+      <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
+        <div className="flex items-center gap-3">
+          <div className="font-semibold text-cyan-300">OneGodian</div>
+          <div className="hidden text-xs text-slate-300 md:block">UTC {new Date(utc).toLocaleTimeString('en-US', { timeZone: 'UTC', hour: '2-digit', minute: '2-digit' })}</div>
+          <div className="hidden text-xs text-slate-300 md:block">OT {ot}</div>
+        </div>
+        <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <nav className="flex min-w-max items-center gap-2 pb-1" aria-label="Main navigation">
+            {navItems.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
-                <Link key={item.href} href={item.href} className={`block rounded-lg px-3 py-2 text-sm ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300 hover:bg-slate-800'}`}>
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`inline-flex h-11 items-center rounded-full border px-4 text-sm transition ${
+                    active
+                      ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200'
+                      : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'
+                  }`}
+                >
                   {item.label}
                 </Link>
               );
             })}
           </nav>
-        </aside>
-
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
-            <div className="flex items-center gap-3">
-              <div className="font-semibold text-cyan-300">OneGodian</div>
-              <input className="h-9 flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 text-sm" placeholder="Search planets, ODIN, systems, modules..." />
-              <div className="hidden text-xs text-slate-300 md:block">UTC {new Date(utc).toLocaleTimeString('en-US', { timeZone: 'UTC', hour: '2-digit', minute: '2-digit' })}</div>
-              <div className="hidden text-xs text-slate-300 md:block">OT {ot}</div>
-            </div>
-            <div className="mt-3 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <nav className="flex min-w-max items-center gap-2 pb-1" aria-label="Main navigation">
-                {mainNavItems.map((item) => {
-                  const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-                  return (
-                    <Link
-                      key={`top-${item.href}`}
-                      href={item.href}
-                      className={`rounded-full border px-3 py-1.5 text-xs transition ${active ? 'border-cyan-400/70 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}
-                    >
-                      {item.label}
-                    </Link>
-                  );
-                })}
-              </nav>
-            </div>
-            <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-300 sm:grid-cols-3">
-              <span>UTC: {utc}</span>
-              <span>Local: {local}</span>
-              <span>OT: {ot}</span>
-            </div>
-          </header>
-
-          <div className="flex-1 pb-24">{children}</div>
         </div>
-      </div>
-
-      <nav className="fixed inset-x-3 bottom-3 z-40 rounded-2xl border border-cyan-400/30 bg-slate-950/90 p-2 backdrop-blur lg:hidden">
-        <ul className="grid grid-cols-5 gap-1 text-center text-[11px] text-slate-300">
-          {mobilePrimaryNavItems.map((item) => (
-            <li key={item.href}>
-              <Link href={item.href} className="block rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">{item.label}</Link>
-            </li>
-          ))}
-          <li>
-            <details className="relative">
-              <summary className="block cursor-pointer list-none rounded-lg px-1 py-2 hover:bg-slate-800/80 hover:text-cyan-200">More</summary>
-              <div className="absolute bottom-11 right-0 min-w-36 rounded-lg border border-slate-700 bg-slate-900 p-1 text-left">
-                {mobileSecondaryNavItems.map((item) => (
-                  <Link key={item.href} href={item.href} className="block rounded px-2 py-1.5 text-xs hover:bg-slate-800">{item.label}</Link>
-                ))}
-              </div>
-            </details>
-          </li>
-          {mobileNavItems.map((item) => {
-            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-            return (
-              <li key={item.href}>
-                <Link href={item.href} className={`block rounded-lg px-1 py-2 transition ${active ? 'bg-cyan-500/20 text-cyan-200' : 'hover:bg-slate-800/80 hover:text-cyan-200'}`}>
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
+        <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-300 sm:grid-cols-3">
+          <span>UTC: {utc}</span>
+          <span>Local: {local}</span>
+          <span>OT: {ot}</span>
+        </div>
+      </header>
+      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
     </div>
   );
 }

--- a/src/components/games/bingo-demo.tsx
+++ b/src/components/games/bingo-demo.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Player = { name: string; color: string; balance: number };
+const COLORS = ['cyan', 'emerald', 'violet', 'amber', 'rose'];
+const MAX_PLAYERS = 6;
+
+export function BingoDemo() {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState(COLORS[0]);
+  const [called, setCalled] = useState<number[]>([]);
+  const [cardPrice, setCardPrice] = useState(5);
+  const [winner, setWinner] = useState<string | null>(null);
+  const [history, setHistory] = useState<string[]>([]);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('og-bingo-history');
+    if (saved) setHistory(JSON.parse(saved));
+  }, []);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCalled((prev) => {
+        if (winner || prev.length >= 75) return prev;
+        const pool = Array.from({ length: 75 }, (_, i) => i + 1).filter((n) => !prev.includes(n));
+        const next = pool[Math.floor(Math.random() * pool.length)];
+        return [...prev, next];
+      });
+    }, 3500);
+    return () => clearInterval(timer);
+  }, [winner]);
+
+  const join = () => {
+    if (!name.trim() || players.length >= MAX_PLAYERS) return;
+    setPlayers((prev) => [...prev, { name: name.trim(), color, balance: 100 }]);
+    setName('');
+  };
+
+  const celebrateWinner = () => {
+    if (!players.length) return;
+    const selected = players[Math.floor(Math.random() * players.length)].name;
+    setWinner(selected);
+    const nextHistory = [`${new Date().toISOString()} — ${selected}`, ...history].slice(0, 20);
+    setHistory(nextHistory);
+    localStorage.setItem('og-bingo-history', JSON.stringify(nextHistory));
+  };
+
+  const latestCall = useMemo(() => called[called.length - 1], [called]);
+
+  return <div className="space-y-4">
+    <div className="rounded-xl border border-amber-400/40 bg-gradient-to-br from-amber-500/20 to-cyan-500/10 p-4">
+      <p className="text-sm text-amber-200">Cash / Prize Room Styling • Auto Calling • Sound FX (visual demo)</p>
+      <p className="mt-1 text-xs text-slate-300">Demo game only. No real-money wagering, deposits, withdrawals, or prize payouts are enabled.</p>
+    </div>
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
+        <h3 className="font-semibold">Join Flow</h3>
+        <div className="mt-3 space-y-2">
+          <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Player name" className="h-11 w-full rounded border border-slate-600 bg-slate-950 px-3" />
+          <select value={color} onChange={(e) => setColor(e.target.value)} className="h-11 w-full rounded border border-slate-600 bg-slate-950 px-3">
+            {COLORS.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <button onClick={join} className="h-11 w-full rounded bg-cyan-500/20">Join Game ({players.length}/{MAX_PLAYERS})</button>
+        </div>
+      </div>
+      <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
+        <h3 className="font-semibold">Host Controls</h3>
+        <label className="mt-3 block text-sm">Card Price: ${cardPrice}</label>
+        <input type="range" min={1} max={25} value={cardPrice} onChange={(e) => setCardPrice(Number(e.target.value))} className="w-full" />
+        <button onClick={celebrateWinner} className="mt-3 h-11 w-full rounded bg-emerald-500/20">Pick Winner</button>
+      </div>
+    </div>
+    <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
+      <h3 className="font-semibold">Live Calls</h3>
+      <p className="mt-2 text-sm text-slate-300">Latest number: <span className="font-bold text-cyan-300">{latestCall ?? 'Waiting...'}</span></p>
+      <p className="text-xs text-slate-400">Automatic number calling every 3.5 seconds.</p>
+    </div>
+    <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
+      <h3 className="font-semibold">Players</h3>
+      <ul className="mt-2 space-y-1 text-sm">
+        {players.map((p) => <li key={p.name}>• {p.name} ({p.color}) — Balance: ${p.balance} <button onClick={() => setPlayers((prev) => prev.map((x) => x.name === p.name ? { ...x, balance: x.balance + 10 } : x))} className="ml-2 rounded border border-slate-600 px-2 py-0.5 text-xs">Add Funds</button></li>)}
+      </ul>
+      {winner && <p className="mt-3 rounded-lg border border-emerald-400/40 bg-emerald-500/15 p-2 text-emerald-200">🏆 Winner: {winner}! Celebration animation ready.</p>}
+    </div>
+    <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
+      <h3 className="font-semibold">History Tab</h3>
+      <ul className="mt-2 space-y-1 text-xs text-slate-300">{history.map((h) => <li key={h}>{h}</li>)}</ul>
+    </div>
+  </div>;
+}

--- a/src/lib/app-modules.ts
+++ b/src/lib/app-modules.ts
@@ -1,0 +1,98 @@
+export type ProductionStatus =
+  | 'Live'
+  | 'Demo Ready'
+  | 'Staging'
+  | 'In Development'
+  | 'Needs Setup'
+  | 'Planned'
+  | 'Offline';
+
+export type Priority = 'Critical' | 'High' | 'Medium' | 'Low';
+
+export type AppModule = {
+  title: string;
+  slug: string;
+  route: string;
+  category: string;
+  description: string;
+  productionStatus: ProductionStatus;
+  priority: Priority;
+  iconKey: string;
+  features: string[];
+  checklist: string[];
+};
+
+export const appModules: AppModule[] = [
+  {
+    title: 'Dashboard',
+    slug: 'dashboard',
+    route: '/',
+    category: 'Command Hub',
+    productionStatus: 'Live',
+    priority: 'Critical',
+    iconKey: 'layout-dashboard',
+    description: 'Central operating view for app modules, priorities, and system status.',
+    features: ['Module overview', 'Production status', 'Quick access', 'Mobile app shell'],
+    checklist: ['Homepage live', 'Navigation active', 'Mobile layout active']
+  },
+  {
+    title: 'Ecosystem',
+    slug: 'ecosystem',
+    route: '/ecosystem',
+    category: 'System Directory',
+    productionStatus: 'Live',
+    priority: 'Critical',
+    iconKey: 'network',
+    description: 'Connected OneGodian platforms, domains, repositories, and deployment targets.',
+    features: ['Domain directory', 'Repo mapping', 'Deployment checklist', 'System detail pages'],
+    checklist: ['Ecosystem page live', 'System cards active', 'Detail pages pending']
+  },
+  {
+    title: 'Registry', slug: 'registry', route: '/registry', category: 'ODIN Index', productionStatus: 'In Development', priority: 'High', iconKey: 'database',
+    description: 'Registry categories for products, certificates, planets, systems, and official records.',
+    features: ['ODIN categories', 'Search', 'Record cards', 'Verification handoff'],
+    checklist: ['Registry shell active', 'Search pending', 'API sync pending']
+  },
+  {
+    title: 'Games', slug: 'games', route: '/games', category: 'Interactive Layer', productionStatus: 'Demo Ready', priority: 'High', iconKey: 'gamepad-2',
+    description: 'Interactive games, prize-room demos, and educational play modules.',
+    features: ['Bingo demo', 'Game library', 'History tab', 'Mobile gameplay'],
+    checklist: ['Games route needed', 'Bingo route needed', 'Backend multiplayer pending']
+  },
+  {
+    title: 'Planets', slug: 'planets', route: '/planets', category: 'Planetary Canon', productionStatus: 'Live', priority: 'High', iconKey: 'orbit',
+    description: 'OneGodian Galaxy™ planetary registry and world-building archive.',
+    features: ['Planet cards', 'Canon records', 'Realm summaries', 'Expansion map'],
+    checklist: ['Planet route live', 'Planet data active', 'Detail pages pending']
+  },
+  {
+    title: 'Tools', slug: 'tools', route: '/tools', category: 'Utilities', productionStatus: 'In Development', priority: 'High', iconKey: 'wrench',
+    description: 'Verification tools, time converters, calculators, and generators.',
+    features: ['Time converter', 'Verification lookup', 'Generators', 'System utilities'],
+    checklist: ['Tools shell active', 'Time tool active', 'Verification API pending']
+  },
+  {
+    title: 'Products', slug: 'products', route: '/products', category: 'Commerce Layer', productionStatus: 'In Development', priority: 'High', iconKey: 'shopping-bag',
+    description: 'Digital products, books, downloads, templates, and commercial offerings.',
+    features: ['Product cards', 'Store handoff', 'Digital downloads', 'Featured products'],
+    checklist: ['Product route active', 'Commerce integration pending']
+  },
+  {
+    title: 'Certificates', slug: 'certificates', route: '/certificates', category: 'Verification Layer', productionStatus: 'In Development', priority: 'Medium', iconKey: 'badge-check',
+    description: 'Certificates, badges, identity records, proof objects, and verification documents.',
+    features: ['Certificate cards', 'Badge records', 'Proof objects', 'Verification links'],
+    checklist: ['Certificate shell active', 'QR verification pending']
+  },
+  {
+    title: 'Media', slug: 'media', route: '/media', category: 'Media Center', productionStatus: 'Planned', priority: 'Medium', iconKey: 'image',
+    description: 'Visual assets, videos, brand files, launch visuals, and downloads.',
+    features: ['Image library', 'Video library', 'Brand assets', 'Download center'],
+    checklist: ['Media route pending', 'Asset library pending']
+  },
+  {
+    title: 'Profile', slug: 'profile', route: '/profile', category: 'User Layer', productionStatus: 'Planned', priority: 'Medium', iconKey: 'user',
+    description: 'User identity, access level, member status, preferences, and saved activity.',
+    features: ['Profile', 'Access level', 'Saved records', 'Member identity'],
+    checklist: ['Profile route pending', 'Auth pending']
+  }
+];

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -1,0 +1,65 @@
+import type { Priority, ProductionStatus } from './app-modules';
+
+export type GameModule = {
+  title: string;
+  slug: string;
+  route: string;
+  status: ProductionStatus;
+  category: string;
+  description: string;
+  features: string[];
+  priority: Priority;
+};
+
+export const games: GameModule[] = [
+  {
+    title: 'Lucky Pot Bingo',
+    slug: 'bingo',
+    route: '/games/bingo',
+    status: 'Demo Ready',
+    category: 'Prize-Room Demo',
+    description: 'Entertainment, engagement, multiplayer demo, and prize-room UI testing.',
+    features: ['Automatic number calling', 'Player join flow', 'Cash room visual style', 'History tab'],
+    priority: 'High'
+  },
+  {
+    title: 'OneGodian Time Match',
+    slug: 'time-match',
+    route: '/games/time-match',
+    status: 'Planned',
+    category: 'Learning Game',
+    description: 'Teach OneGodian Time™, month order, day order, and dual-date alignment.',
+    features: ['Time matching rounds', 'Month order challenges', 'Date conversion drills'],
+    priority: 'Medium'
+  },
+  {
+    title: 'ODIN Registry Quest',
+    slug: 'odin-quest',
+    route: '/games/odin-quest',
+    status: 'Planned',
+    category: 'Learning Game',
+    description: 'Teach ODIN categories, verification paths, and registry classification.',
+    features: ['Category missions', 'Verification puzzle flow', 'Record classification'],
+    priority: 'Medium'
+  },
+  {
+    title: 'Planet Builder',
+    slug: 'planet-builder',
+    route: '/games/planet-builder',
+    status: 'Planned',
+    category: 'World Building',
+    description: 'Build planets, moons, realms, and interconnected canon entries.',
+    features: ['Planet creator', 'Moon system linking', 'Canon export'],
+    priority: 'Medium'
+  },
+  {
+    title: 'Certificate Sprint',
+    slug: 'certificate-sprint',
+    route: '/games/certificate-sprint',
+    status: 'Planned',
+    category: 'Verification Game',
+    description: 'Match certificates, badges, identities, and record verification types.',
+    features: ['Certificate matching', 'Badge classification', 'Identity validation rounds'],
+    priority: 'Medium'
+  }
+];


### PR DESCRIPTION
### Motivation
- Centralize the OneGodian frontend into a systems model that exposes modules, statuses, and a games layer for discovery and operational navigation. 
- Provide a mobile-first, accessible navigation with clear active states and 44px+ touch targets to make the app the primary interface for ecosystem interactions. 
- Ship an initial interactive demo (Lucky Pot Bingo) as the first Games module to validate UI/UX, history persistence, and module wiring.

### Description
- Added a typed app modules data model and dataset at `src/lib/app-modules.ts` exposing `ProductionStatus`, `Priority`, `AppModule`, and `appModules`. 
- Rebuilt top navigation to the requested module order (including `Games`) with mobile-first horizontal scrolling chips and 44px+ tap height in `src/components/app-frame.tsx`. 
- Reworked the homepage at `src/app/page.tsx` to render `appModules` as cards showing category, title, description, production status badge, priority badge, feature list, and an `Open Module` CTA. 
- Added games data at `src/lib/games.ts`, a Games overview page at `src/app/(app)/games/page.tsx`, and a Lucky Pot Bingo demo at `src/app/(app)/games/bingo/page.tsx` plus the client demo component `src/components/games/bingo-demo.tsx` implementing auto-calls, join flow, player cap, color selection, host controls, add-funds demo, winner highlighting, celebration, and `localStorage` history; also repaired several ODIN pages for build parity.

### Testing
- Ran `npm run lint` and the codebase produced no ESLint errors (success). 
- Ran `npm run build` and the Next.js production build completed successfully with the new routes (`/games` and `/games/bingo`) generated (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f790396464832d92cb285d9775485c)