### PR TITLE
Add OMOS app bridge dashboard

### DIFF
--- a/docs/OMOS_LLM_GATEWAY_APP_INTEGRATION.md
+++ b/docs/OMOS_LLM_GATEWAY_APP_INTEGRATION.md
@@ -1,0 +1,85 @@
+# OMOS LLM Gateway + OneGodian App Integration
+
+This upgrade connects the OMOS / OMO WordPress plugin to the OneGodian App as a first-class module and prepares the secure LLM gateway layer.
+
+## App Module
+
+Route added:
+
+```txt
+/omos
+```
+
+The page displays:
+
+- Plugin bridge status
+- App bridge key readiness
+- App manifest data
+- OMOS tool registry
+- Submission stats
+- LLM gateway status
+- Provider configuration readiness
+- REST endpoint list
+
+## Server-Side App Proxy
+
+Route added:
+
+```txt
+/api/omos/llm/chat
+```
+
+This route forwards chat requests to the WordPress OMOS bridge. Provider keys must never be exposed to the browser.
+
+## Required App Environment Variables
+
+```env
+OMOS_REST_BASE_URL=https://onegodian.org/wp-json/omos/v1
+OMOS_API_BASE_URL=https://onegodian.org/wp-json/omos/v1
+OMOS_APP_BRIDGE_KEY=PASTE_GENERATED_KEY_HERE
+OMOS_APP_DASHBOARD_URL=https://app.onegodian.com/omos
+OMOS_MODULE_SLUG=omos
+```
+
+## WordPress Plugin Version
+
+Install:
+
+```txt
+omos-core-tools-v1.2.0-llm-gateway-app-bridge.zip
+```
+
+## Plugin Endpoints
+
+```txt
+/wp-json/omos/v1/status
+/wp-json/omos/v1/app-manifest
+/wp-json/omos/v1/tools
+/wp-json/omos/v1/submissions/stats
+/wp-json/omos/v1/llm/providers
+/wp-json/omos/v1/llm/models
+/wp-json/omos/v1/llm/chat
+/wp-json/omos/v1/llm/usage
+/wp-json/omos/v1/llm/logs
+```
+
+## Provider Layer
+
+The plugin admin screen supports:
+
+- OpenAI
+- Anthropic / Claude
+- Google Gemini
+- xAI / Grok
+- Mistral
+- Groq
+- OpenRouter
+- Perplexity
+- DeepSeek
+- Ollama / local models
+- Meta / Llama-compatible providers
+- Custom OpenAI-compatible providers
+
+## Security Rule
+
+Provider keys stay in WordPress admin settings. The OneGodian App calls OMOS through the app bridge using `X-OMOS-App-Key` from server-side code only.

