### PR TITLE
Fix ODIN pages: remove dead returns, restore `OdinPageLayout`, and clarify PaaP copy

### DIFF
--- a/src/app/(app)/odin/canon/page.tsx
+++ b/src/app/(app)/odin/canon/page.tsx
@@ -2,7 +2,6 @@ import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinCanonNotice } from '@/components/odin/OdinWidgets';
 
 export default function OdinCanonPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl'><OdinCanonNotice /></div></main>;
   return (
     <OdinPageLayout title='Canon & Authority'>
       <OdinCanonNotice />

--- a/src/app/(app)/odin/platforms/page.tsx
+++ b/src/app/(app)/odin/platforms/page.tsx
@@ -2,11 +2,15 @@ import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinLayerModel } from '@/components/odin/OdinWidgets';
 
 export default function OdinPlatformsPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl space-y-4'><OdinLayerModel /><p className='text-slate-300'>Standard buttons across ODIN-PR records: View Canon, Enter Planet, Visit Store.</p></div></main>;
   return (
     <OdinPageLayout title='PaaP™ — Planet-as-a-Platform'>
       <OdinLayerModel />
-      <p className='text-slate-300'>Definition: PaaP™ is the operational platform layer for each world. Standard actions remain View Canon, Enter Planet, and Visit Store.</p>
+      <section className='rounded-xl border border-slate-700 bg-slate-900/70 p-5 text-slate-200'>
+        <p>
+          Definition: PaaP™ is the operational platform layer for each world, distinct from canon registry records and commerce execution.
+        </p>
+        <p className='mt-3'>Standard actions remain View Canon, Enter Planet, and Visit Store.</p>
+      </section>
     </OdinPageLayout>
   );
 }

--- a/src/app/(app)/odin/verification/page.tsx
+++ b/src/app/(app)/odin/verification/page.tsx
@@ -2,7 +2,6 @@ import { OdinPageLayout } from '@/components/odin/OdinPageLayout';
 import { OdinVerificationPanel } from '@/components/odin/OdinWidgets';
 
 export default function OdinVerificationPage() {
-  return <main className='min-h-screen px-6 py-10'><div className='mx-auto max-w-4xl'><OdinVerificationPanel /></div></main>;
   return (
     <OdinPageLayout title='Verification & Provenance'>
       <OdinVerificationPanel />


### PR DESCRIPTION
### Motivation
- Ensure all ODIN routes render from the intended shared layout and remove unreachable duplicate return paths that could cause inconsistent page output.
- Clarify the PaaP™ (Planet-as-a-Platform) description to emphasize separation between canon, platform, and commerce layers.

### Description
- Removed unreachable inline return blocks and restored `OdinPageLayout` usage for the `/odin/canon` page in `src/app/(app)/odin/canon/page.tsx` so the title `Canon & Authority` and layout are applied.
- Removed unreachable inline return blocks and restored `OdinPageLayout` usage for the `/odin/verification` page in `src/app/(app)/odin/verification/page.tsx` so the title `Verification & Provenance` and layout are applied.
- Replaced the previous ad-hoc content in `src/app/(app)/odin/platforms/page.tsx` with a clarified PaaP™ content block that defines PaaP™ as the platform layer distinct from canon and commerce and keeps the `PaaP™ — Planet-as-a-Platform` title.

### Testing
- Ran `npm run build` (Next.js production build), which completed successfully and reported static page generation and optimization without errors.
- Confirmed the Next.js build output includes the required ODIN routes `
  /odin`, `/odin/series`, `/odin/planetary-registry`, `/odin/canon`, `/odin/verification`, `/odin/worlds`, and `/odin/platforms` as prerendered pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8920555a8832d9ae62309feb99e2a)