### PR TITLE
Add Games navigation and Games pages with Lucky Pot Bingo demo

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -2,34 +2,42 @@ import Link from 'next/link';
 import { games } from '@/lib/games';
 
 export default function GamesPage() {
-  const featured = games[0];
+  const featured = games.find((game) => game.slug === 'bingo') ?? games[0];
+
   return (
     <main className="space-y-6 text-slate-100">
       <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian Games</h1>
-        <p className="mt-3 text-slate-300">Interactive games, prize-room interfaces, and educational play modules for the OneGodian App.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">A. Hero</p>
+        <h1 className="mt-2 text-3xl font-bold text-white sm:text-4xl">OneGodian Games</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Interactive games, prize-room interfaces, and educational play modules for the OneGodian App.</p>
       </section>
+
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/60 p-6">
-        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Featured Game</p>
-        <h2 className="mt-2 text-2xl font-semibold">{featured.title}</h2>
-        <p className="mt-2 text-sm text-slate-300">Status: {featured.status}</p>
-        <p className="mt-2 text-sm text-slate-300">Route: {featured.route}</p>
-        <p className="mt-3 text-slate-300">{featured.description}</p>
-        <Link href={featured.route} className="mt-4 inline-flex rounded-lg border border-cyan-400/70 px-4 py-2 text-sm text-cyan-200">Open Featured Game</Link>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">B. Featured Game</p>
+        <h2 className="mt-2 text-2xl font-semibold">Lucky Pot Bingo</h2>
+        <p className="mt-3 text-sm text-slate-300">A mobile-first bingo room interface with automatic number calling, multiplayer player list, join flow, sound effects, cash/prize styling, card pricing, max-player limits, player colors, winner highlighting, and local history tracking.</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link href="/games/bingo" className="inline-flex min-h-11 items-center rounded-lg border border-cyan-400/70 bg-cyan-500/15 px-4 py-2 text-sm font-medium text-cyan-200">Play Demo</Link>
+          <Link href={featured.route} className="inline-flex min-h-11 items-center rounded-lg border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200">View Details</Link>
+        </div>
       </section>
+
       <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h2 className="text-xl font-semibold">Game Library</h2>
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">C. Game Library</p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
           {games.map((game) => (
             <article key={game.slug} className="rounded-xl border border-slate-700 bg-slate-950/60 p-4">
               <h3 className="font-semibold">{game.title}</h3>
+              <p className="mt-1 text-xs text-cyan-300">Status: {game.status}</p>
               <p className="mt-2 text-sm text-slate-300">{game.description}</p>
+              <p className="mt-2 text-xs text-slate-400">{game.route}</p>
             </article>
           ))}
         </div>
       </section>
+
       <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h2 className="text-xl font-semibold">Roadmap</h2>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">D. Game Status / Roadmap</p>
         <ul className="mt-3 space-y-2 text-sm text-slate-300">
           {games.map((game) => <li key={`${game.slug}-status`}>• {game.title} — {game.status} ({game.priority} priority)</li>)}
         </ul>

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -9,6 +9,8 @@ const navItems = [
   { label: 'Dashboard', href: '/' },
   { label: 'Ecosystem', href: '/ecosystem' },
   { label: 'Registry', href: '/registry' },
+  { label: 'Games', href: '/games' },
+  { label: 'Planets', href: '/planets' },
   { label: 'Systems', href: '/systems' },
   { label: 'Members', href: '/members' },
   { label: 'Capital', href: '/capital' },
@@ -31,8 +33,8 @@ const mobilePrimary = [
   { icon: '🏠', label: 'Dashboard', href: '/' },
   { icon: '🌐', label: 'Ecosystem', href: '/ecosystem' },
   { icon: '🪪', label: 'Registry', href: '/registry' },
-  { icon: '⚙️', label: 'Systems', href: '/systems' },
-  { icon: '☰', label: 'More', href: '/developers' }
+  { icon: '🎮', label: 'Games', href: '/games' },
+  { icon: '🪐', label: 'Planets', href: '/planets' }
 ];
 
 function useLiveTimes() {
@@ -71,14 +73,14 @@ export function AppFrame({ children }: { children: ReactNode }) {
           <div className="hidden text-xs text-slate-300 md:block">OT {ot}</div>
         </div>
         <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <nav className="flex min-w-max items-center gap-2 pb-1" aria-label="Main navigation">
+          <nav className="flex min-w-max flex-nowrap items-center gap-2 pb-1 sm:flex-wrap" aria-label="Main navigation">
             {navItems.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`inline-flex h-11 items-center rounded-full border px-4 text-sm transition ${
+                  className={`inline-flex min-h-11 items-center justify-center whitespace-nowrap rounded-full border px-4 py-2 text-sm font-medium transition ${
                     active
                       ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200'
                       : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'
@@ -103,9 +105,9 @@ export function AppFrame({ children }: { children: ReactNode }) {
           {mobilePrimary.map((item) => {
             const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
             return (
-              <Link key={item.href} href={item.href} className={`flex flex-col items-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
+              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
                 <span>{item.icon}</span>
-                <span>{item.label}</span>
+                <span className="mt-0.5">{item.label}</span>
               </Link>
             );
           })}

--- a/src/components/games/bingo-demo.tsx
+++ b/src/components/games/bingo-demo.tsx
@@ -14,6 +14,8 @@ export function BingoDemo() {
   const [cardPrice, setCardPrice] = useState(5);
   const [winner, setWinner] = useState<string | null>(null);
   const [history, setHistory] = useState<string[]>([]);
+  const [tab, setTab] = useState<'room' | 'history'>('room');
+  const [soundOn, setSoundOn] = useState(true);
 
   useEffect(() => {
     const saved = localStorage.getItem('og-bingo-history');
@@ -45,15 +47,17 @@ export function BingoDemo() {
     const nextHistory = [`${new Date().toISOString()} — ${selected}`, ...history].slice(0, 20);
     setHistory(nextHistory);
     localStorage.setItem('og-bingo-history', JSON.stringify(nextHistory));
+    setTab('history');
   };
 
   const latestCall = useMemo(() => called[called.length - 1], [called]);
 
   return <div className="space-y-4">
     <div className="rounded-xl border border-amber-400/40 bg-gradient-to-br from-amber-500/20 to-cyan-500/10 p-4">
-      <p className="text-sm text-amber-200">Cash / Prize Room Styling • Auto Calling • Sound FX (visual demo)</p>
+      <p className="text-sm text-amber-200">Cash / Prize Room Styling • Auto Calling • Sound FX Demo</p>
       <p className="mt-1 text-xs text-slate-300">Demo game only. No real-money wagering, deposits, withdrawals, or prize payouts are enabled.</p>
     </div>
+
     <div className="grid gap-4 md:grid-cols-2">
       <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
         <h3 className="font-semibold">Join Flow</h3>
@@ -69,24 +73,31 @@ export function BingoDemo() {
         <h3 className="font-semibold">Host Controls</h3>
         <label className="mt-3 block text-sm">Card Price: ${cardPrice}</label>
         <input type="range" min={1} max={25} value={cardPrice} onChange={(e) => setCardPrice(Number(e.target.value))} className="w-full" />
+        <button onClick={() => setSoundOn((prev) => !prev)} className="mt-2 h-11 w-full rounded border border-slate-600">Sound: {soundOn ? 'On' : 'Off'}</button>
         <button onClick={celebrateWinner} className="mt-3 h-11 w-full rounded bg-emerald-500/20">Pick Winner</button>
       </div>
     </div>
+
     <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
       <h3 className="font-semibold">Live Calls</h3>
       <p className="mt-2 text-sm text-slate-300">Latest number: <span className="font-bold text-cyan-300">{latestCall ?? 'Waiting...'}</span></p>
       <p className="text-xs text-slate-400">Automatic number calling every 3.5 seconds.</p>
     </div>
+
     <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
       <h3 className="font-semibold">Players</h3>
       <ul className="mt-2 space-y-1 text-sm">
-        {players.map((p) => <li key={p.name}>• {p.name} ({p.color}) — Balance: ${p.balance} <button onClick={() => setPlayers((prev) => prev.map((x) => x.name === p.name ? { ...x, balance: x.balance + 10 } : x))} className="ml-2 rounded border border-slate-600 px-2 py-0.5 text-xs">Add Funds</button></li>)}
+        {players.map((p) => <li key={p.name} className={winner === p.name ? 'rounded border border-emerald-400/50 bg-emerald-500/10 p-1' : ''}>• {p.name} ({p.color}) — Balance: ${p.balance} <button onClick={() => setPlayers((prev) => prev.map((x) => x.name === p.name ? { ...x, balance: x.balance + 10 } : x))} className="ml-2 rounded border border-slate-600 px-2 py-0.5 text-xs">Add Funds</button></li>)}
       </ul>
-      {winner && <p className="mt-3 rounded-lg border border-emerald-400/40 bg-emerald-500/15 p-2 text-emerald-200">🏆 Winner: {winner}! Celebration animation ready.</p>}
+      {winner && <p className="mt-3 rounded-lg border border-emerald-400/40 bg-emerald-500/15 p-2 text-emerald-200"><span className='mr-2 rounded bg-emerald-400/30 px-2 py-0.5 text-xs font-semibold'>WINNER</span>🏆 Winner: {winner}! Celebration animation: ✨🎉✨</p>}
     </div>
+
     <div className="rounded-xl border border-slate-700 bg-slate-900/70 p-4">
-      <h3 className="font-semibold">History Tab</h3>
-      <ul className="mt-2 space-y-1 text-xs text-slate-300">{history.map((h) => <li key={h}>{h}</li>)}</ul>
+      <div className="mb-2 flex gap-2">
+        <button onClick={() => setTab('room')} className={`rounded px-3 py-1 text-sm ${tab === 'room' ? 'bg-cyan-500/20 text-cyan-200' : 'bg-slate-800 text-slate-300'}`}>Room</button>
+        <button onClick={() => setTab('history')} className={`rounded px-3 py-1 text-sm ${tab === 'history' ? 'bg-cyan-500/20 text-cyan-200' : 'bg-slate-800 text-slate-300'}`}>History</button>
+      </div>
+      {tab === 'history' ? <ul className="mt-2 space-y-1 text-xs text-slate-300">{history.map((h) => <li key={h}>{h}</li>)}</ul> : <p className="text-sm text-slate-300">Game room tab active. Run rounds and pick winners to populate history.</p>}
     </div>
   </div>;
 }


### PR DESCRIPTION
### Motivation
- Introduce a Games surface to the OneGodian App so users can discover and launch interactive demos and educational play modules from primary navigation.
- Provide a mobile-first, responsive navigation experience so the top and bottom nav remain readable, tappable, and preserve active-state styling on small screens.
- Ship a demo-ready Lucky Pot Bingo room to validate prize-room visual language, join/host flows, and local demo UX without any real-money functionality.

### Description
- Added `Games` to the primary nav and updated mobile primary shortcuts by editing `src/components/app-frame.tsx`, and improved nav responsiveness with horizontal scrolling, non-wrapping/whitespace handling, larger tap targets, and sm breakpoint wrap behavior.
- Implemented the Games landing page at `src/app/(app)/games/page.tsx` with sections: A. Hero, B. Featured Game (with `Play Demo` -> `/games/bingo` and `View Details` CTAs), C. Game Library, and D. Roadmap; layout uses existing Tailwind dark visual language.
- Enhanced the Lucky Pot Bingo demo component at `src/components/games/bingo-demo.tsx` to include automatic number calling, multiplayer join flow, max-player limits, color selection, host card-price control, sound-toggle demo control, player balance/add-funds demo buttons, winner highlighting with a prominent `WINNER` badge and celebration text, localStorage-backed history, and Room/History tabs, plus the required demo-only disclaimer.
- Reused the shared `src/lib/games.ts` games array for library data and routes, and kept styling consistent with existing Card/Button conventions and Tailwind utilities.

### Testing
- Ran `npm run lint` which failed due to a pre-existing parse error in `src/app/page.tsx` unrelated to these changes, so lint did not complete successfully.
- Ran `npx tsc --noEmit` which failed for the same TypeScript/JSX syntax issue in `src/app/page.tsx` and prevented full type-check completion.
- Ran `npm run build` which failed during Next.js compilation for the same pre-existing syntax error in `src/app/page.tsx`, so the production build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78c4a6178832db52f88442dd28b30)