--- a/docs/ONEGODIAN_APP_STRUCTURE_STANDARD.md
+++ b/docs/ONEGODIAN_APP_STRUCTURE_STANDARD.md
@@ -1,0 +1,179 @@
+# OneGodian App Structure Standard
+
+This is the baseline production structure for every OneGodian app, plugin, module, and bridge.
+
+Every OneGodian app must be usable in three ways:
+
+1. Public-facing page
+2. Logged-in dashboard
+3. Admin/control panel
+
+## 1. Public App Layer
+
+Required items:
+
+- Homepage or module landing page
+- About or purpose page
+- Feature overview
+- Public documentation
+- Pricing or access level, if applicable
+- Contact or support call to action
+
+## 2. Dashboard Layer
+
+Required items:
+
+- Main dashboard
+- System status cards
+- Quick actions
+- Recent activity
+- User/member profile
+- Notifications
+- Module navigation
+
+## 3. Admin Layer
+
+Required items:
+
+- Admin dashboard
+- Settings panel
+- API/app bridge settings
+- Key generation and rotation
+- User/member management
+- Submission management
+- Production checklist
+- Logs and audit trail
+
+## 4. API / Bridge Layer
+
+Required items:
+
+- Health endpoint
+- Manifest endpoint
+- Tool list endpoint
+- Stats endpoint
+- Secure REST endpoints
+- `X-OMOS-App-Key` support
+- Environment variable panel
+- Webhook support where needed
+
+## 5. Data Layer
+
+Required items:
+
+- Database schema
+- Submissions table
+- Users/members table
+- Settings table
+- Logs table
+- Certificates/records table, if applicable
+- Export/import support
+
+## 6. Security Layer
+
+Required items:
+
+- App key authentication
+- Role-based permissions
+- Nonce / CSRF protection
+- Input validation
+- Rate limiting
+- Audit logging
+- Secure Stripe/payment fallback where applicable
+
+## 7. UI / UX Layer
+
+Required items:
+
+- Consistent OneGodian branding
+- Admin cards and status badges
+- Sidebar navigation
+- Mobile-responsive layout
+- Icons for every module
+- Empty states
+- Success/error notices
+- Production readiness indicators
+
+## 8. Documentation Layer
+
+Required items:
+
+- README
+- Installation guide
+- Environment variable guide
+- API endpoint documentation
+- Admin usage guide
+- Production checklist
+- Changelog
+- Version history
+
+## 9. Compliance Layer
+
+Required items:
+
+- Terms notice
+- Privacy notice
+- Contributor/user disclaimer
+- Financial disclaimer if money is involved
+- Membership terms if users join
+- Intellectual property notice
+- Legal-safe public language
+
+## 10. Deployment Layer
+
+Required items:
+
+- `.env.example`
+- Build/test scripts
+- Syntax/lint checks
+- Version number
+- GitHub-ready structure
+- Hostinger/Vercel/WordPress deployment notes
+- Rollback instructions
+
+## Required Core Pages
+
+Every OneGodian app should include or intentionally map these routes:
+
+```txt
+/dashboard
+/ecosystem
+/registry
+/tools
+/members
+/certificates
+/products
+/media
+/settings
+/admin
+/api/health
+/api/manifest
+/api/tools
+/api/stats
+```
+
+## Required Plugin/Admin Screens
+
+Every OneGodian plugin or bridge should include these admin/control screens:
+
+- App Bridge
+- Dashboard
+- Settings
+- API Keys
+- Submissions
+- Tools
+- Status
+- Production Checklist
+- Documentation
+
+## Production Gate
+
+A OneGodian app, plugin, module, or bridge should not be treated as production-ready unless the following are true:
+
+- The public app layer is reachable.
+- The logged-in dashboard layer is usable.
+- The admin/control panel exists.
+- Health, manifest, tools, and stats endpoints are available.
+- Authentication, permissions, validation, and logging are implemented.
+- Documentation, environment variables, and deployment notes are included.
+- Compliance notices are present when the app involves members, money, data collection, certificates, submissions, or regulated claims.

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,0 +1,152 @@
+import { getOmosDashboardData } from '@/lib/omos-bridge';
+
+function StatusPill({ active, label }: { active: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-xs font-medium ${
+        active
+          ? 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200'
+          : 'border-amber-400/50 bg-amber-500/10 text-amber-200'
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ErrorBox({ title, error }: { title: string; error?: string }) {
+  return (
+    <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-4">
+      <h3 className="font-semibold text-red-200">{title}</h3>
+      <p className="mt-2 text-sm text-red-100/80">{error || 'Connection unavailable. Confirm the plugin is installed, the bridge is enabled, and the app key is set.'}</p>
+    </div>
+  );
+}
+
+export default async function OmosPage() {
+  const data = await getOmosDashboardData();
+  const providers = data.providers.data?.items || data.manifest.data?.llmGateway?.providers || [];
+  const tools = data.tools.data || [];
+  const gateway = data.manifest.data?.llmGateway;
+  const endpoints = data.manifest.data?.restEndpoints || gateway?.endpoints || [];
+
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6 sm:p-8">
+        <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">OMOS · ONEGODIAN APP BRIDGE</p>
+        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold sm:text-4xl">OMOS Bridge + LLM Gateway</h1>
+            <p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-300 sm:text-base">
+              Connected dashboard for the OMO / OMOS WordPress plugin, app manifest, tool registry, submission telemetry, and the secure multi-provider LLM gateway.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <StatusPill active={data.environment.hasBridgeKey} label={data.environment.hasBridgeKey ? 'App Key Set' : 'App Key Missing'} />
+            <StatusPill active={Boolean(gateway?.enabled)} label={gateway?.enabled ? 'LLM Gateway Enabled' : 'LLM Gateway Disabled'} />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">Plugin</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{data.status.data?.version || data.manifest.data?.version || 'Pending'}</h2>
+          <p className="mt-2 text-sm text-slate-300">OMOS Core Tools version detected from WordPress.</p>
+        </article>
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">Tools</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{tools.length}</h2>
+          <p className="mt-2 text-sm text-slate-300">Plugin tools available through the app bridge.</p>
+        </article>
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">Submissions</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{data.stats.data?.total ?? '—'}</h2>
+          <p className="mt-2 text-sm text-slate-300">Logged OMOS records and generator submissions.</p>
+        </article>
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">LLM Providers</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{gateway?.configuredProviders ?? providers.filter((p) => p.configured).length}</h2>
+          <p className="mt-2 text-sm text-slate-300">Configured providers available to OMOS.</p>
+        </article>
+      </section>
+
+      {(!data.status.ok || !data.manifest.ok) && (
+        <section className="grid gap-4 md:grid-cols-2">
+          {!data.status.ok && <ErrorBox title="Status endpoint unavailable" error={data.status.error} />}
+          {!data.manifest.ok && <ErrorBox title="Manifest endpoint unavailable" error={data.manifest.error} />}
+        </section>
+      )}
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold text-white">LLM Gateway Providers</h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-300">
+            Provider keys stay in WordPress. The OneGodian App uses the OMOS bridge key server-side and should never expose provider keys in the browser.
+          </p>
+          <div className="mt-4 grid gap-3">
+            {providers.length === 0 ? (
+              <p className="text-sm text-slate-400">Provider list pending. Install OMOS Core Tools v1.2.0 and enable the LLM Gateway.</p>
+            ) : (
+              providers.map((provider) => (
+                <div key={provider.slug} className="rounded-xl border border-slate-700 bg-slate-950/50 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="font-semibold text-slate-100">{provider.name}</h3>
+                    <StatusPill active={provider.configured} label={provider.configured ? 'Configured' : 'Needs Key'} />
+                  </div>
+                  <p className="mt-2 text-xs text-slate-400">{provider.slug} · {provider.type}</p>
+                  <p className="mt-1 text-xs text-slate-400">Model: {provider.model || 'Not set'}</p>
+                </div>
+              ))
+            )}
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold text-white">OMOS Tools</h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-300">Tool registry exposed from the WordPress plugin for app cards and future action workflows.</p>
+          <div className="mt-4 grid gap-3">
+            {tools.length === 0 ? (
+              <p className="text-sm text-slate-400">Tool list pending. Confirm /wp-json/omos/v1/tools is reachable.</p>
+            ) : (
+              tools.map((tool) => (
+                <div key={tool.slug || tool.id || tool.title || tool.name} className="rounded-xl border border-slate-700 bg-slate-950/50 p-4">
+                  <h3 className="font-semibold text-slate-100">{tool.title || tool.name || tool.slug}</h3>
+                  {tool.description && <p className="mt-2 text-sm text-slate-300">{tool.description}</p>}
+                  {tool.shortcode && <p className="mt-2 text-xs text-cyan-200">{tool.shortcode}</p>}
+                </div>
+              ))
+            )}
+          </div>
+        </article>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold text-white">Connection Settings</h2>
+          <dl className="mt-4 space-y-3 text-sm">
+            <div><dt className="text-slate-400">API Base URL</dt><dd className="break-all text-slate-100">{data.environment.apiBaseUrl}</dd></div>
+            <div><dt className="text-slate-400">Module Slug</dt><dd className="text-slate-100">{data.environment.moduleSlug}</dd></div>
+            <div><dt className="text-slate-400">Dashboard URL</dt><dd className="break-all text-slate-100">{data.environment.appDashboardUrl}</dd></div>
+            <div><dt className="text-slate-400">Default LLM Provider</dt><dd className="text-slate-100">{gateway?.defaultProvider || 'Not detected'}</dd></div>
+          </dl>
+        </article>
+
+        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold text-white">REST Endpoints</h2>
+          <div className="mt-4 space-y-2">
+            {endpoints.length === 0 ? (
+              <p className="text-sm text-slate-400">Manifest endpoints pending.</p>
+            ) : (
+              endpoints.map((endpoint) => (
+                <code key={endpoint} className="block break-all rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-xs text-cyan-100">
+                  {endpoint}
+                </code>
+              ))
+            )}
+          </div>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/src/app/api/omos/llm/chat/route.ts
+++ b/src/app/api/omos/llm/chat/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { postOmosEndpoint } from '@/lib/omos-bridge';
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const response = await postOmosEndpoint('/llm/chat', payload);
+
+  if (!response.ok) {
+    return NextResponse.json({ error: response.error || 'OMOS LLM gateway unavailable.' }, { status: 502 });
+  }
+
+  return NextResponse.json(response.data);
+}

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { gregorianToOT } from '@/lib/onegodian-time';
+
+const navItems = [
+  { label: 'Dashboard', href: '/' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'OMOS', href: '/omos' },
+  { label: 'Galaxy', href: '/galaxy' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Time', href: '/time' },
+  { label: 'OHI', href: '/ohi' },
+  { label: 'Algorithm', href: '/algorithm' },
+  { label: 'Assets', href: '/assets' },
+  { label: 'Economics', href: '/economics' }
+];
+
+function useLiveTimes() {
+  const [now, setNow] = useState<Date>(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const utc = now.toISOString();
+  const local = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  const ot = useMemo(() => gregorianToOT(now).display, [now]);
+
+  return { utc, local, ot };
+}
+
+export function AppFrame({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { utc, local, ot } = useLiveTimes();
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
+        <div className="flex items-center gap-3">
+          <div className="font-semibold text-cyan-300">OneGodian</div>
+          <div className="hidden text-xs text-slate-300 md:block">UTC {new Date(utc).toLocaleTimeString('en-US', { timeZone: 'UTC', hour: '2-digit', minute: '2-digit' })}</div>
+          <div className="hidden text-xs text-slate-300 md:block">OT {ot}</div>
+        </div>
+        <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <nav className="flex min-w-max items-center gap-2 pb-1" aria-label="Main navigation">
+            {navItems.map((item) => {
+              const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`inline-flex h-11 items-center rounded-full border px-4 text-sm transition ${
+                    active
+                      ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200'
+                      : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+        <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-300 sm:grid-cols-3">
+          <span>UTC: {utc}</span>
+          <span>Local: {local}</span>
+          <span>OT: {ot}</span>
+        </div>
+      </header>
+      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
+    </div>
+  );
+}

--- a/src/lib/app-modules.ts
+++ b/src/lib/app-modules.ts
@@ -1,0 +1,110 @@
+export type ProductionStatus =
+  | 'Live'
+  | 'Demo Ready'
+  | 'Staging'
+  | 'In Development'
+  | 'Needs Setup'
+  | 'Planned'
+  | 'Offline';
+
+export type Priority = 'Critical' | 'High' | 'Medium' | 'Low';
+
+export type AppModule = {
+  title: string;
+  slug: string;
+  route: string;
+  category: string;
+  description: string;
+  productionStatus: ProductionStatus;
+  priority: Priority;
+  iconKey: string;
+  features: string[];
+  checklist: string[];
+};
+
+export const appModules: AppModule[] = [
+  {
+    title: 'Dashboard',
+    slug: 'dashboard',
+    route: '/',
+    category: 'Command Hub',
+    productionStatus: 'Live',
+    priority: 'Critical',
+    iconKey: 'layout-dashboard',
+    description: 'Central operating view for app modules, priorities, and system status.',
+    features: ['Module overview', 'Production status', 'Quick access', 'Mobile app shell'],
+    checklist: ['Homepage live', 'Navigation active', 'Mobile layout active']
+  },
+  {
+    title: 'Ecosystem',
+    slug: 'ecosystem',
+    route: '/ecosystem',
+    category: 'System Directory',
+    productionStatus: 'Live',
+    priority: 'Critical',
+    iconKey: 'network',
+    description: 'Connected OneGodian platforms, domains, repositories, and deployment targets.',
+    features: ['Domain directory', 'Repo mapping', 'Deployment checklist', 'System detail pages'],
+    checklist: ['Ecosystem page live', 'System cards active', 'Detail pages pending']
+  },
+  {
+    title: 'OMOS Bridge',
+    slug: 'omos',
+    route: '/omos',
+    category: 'Protocol Layer',
+    productionStatus: 'In Development',
+    priority: 'Critical',
+    iconKey: 'brain-circuit',
+    description: 'OMO / OMOS plugin bridge, WordPress admin connection, tool manifest, health status, and app integration dashboard.',
+    features: ['Plugin health', 'App manifest', 'Tool list', 'Submission stats', 'Admin bridge settings', 'Production checklist'],
+    checklist: ['Install OMOS plugin v1.1.0', 'Generate bridge key in WordPress', 'Set app environment variables', 'Confirm REST bridge status']
+  },
+  {
+    title: 'Registry', slug: 'registry', route: '/registry', category: 'ODIN Index', productionStatus: 'In Development', priority: 'High', iconKey: 'database',
+    description: 'Registry categories for products, certificates, planets, systems, and official records.',
+    features: ['ODIN categories', 'Search', 'Record cards', 'Verification handoff'],
+    checklist: ['Registry shell active', 'Search pending', 'API sync pending']
+  },
+  {
+    title: 'Games', slug: 'games', route: '/games', category: 'Interactive Layer', productionStatus: 'Demo Ready', priority: 'High', iconKey: 'gamepad-2',
+    description: 'Interactive games, prize-room demos, and educational play modules.',
+    features: ['Bingo demo', 'Game library', 'History tab', 'Mobile gameplay'],
+    checklist: ['Games route needed', 'Bingo route needed', 'Backend multiplayer pending']
+  },
+  {
+    title: 'Planets', slug: 'planets', route: '/planets', category: 'Planetary Canon', productionStatus: 'Live', priority: 'High', iconKey: 'orbit',
+    description: 'OneGodian Galaxy™ planetary registry and world-building archive.',
+    features: ['Planet cards', 'Canon records', 'Realm summaries', 'Expansion map'],
+    checklist: ['Planet route live', 'Planet data active', 'Detail pages pending']
+  },
+  {
+    title: 'Tools', slug: 'tools', route: '/tools', category: 'Utilities', productionStatus: 'In Development', priority: 'High', iconKey: 'wrench',
+    description: 'Verification tools, time converters, calculators, and generators.',
+    features: ['Time converter', 'Verification lookup', 'Generators', 'System utilities'],
+    checklist: ['Tools shell active', 'Time tool active', 'Verification API pending']
+  },
+  {
+    title: 'Products', slug: 'products', route: '/products', category: 'Commerce Layer', productionStatus: 'In Development', priority: 'High', iconKey: 'shopping-bag',
+    description: 'Digital products, books, downloads, templates, and commercial offerings.',
+    features: ['Product cards', 'Store handoff', 'Digital downloads', 'Featured products'],
+    checklist: ['Product route active', 'Commerce integration pending']
+  },
+  {
+    title: 'Certificates', slug: 'certificates', route: '/certificates', category: 'Verification Layer', productionStatus: 'In Development', priority: 'Medium', iconKey: 'badge-check',
+    description: 'Certificates, badges, identity records, proof objects, and verification documents.',
+    features: ['Certificate cards', 'Badge records', 'Proof objects', 'Verification links'],
+    checklist: ['Certificate shell active', 'QR verification pending']
+  },
+  {
+    title: 'Media', slug: 'media', route: '/media', category: 'Media Center', productionStatus: 'Planned', priority: 'Medium', iconKey: 'image',
+    description: 'Visual assets, videos, brand files, launch visuals, and downloads.',
+    features: ['Image library', 'Video library', 'Brand assets', 'Download center'],
+    checklist: ['Media route pending', 'Asset library pending']
+  },
+  {
+    title: 'Profile', slug: 'profile', route: '/profile', category: 'User Layer', productionStatus: 'Planned', priority: 'Medium', iconKey: 'user',
+    description: 'User identity, access level, member status, preferences, and saved activity.',
+    features: ['Profile', 'Access level', 'Saved records', 'Member identity'],
+    checklist: ['Profile route pending', 'Auth pending']
+  }
+];

--- a/src/lib/ecosystem.ts
+++ b/src/lib/ecosystem.ts
@@ -1,0 +1,272 @@
+export type EcosystemCategory = 'infrastructure' | 'identity' | 'commerce' | 'governance' | 'education' | 'media';
+
+export type ProductionStatus = 'Live' | 'Staging' | 'In Development' | 'Needs Setup' | 'Offline' | 'Planned';
+
+export type Priority = 'Critical' | 'High' | 'Medium' | 'Low';
+
+export type EcosystemIconKey =
+  | 'identity'
+  | 'registry'
+  | 'commerce'
+  | 'infrastructure'
+  | 'api'
+  | 'education'
+  | 'time'
+  | 'media';
+
+export type EcosystemSystem = {
+  id: string;
+  slug: string;
+  title: string;
+  name: string;
+  category: EcosystemCategory;
+  iconKey: EcosystemIconKey;
+  productionStatus: ProductionStatus;
+  priority: Priority;
+  domain: string;
+  repo: string;
+  deploymentTarget: string;
+  publicUrl: string;
+  adminUrl: string;
+  apiHealthUrl: string;
+  lastCheckedLabel: string;
+  description: string;
+  productionChecklist: string[];
+  nextActions: string[];
+};
+
+export const PRODUCTION_STATUSES: ProductionStatus[] = ['Live', 'Staging', 'In Development', 'Needs Setup', 'Offline', 'Planned'];
+
+export const PRIORITIES: Priority[] = ['Critical', 'High', 'Medium', 'Low'];
+
+export const ECOSYSTEM_CATEGORIES: EcosystemCategory[] = ['infrastructure', 'identity', 'commerce', 'governance', 'education', 'media'];
+
+export const ONEGODIAN_ECOSYSTEM: EcosystemSystem[] = [
+  {
+    id: 'OG-ECO-01',
+    slug: 'onegodian-identity-engine',
+    title: 'OneGodian Identity Engine',
+    name: 'OneGodian Identity Engine',
+    category: 'identity',
+    iconKey: 'identity',
+    productionStatus: 'In Development',
+    priority: 'Critical',
+    domain: 'identity.quantumohi.com',
+    repo: 'ohi-stack/execution-interface',
+    deploymentTarget: 'Hostinger Node/Next.js runtime',
+    publicUrl: 'https://app.onegodian.com/profile',
+    adminUrl: 'https://app.onegodian.com/settings',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Manual review required before production lock',
+    description:
+      'Unified identity profiles, session trust, role-ready account surfaces, and OneGodian member identity controls for app.onegodian.com.',
+    productionChecklist: [
+      'Confirm authentication and account sessions',
+      'Validate profile route and identity data model',
+      'Connect membership roles to dashboard access',
+      'Document privacy and identity data handling'
+    ],
+    nextActions: [
+      'Wire identity records to the API gateway',
+      'Add member status indicators to dashboard cards',
+      'Create QR-V ready identity verification states'
+    ]
+  },
+  {
+    id: 'OG-ECO-02',
+    slug: 'odin-registry-core',
+    title: 'ODIN Registry Core',
+    name: 'ODIN Registry Core',
+    category: 'governance',
+    iconKey: 'registry',
+    productionStatus: 'Staging',
+    priority: 'Critical',
+    domain: 'app.onegodian.com/odin',
+    repo: 'ohi-stack/execution-interface',
+    deploymentTarget: 'Next.js App Router route group',
+    publicUrl: 'https://app.onegodian.com/odin',
+    adminUrl: 'https://app.onegodian.com/registry',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Route available; API synchronization pending',
+    description:
+      'Canonical registration, validation, indexing, and review surface for ODIN records across OneGodian systems.',
+    productionChecklist: [
+      'Confirm ODIN route renders on production domain',
+      'Connect registry data source to API gateway',
+      'Add immutable record export workflow',
+      'Add admin-only registry controls'
+    ],
+    nextActions: [
+      'Define ODIN schema for production records',
+      'Add record detail pages',
+      'Add status filters for registry entries'
+    ]
+  },
+  {
+    id: 'OG-ECO-03',
+    slug: 'capital-products-exchange',
+    title: 'Capital + Products Exchange',
+    name: 'Capital + Products Exchange',
+    category: 'commerce',
+    iconKey: 'commerce',
+    productionStatus: 'Needs Setup',
+    priority: 'High',
+    domain: 'onegodian.com',
+    repo: 'ohi-stack/execution-interface',
+    deploymentTarget: 'WooCommerce + Stripe commerce layer with app dashboard links',
+    publicUrl: 'https://app.onegodian.com/products',
+    adminUrl: 'https://onegodian.com/wp-admin',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Commerce integration not yet locked',
+    description:
+      'Commerce and product rails for digital products, certificates, memberships, licensing, and member-grade monetization.',
+    productionChecklist: [
+      'Confirm Stripe live mode products',
+      'Connect product catalog to app cards',
+      'Add checkout return and success states',
+      'Document fulfillment and certificate delivery flow'
+    ],
+    nextActions: [
+      'Map WooCommerce products to app modules',
+      'Add product status widgets',
+      'Create revenue summary card for dashboard'
+    ]
+  },
+  {
+    id: 'OG-ECO-04',
+    slug: 'planetary-infra-layer',
+    title: 'Planetary Infra Layer',
+    name: 'Planetary Infra Layer',
+    category: 'infrastructure',
+    iconKey: 'infrastructure',
+    productionStatus: 'In Development',
+    priority: 'Medium',
+    domain: 'galaxy.onegodian.com',
+    repo: 'ohi-stack/execution-interface',
+    deploymentTarget: 'Next.js planetary and moons routes',
+    publicUrl: 'https://app.onegodian.com/planets',
+    adminUrl: 'https://app.onegodian.com/moons-systems',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Static canon routes live; data API pending',
+    description:
+      'Operational infrastructure for planets, moon systems, orbital records, and cross-route canon data mirroring.',
+    productionChecklist: [
+      'Confirm planets route production rendering',
+      'Confirm moons and systems route production rendering',
+      'Normalize canon data into reusable library files',
+      'Add API-backed lookup for planetary records'
+    ],
+    nextActions: [
+      'Add detail pages for planets and moons',
+      'Add canon source references',
+      'Add ODIN-PR record linkage'
+    ]
+  },
+  {
+    id: 'OG-ECO-05',
+    slug: 'onegodian-api-gateway',
+    title: 'OneGodian API Gateway',
+    name: 'OneGodian API Gateway',
+    category: 'infrastructure',
+    iconKey: 'api',
+    productionStatus: 'Needs Setup',
+    priority: 'Critical',
+    domain: 'api.onegodian.org',
+    repo: 'ohi-stack/onegodian-api',
+    deploymentTarget: 'Hostinger Node.js Express service',
+    publicUrl: 'https://api.onegodian.org',
+    adminUrl: 'https://hpanel.hostinger.com',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Deployment target identified; production health pending',
+    description:
+      'Official OneGodian API gateway for health checks, registry endpoints, identity verification, commerce callbacks, and app data services.',
+    productionChecklist: [
+      'Deploy root Node server.js on Hostinger',
+      'Confirm /health returns JSON status',
+      'Configure CORS for app.onegodian.com',
+      'Add environment variables and secrets',
+      'Document restart and rollback procedure'
+    ],
+    nextActions: [
+      'Deploy API gateway to Hostinger',
+      'Connect app dashboard summary cards to health endpoint',
+      'Add uptime and last checked automation'
+    ]
+  },
+  {
+    id: 'OG-ECO-06',
+    slug: 'university-of-onegodian',
+    title: 'University of OneGodian',
+    name: 'University of OneGodian',
+    category: 'education',
+    iconKey: 'education',
+    productionStatus: 'Planned',
+    priority: 'High',
+    domain: 'u.onegodian.org',
+    repo: 'ohi-stack/execution-interface',
+    deploymentTarget: 'WordPress LMS + app dashboard integration',
+    publicUrl: 'https://u.onegodian.org',
+    adminUrl: 'https://u.onegodian.org/wp-admin',
+    apiHealthUrl: 'https://api.onegodian.org/health',
+    lastCheckedLabel: 'Content model ready; LMS production setup pending',
+    description:
+      'Education, courses, certifications, learning paths, and member development programs for the OneGodian ecosystem.',
+    productionChecklist: [
+      'Confirm LMS platform and course structure',
+      'Add course catalog and enrollment flow',
+      'Connect certificate issuance process',
+      'Create app links for active learners'
+    ],
+    nextActions: [
+      'Build LMS landing page',
+      'Create first certification path',
+      'Add learner dashboard widgets'
+    ]
+  },
+  {
+    id: 'OG-ECO-07',
+    slug: 'omos-plugin-bridge',
+    title: 'OMOS Plugin Bridge',
+    name: 'OMOS Plugin Bridge',
+    category: 'infrastructure',
+    iconKey: 'api',
+    productionStatus: 'In Development',
+    priority: 'Critical',
+    domain: 'onegodian.org/wp-json/omos/v1',
+    repo: 'omos-core-tools-v1.1.0-onegodian-app-bridge.zip + ohi-stack/execution-interface',
+    deploymentTarget: 'WordPress plugin REST bridge + Next.js app dashboard',
+    publicUrl: 'https://app.onegodian.com/omos',
+    adminUrl: 'https://onegodian.org/wp-admin/admin.php?page=omos-app-bridge',
+    apiHealthUrl: 'https://onegodian.org/wp-json/omos/v1/status',
+    lastCheckedLabel: 'Plugin package prepared; install and bridge key setup required',
+    description:
+      'Connects the OMO / OMOS WordPress plugin to the OneGodian App with status checks, app manifest, tool list, submission stats, and admin bridge configuration.',
+    productionChecklist: [
+      'Install OMOS Core Tools v1.1.0 OneGodian App Bridge plugin on WordPress',
+      'Open OMOS Tools → App Bridge and generate the bridge key',
+      'Set OMOS_API_BASE_URL and OMOS_APP_BRIDGE_KEY in the Next.js environment',
+      'Confirm /wp-json/omos/v1/status returns a valid response',
+      'Confirm /wp-json/omos/v1/app-manifest powers the app dashboard module',
+      'Restrict bridge key access to server-side calls only'
+    ],
+    nextActions: [
+      'Deploy app route /omos',
+      'Connect app-side API routes to the WordPress REST bridge',
+      'Display plugin health, manifest, tools, and submission stats in the dashboard',
+      'Add admin action links back to WordPress App Bridge settings'
+    ]
+  }
+];
+
+export function getEcosystemSystemBySlug(slug: string) {
+  return ONEGODIAN_ECOSYSTEM.find((system) => system.slug === slug);
+}
+
+export function getEcosystemSummary() {
+  return {
+    totalSystems: ONEGODIAN_ECOSYSTEM.length,
+    liveSystems: ONEGODIAN_ECOSYSTEM.filter((system) => system.productionStatus === 'Live').length,
+    criticalSystems: ONEGODIAN_ECOSYSTEM.filter((system) => system.priority === 'Critical').length,
+    needsSetup: ONEGODIAN_ECOSYSTEM.filter((system) => system.productionStatus === 'Needs Setup').length
+  };
+}

--- a/src/lib/omos-bridge.ts
+++ b/src/lib/omos-bridge.ts
@@ -15,6 +15,24 @@ export type OmosStatus = {
   [key: string]: unknown;
 };
 
+export type OmosProvider = {
+  slug: string;
+  name: string;
+  type: string;
+  configured: boolean;
+  hasApiKey?: boolean;
+  baseUrl?: string;
+  model?: string;
+};
+
+export type OmosLlmGateway = {
+  enabled?: boolean;
+  defaultProvider?: string;
+  configuredProviders?: number;
+  providers?: OmosProvider[];
+  endpoints?: string[];
+};
+
 export type OmosManifest = {
   name?: string;
   slug?: string;
@@ -22,7 +40,9 @@ export type OmosManifest = {
   app_url?: string;
   dashboard_url?: string;
   endpoints?: Record<string, string> | string[];
+  restEndpoints?: string[];
   tools?: unknown[];
+  llmGateway?: OmosLlmGateway;
   llm_providers?: string[];
   [key: string]: unknown;
 };
@@ -32,24 +52,39 @@ export type OmosSubmissionStats = {
   pending?: number;
   approved?: number;
   rejected?: number;
+  declaration?: number;
+  seal?: number;
+  mapper?: number;
   [key: string]: unknown;
 };
 
 export type OmosTool = {
   id?: string;
   name?: string;
+  title?: string;
   slug?: string;
   description?: string;
   endpoint?: string;
+  shortcode?: string;
   status?: string;
   provider?: string;
   [key: string]: unknown;
 };
 
+export type OmosProvidersResponse = {
+  items?: OmosProvider[];
+};
+
+export type OmosUsage = {
+  totalRequestsLogged?: number;
+  byProvider?: Record<string, number>;
+  lastRequest?: Record<string, unknown> | null;
+};
+
 const DEFAULT_BASE_URL = 'https://onegodian.org/wp-json/omos/v1';
 
 export function getOmosBaseUrl() {
-  return (process.env.OMOS_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+  return (process.env.OMOS_API_BASE_URL || process.env.OMOS_REST_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
 }
 
 export function getOmosEnvironmentSummary() {
@@ -61,11 +96,12 @@ export function getOmosEnvironmentSummary() {
   };
 }
 
-export async function fetchOmosEndpoint<T>(path: string): Promise<OmosBridgeResponse<T>> {
+export async function fetchOmosEndpoint<T>(path: string, init: RequestInit = {}): Promise<OmosBridgeResponse<T>> {
   const baseUrl = getOmosBaseUrl();
   const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
   const headers: HeadersInit = {
-    Accept: 'application/json'
+    Accept: 'application/json',
+    ...(init.headers || {})
   };
 
   if (process.env.OMOS_APP_BRIDGE_KEY) {
@@ -74,6 +110,7 @@ export async function fetchOmosEndpoint<T>(path: string): Promise<OmosBridgeResp
 
   try {
     const response = await fetch(url, {
+      ...init,
       headers,
       cache: 'no-store'
     });
@@ -97,19 +134,38 @@ export async function fetchOmosEndpoint<T>(path: string): Promise<OmosBridgeResp
   }
 }
 
+export async function postOmosEndpoint<T>(path: string, body: unknown): Promise<OmosBridgeResponse<T>> {
+  return fetchOmosEndpoint<T>(path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+function normalizeTools(data: OmosTool[] | { items?: OmosTool[] } | null) {
+  if (Array.isArray(data)) return data;
+  return data?.items || [];
+}
+
 export async function getOmosDashboardData() {
-  const [status, manifest, tools, stats] = await Promise.all([
+  const [status, manifest, tools, stats, providers, usage] = await Promise.all([
     fetchOmosEndpoint<OmosStatus>('/status'),
     fetchOmosEndpoint<OmosManifest>('/app-manifest'),
-    fetchOmosEndpoint<OmosTool[]>('/tools'),
-    fetchOmosEndpoint<OmosSubmissionStats>('/submissions/stats')
+    fetchOmosEndpoint<OmosTool[] | { items?: OmosTool[] }>('/tools'),
+    fetchOmosEndpoint<OmosSubmissionStats>('/submissions/stats'),
+    fetchOmosEndpoint<OmosProvidersResponse>('/llm/providers'),
+    fetchOmosEndpoint<OmosUsage>('/llm/usage')
   ]);
 
   return {
     environment: getOmosEnvironmentSummary(),
     status,
     manifest,
-    tools,
-    stats
+    tools: { ...tools, data: normalizeTools(tools.data) },
+    stats,
+    providers,
+    usage
   };
 }

--- a/src/lib/omos-bridge.ts
+++ b/src/lib/omos-bridge.ts
@@ -1,0 +1,115 @@
+export type OmosBridgeResponse<T> = {
+  ok: boolean;
+  data: T | null;
+  error?: string;
+};
+
+export type OmosStatus = {
+  status?: string;
+  plugin?: string;
+  version?: string;
+  site_url?: string;
+  app_url?: string;
+  module_slug?: string;
+  timestamp?: string;
+  [key: string]: unknown;
+};
+
+export type OmosManifest = {
+  name?: string;
+  slug?: string;
+  version?: string;
+  app_url?: string;
+  dashboard_url?: string;
+  endpoints?: Record<string, string> | string[];
+  tools?: unknown[];
+  llm_providers?: string[];
+  [key: string]: unknown;
+};
+
+export type OmosSubmissionStats = {
+  total?: number;
+  pending?: number;
+  approved?: number;
+  rejected?: number;
+  [key: string]: unknown;
+};
+
+export type OmosTool = {
+  id?: string;
+  name?: string;
+  slug?: string;
+  description?: string;
+  endpoint?: string;
+  status?: string;
+  provider?: string;
+  [key: string]: unknown;
+};
+
+const DEFAULT_BASE_URL = 'https://onegodian.org/wp-json/omos/v1';
+
+export function getOmosBaseUrl() {
+  return (process.env.OMOS_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+}
+
+export function getOmosEnvironmentSummary() {
+  return {
+    apiBaseUrl: getOmosBaseUrl(),
+    hasBridgeKey: Boolean(process.env.OMOS_APP_BRIDGE_KEY),
+    appDashboardUrl: process.env.OMOS_APP_DASHBOARD_URL || 'https://app.onegodian.com/omos',
+    moduleSlug: process.env.OMOS_MODULE_SLUG || 'omos'
+  };
+}
+
+export async function fetchOmosEndpoint<T>(path: string): Promise<OmosBridgeResponse<T>> {
+  const baseUrl = getOmosBaseUrl();
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+  const headers: HeadersInit = {
+    Accept: 'application/json'
+  };
+
+  if (process.env.OMOS_APP_BRIDGE_KEY) {
+    headers['X-OMOS-App-Key'] = process.env.OMOS_APP_BRIDGE_KEY;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers,
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        data: null,
+        error: `OMOS bridge returned ${response.status}`
+      };
+    }
+
+    const data = (await response.json()) as T;
+    return { ok: true, data };
+  } catch (error) {
+    return {
+      ok: false,
+      data: null,
+      error: error instanceof Error ? error.message : 'Unknown OMOS bridge error'
+    };
+  }
+}
+
+export async function getOmosDashboardData() {
+  const [status, manifest, tools, stats] = await Promise.all([
+    fetchOmosEndpoint<OmosStatus>('/status'),
+    fetchOmosEndpoint<OmosManifest>('/app-manifest'),
+    fetchOmosEndpoint<OmosTool[]>('/tools'),
+    fetchOmosEndpoint<OmosSubmissionStats>('/submissions/stats')
+  ]);
+
+  return {
+    environment: getOmosEnvironmentSummary(),
+    status,
+    manifest,
+    tools,
+    stats
+  };
+}

--- a/src/lib/omos-bridge.ts
+++ b/src/lib/omos-bridge.ts
@@ -99,10 +99,14 @@ export function getOmosEnvironmentSummary() {
 export async function fetchOmosEndpoint<T>(path: string, init: RequestInit = {}): Promise<OmosBridgeResponse<T>> {
   const baseUrl = getOmosBaseUrl();
   const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
-  const headers: HeadersInit = {
-    Accept: 'application/json',
-    ...(init.headers || {})
+  const headers: Record<string, string> = {
+    Accept: 'application/json'
   };
+
+  const incomingHeaders = new Headers(init.headers);
+  incomingHeaders.forEach((value, key) => {
+    headers[key] = value;
+  });
 
   if (process.env.OMOS_APP_BRIDGE_KEY) {
     headers['X-OMOS-App-Key'] = process.env.OMOS_APP_BRIDGE_KEY;


### PR DESCRIPTION
## Summary

Adds OMOS plugin support inside the OneGodian App.

## Changes

- Adds `/omos` dashboard page.
- Adds OMOS module to the app dashboard registry.
- Adds OMOS navigation item.
- Adds OMOS bridge client helpers.
- Adds server-side `/api/omos/llm/chat` route.
- Adds ecosystem entry for the OMOS Plugin Bridge.
- Adds integration documentation.

## Environment

```env
OMOS_REST_BASE_URL=https://onegodian.org/wp-json/omos/v1
OMOS_API_BASE_URL=https://onegodian.org/wp-json/omos/v1
OMOS_APP_BRIDGE_KEY=PASTE_GENERATED_KEY_HERE
OMOS_APP_DASHBOARD_URL=https://app.onegodian.com/omos
OMOS_MODULE_SLUG=omos
```

## Notes

A companion OMOS plugin ZIP was prepared with the secure multi-provider gateway and WordPress admin settings. Provider keys stay in WordPress and are never exposed in frontend code.

PHP syntax checks passed for the companion plugin files.