### PR TITLE
Add OneGodian app structure standard module scaffolding

### DIFF
--- a/docs/onegodian-app-structure-standard.md
+++ b/docs/onegodian-app-structure-standard.md
@@ -1,0 +1,31 @@
+# OneGodian App Structure Standard
+
+## Required module layers
+
+Every module is expected to support all layers below:
+
+1. Public Layer
+2. Dashboard Layer
+3. Admin Layer
+4. API Layer
+5. Data Layer
+6. Security Layer
+7. UI/UX Layer
+8. Documentation Layer
+9. Compliance Layer
+10. Deployment Layer
+
+## Enforcement policy
+
+- Do not ship isolated features.
+- If a layer is not implemented, create a stub, add a checklist item, or mark it as planned.
+- Update module registry, navigation, production status, and documentation references for each module intake.
+- A module is incomplete if it does not support public, dashboard, and admin access paths.
+
+## Validation gates
+
+Required checks before completion:
+
+- `npm run lint`
+- `npx tsc --noEmit`
+- `npm run build`

--- a/src/app/(admin)/admin/modules/app-structure/page.tsx
+++ b/src/app/(admin)/admin/modules/app-structure/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminAppStructureModulePage() {
+  return (
+    <section className="space-y-3">
+      <h1 className="text-2xl font-semibold text-slate-100">Admin: App Structure Standard</h1>
+      <p className="text-slate-300">Admin controls are planned. This stub exists to satisfy required cross-layer module coverage.</p>
+    </section>
+  );
+}

--- a/src/app/(app)/standards/app-structure/page.tsx
+++ b/src/app/(app)/standards/app-structure/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+
+const layers = [
+  'Public Layer',
+  'Dashboard Layer',
+  'Admin Layer',
+  'API Layer',
+  'Data Layer',
+  'Security Layer',
+  'UI/UX Layer',
+  'Documentation Layer',
+  'Compliance Layer',
+  'Deployment Layer'
+] as const;
+
+export default function OneGodianAppStructurePage() {
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.25em] text-cyan-300">OneGodian Standard</p>
+        <h1 className="text-3xl font-semibold text-slate-100">App Structure Standard</h1>
+        <p className="max-w-3xl text-slate-300">
+          Every module must include all ten layers. Missing layers must be marked as <strong>planned</strong>,
+          represented by a stub, or tracked with a checklist item before implementation is considered complete.
+        </p>
+      </header>
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {layers.map((layer, index) => (
+          <li key={layer} className="rounded-xl border border-slate-800 bg-slate-900/50 p-4 text-sm text-slate-200">
+            <span className="mr-2 text-cyan-300">{index + 1}.</span>
+            {layer}
+          </li>
+        ))}
+      </ul>
+
+      <div className="rounded-xl border border-cyan-700/40 bg-cyan-950/20 p-4 text-sm text-cyan-100">
+        Registry updates are required for module intake. Manage module status in{' '}
+        <code className="rounded bg-slate-900 px-2 py-1">src/lib/app-modules.ts</code> and publish supporting docs in{' '}
+        <code className="rounded bg-slate-900 px-2 py-1">docs/</code>.
+      </div>
+
+      <Link href="/docs" className="inline-flex rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 hover:border-cyan-400 hover:text-cyan-200">
+        Open docs index
+      </Link>
+    </section>
+  );
+}

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -19,6 +19,7 @@ const navItems = [
   { label: 'Algorithm', href: '/algorithm' },
   { label: 'Capital', href: '/capital' },
   { label: 'OMOS', href: '/omos' },
+  { label: 'Standards', href: '/standards/app-structure' },
   { label: 'Settings', href: '/settings' }
 ];
 

--- a/src/lib/app-modules.ts
+++ b/src/lib/app-modules.ts
@@ -248,5 +248,26 @@ export const appModules: AppModule[] = [
     readinessChecklist: { publicPage: true, dashboardView: true, adminView: false, apiRoute: true, dataModel: true, security: false, documentation: false, compliance: true, deployment: false },
     adminRoute: defaultAdminRoute('omos'),
     dashboardRoute: defaultDashboardRoute('omos')
-  }
+  },
+
+  {
+    title: 'App Structure Standard',
+    slug: 'app-structure-standard',
+    route: '/standards/app-structure',
+    category: 'Governance',
+    description: 'OneGodian App Core enforcement module that tracks 10-layer readiness requirements across public, dashboard, admin, API, data, security, UX, docs, compliance, and deployment.',
+    productionStatus: 'In Development',
+    priority: 'Critical',
+    iconKey: 'shield',
+    layer: 'governance',
+    features: ['Layer requirements', 'Checklist enforcement', 'Cross-layer stubs'],
+    checklist: ['Public page live', 'Admin stub live', 'API/data/security/compliance/deployment marked planned'],
+    access: { public: true, dashboard: true, admin: true },
+    api: { enabled: false, endpoints: ['/api/standards/app-structure'], status: 'stubbed' },
+    docs: { exists: true, path: '/docs/onegodian-runtime-standard.md', status: 'ready' },
+    readinessChecklist: { publicPage: true, dashboardView: true, adminView: true, apiRoute: false, dataModel: false, security: false, documentation: true, compliance: false, deployment: false },
+    adminRoute: '/admin/modules/app-structure',
+    dashboardRoute: defaultDashboardRoute('app-structure-standard')
+  },
+
 ];


### PR DESCRIPTION
### Motivation

- Establish and enforce a formal 10-layer OneGodian App Structure Standard so modules are never implemented as isolated features and must be evaluated across Public, Dashboard, and Admin access plus supporting layers.  
- Provide a minimal, cross-layer integration point (public + admin stub + registry entry) so the standard can be referenced in intake and governance workflows.  
- Surface the policy and validation gates in-app and in docs to make module readiness requirements discoverable and actionable.

### Description

- Add a public Standards page at `/standards/app-structure` implemented in `src/app/(app)/standards/app-structure/page.tsx` that lists the ten required layers and guidance on stubs/planned items.  
- Add an Admin-layer stub at `/admin/modules/app-structure` implemented in `src/app/(admin)/admin/modules/app-structure/page.tsx` so the module has admin/control coverage before full admin controls are built.  
- Register the new `app-structure-standard` module in the global registry `src/lib/app-modules.ts` with `public|dashboard|admin` access flags, `productionStatus: 'In Development'`, a stubbed API entry, readiness checklist markers (API/data/security/compliance/deployment set as planned/stubbed), and a docs linkage.  
- Expose the standard via the top navigation in `src/components/app-frame.tsx` and add documentation at `docs/onegodian-app-structure-standard.md` describing the enforcement policy and required validation gates.

### Testing

- Ran `npm run lint` and it completed with no ESLint warnings or errors.  
- Ran `npx tsc --noEmit` and TypeScript type checks passed.  
- Ran `npm run build` and Next.js produced a successful optimized production build with the new routes generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f880095660832d82c3574c6eed7d1a)