### PR TITLE
Add Postgres-backed scheduler store, migrations, and migration runner

### DIFF
--- a/db/migrations/001_create_scheduler_events.sql
+++ b/db/migrations/001_create_scheduler_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS scheduler_events (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  type TEXT NOT NULL DEFAULT 'standard',
+  status TEXT NOT NULL DEFAULT 'scheduled',
+
+  timestamp_utc TIMESTAMPTZ NOT NULL,
+  timestamp_local TEXT NOT NULL,
+  timezone TEXT NOT NULL,
+
+  duration_minutes INTEGER NOT NULL DEFAULT 60,
+  price_usd NUMERIC(12,2) NOT NULL DEFAULT 0,
+  payment_status TEXT NOT NULL DEFAULT 'not_required',
+
+  created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_time
+ON scheduler_events(timestamp_utc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "express": "^4.22.1",
         "lucide-react": "^1.14.0",
         "next": "^14.2.35",
+        "pg": "^8.20.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "uuid": "^14.0.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -4989,6 +4991,95 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5222,6 +5313,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/preact": {
       "version": "10.24.3",
@@ -5911,6 +6041,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -6713,6 +6852,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -6944,6 +7096,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "express": "^4.22.1",
     "lucide-react": "^1.14.0",
     "next": "^14.2.35",
+    "pg": "^8.20.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "uuid": "^14.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,26 @@
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { query } from '../src/db/postgres.js';
+import { ENV } from '../src/config/env.js';
+
+if (!ENV.ENABLE_DATABASE) {
+  console.log('Database disabled');
+  process.exit(0);
+}
+
+if (!ENV.DATABASE_URL) {
+  throw new Error('DATABASE_URL required');
+}
+
+const migrationsPath = path.resolve('db/migrations');
+const files = fs.readdirSync(migrationsPath).sort();
+
+for (const file of files) {
+  const sql = fs.readFileSync(path.join(migrationsPath, file), 'utf8');
+  console.log(`Running: ${file}`);
+  await query(sql);
+}
+
+console.log('Migrations complete');
+process.exit(0);

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,0 +1,1 @@
+export { ENV, CORS_ORIGINS } from './env.ts';

--- a/src/db/postgres.js
+++ b/src/db/postgres.js
@@ -1,0 +1,31 @@
+import pkg from 'pg';
+import { ENV } from '../config/env.js';
+
+const { Pool } = pkg;
+
+let pool;
+
+if (ENV.ENABLE_DATABASE) {
+  pool = new Pool({
+    connectionString: ENV.DATABASE_URL,
+    ssl: ENV.NODE_ENV === 'production'
+      ? { rejectUnauthorized: false }
+      : false
+  });
+}
+
+export async function query(text, params) {
+  if (!pool) throw new Error('database_not_enabled');
+  return pool.query(text, params);
+}
+
+export async function checkDatabase() {
+  if (!pool) return { enabled: false };
+
+  try {
+    await pool.query('SELECT 1');
+    return { enabled: true, ok: true };
+  } catch (err) {
+    return { enabled: true, ok: false };
+  }
+}

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { checkDatabase } from '../db/postgres.js';
+
+const router = express.Router();
+
+router.get('/ready', async (req, res) => {
+  const db = await checkDatabase();
+
+  res.json({
+    ok: db.ok ?? true,
+    database: db,
+    timekeeping: 'OTS-V5'
+  });
+});
+
+export default router;

--- a/src/storage/memory-scheduler-store.js
+++ b/src/storage/memory-scheduler-store.js
@@ -1,0 +1,52 @@
+const events = new Map();
+
+export async function listEvents(filters = {}) {
+  let all = Array.from(events.values());
+  if (filters.from) all = all.filter((e) => new Date(e.timestamp_utc) >= new Date(filters.from));
+  if (filters.to) all = all.filter((e) => new Date(e.timestamp_utc) <= new Date(filters.to));
+  if (filters.status) all = all.filter((e) => e.status === filters.status);
+  return all;
+}
+
+export async function getEvent(id) {
+  return events.get(id);
+}
+
+export async function createEvent(data) {
+  const id = `evt_mem_${Date.now()}`;
+  const row = {
+    id,
+    title: data.title,
+    description: data.description || '',
+    type: data.type || 'standard',
+    status: data.status || 'scheduled',
+    timestamp_utc: data.timestamp_utc,
+    timestamp_local: data.timestamp_local,
+    timezone: data.timezone,
+    duration_minutes: data.duration_minutes || 60,
+    price_usd: data.price_usd || 0,
+    payment_status: data.price_usd > 0 ? 'pending' : 'not_required',
+    created_at_utc: new Date().toISOString(),
+    updated_at_utc: new Date().toISOString(),
+    metadata: data.metadata || {}
+  };
+  events.set(id, row);
+  return row;
+}
+
+export async function updateEvent(id, data) {
+  const existing = events.get(id);
+  if (!existing) return null;
+  const updated = {
+    ...existing,
+    title: data.title ?? existing.title,
+    description: data.description ?? existing.description,
+    updated_at_utc: new Date().toISOString()
+  };
+  events.set(id, updated);
+  return updated;
+}
+
+export async function deleteEvent(id) {
+  return events.delete(id);
+}

--- a/src/storage/postgres-scheduler-store.js
+++ b/src/storage/postgres-scheduler-store.js
@@ -1,0 +1,77 @@
+import { query } from '../db/postgres.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export async function listEvents(filters = {}) {
+  let sql = 'SELECT * FROM scheduler_events WHERE 1=1';
+  const params = [];
+
+  if (filters.from) {
+    params.push(filters.from);
+    sql += ` AND timestamp_utc >= $${params.length}`;
+  }
+
+  if (filters.to) {
+    params.push(filters.to);
+    sql += ` AND timestamp_utc <= $${params.length}`;
+  }
+
+  if (filters.status) {
+    params.push(filters.status);
+    sql += ` AND status = $${params.length}`;
+  }
+
+  const res = await query(sql, params);
+  return res.rows;
+}
+
+export async function getEvent(id) {
+  const res = await query(
+    'SELECT * FROM scheduler_events WHERE id = $1',
+    [id]
+  );
+  return res.rows[0];
+}
+
+export async function createEvent(data) {
+  const id = `evt_${uuidv4()}`;
+
+  const res = await query(`
+    INSERT INTO scheduler_events (
+      id, title, description, type, status,
+      timestamp_utc, timestamp_local, timezone,
+      duration_minutes, price_usd, payment_status
+    )
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+    RETURNING *
+  `, [
+    id,
+    data.title,
+    data.description || '',
+    data.type || 'standard',
+    data.status || 'scheduled',
+    data.timestamp_utc,
+    data.timestamp_local,
+    data.timezone,
+    data.duration_minutes || 60,
+    data.price_usd || 0,
+    data.price_usd > 0 ? 'pending' : 'not_required'
+  ]);
+
+  return res.rows[0];
+}
+
+export async function updateEvent(id, data) {
+  const res = await query(`
+    UPDATE scheduler_events
+    SET title=$2, description=$3, updated_at_utc=NOW()
+    WHERE id=$1
+    RETURNING *
+  `, [id, data.title, data.description]);
+
+  return res.rows[0];
+}
+
+export async function deleteEvent(id) {
+  await query('DELETE FROM scheduler_events WHERE id=$1', [id]);
+  return true;
+}

--- a/src/storage/scheduler-store.js
+++ b/src/storage/scheduler-store.js
@@ -1,0 +1,12 @@
+import { ENV } from '../config/env.js';
+
+import * as memory from './memory-scheduler-store.js';
+import * as postgres from './postgres-scheduler-store.js';
+
+const store = ENV.ENABLE_DATABASE ? postgres : memory;
+
+export const listEvents = store.listEvents;
+export const getEvent = store.getEvent;
+export const createEvent = store.createEvent;
+export const updateEvent = store.updateEvent;
+export const deleteEvent = store.deleteEvent;


### PR DESCRIPTION
### Motivation
- Provide durable scheduler event storage with a Postgres-backed implementation that can be toggled via environment variables to replace the in-memory store. 
- Ship SQL migration and a simple runner so deployments can create the `scheduler_events` table and index in a repeatable way. 
- Expose database readiness on health checks so orchestration tooling can observe DB connectivity status. 

### Description
- Add a Postgres connection helper with env-gated pool initialization, a shared `query` helper, and `checkDatabase()` readiness check in `src/db/postgres.js`. 
- Add the `scheduler_events` SQL migration with UTC timestamp columns and an index on `timestamp_utc` at `db/migrations/001_create_scheduler_events.sql`. 
- Add a migration runner `scripts/migrate.js` that executes sorted SQL files from `db/migrations` if `ENV.ENABLE_DATABASE` is enabled. 
- Implement a Postgres scheduler store (`src/storage/postgres-scheduler-store.js`) with `listEvents`, `getEvent`, `createEvent`, `updateEvent`, and `deleteEvent` and UUID-based event IDs, plus an in-memory fallback store (`src/storage/memory-scheduler-store.js`). 
- Add a storage switcher `src/storage/scheduler-store.js` that selects Postgres or memory based on `ENV.ENABLE_DATABASE`. 
- Add a health route module (`src/routes/health.js`) exposing `/ready` that returns DB readiness and the `OTS-V5` timekeeping marker. 
- Export the typed env bridge in `src/config/env.js` and add required dependencies (`pg`, `uuid`) to `package.json`. 

### Testing
- Ran `npm install pg uuid` successfully to add runtime dependencies. 
- Ran `npm run check` which failed due to a pre-existing duplicate `express` declaration in `server.js` unrelated to these new modules. 
- The migration runner is gated by `ENV.ENABLE_DATABASE`, so migrations were not executed in the default environment during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89ee0f670832db75f7a318b31d5d4)