### PR TITLE
Add OneGodian ID Card frontend module with API-fallback mocks

### DIFF
--- a/src/app/(admin)/admin/id-cards/page.tsx
+++ b/src/app/(admin)/admin/id-cards/page.tsx
@@ -1,0 +1,29 @@
+import { OneGodianIdComplianceNotice } from "@/components/id-card/OneGodianIdComplianceNotice";
+import { OneGodianIdStatusBadge } from "@/components/id-card/OneGodianIdStatusBadge";
+import { getOneGodianIdAdminRows, getOneGodianIdStats } from "@/lib/id-card/client";
+
+export default async function OneGodianIdCardsAdminPage() {
+  const [rows, stats] = await Promise.all([getOneGodianIdAdminRows(), getOneGodianIdStats()]);
+  const statCards = [
+    ["Total Records", stats.total],
+    ["Active", stats.active],
+    ["Pending", stats.pending],
+    ["Needs Update", stats.needsUpdate],
+    ["Revoked", stats.revoked],
+    ["Expired", stats.expired],
+  ];
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-white sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 shadow-2xl shadow-black/20 sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.3em] text-cyan-200">Admin Console</p>
+          <h1 className="mt-3 text-4xl font-black tracking-tight">OneGodian ID Card Records</h1>
+        </section>
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-6">{statCards.map(([label, value]) => <div key={label} className="rounded-3xl border border-white/10 bg-white/[0.04] p-5"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">{label}</p><p className="mt-3 text-3xl font-black text-white">{value}</p></div>)}</section>
+        <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.04] shadow-2xl shadow-black/20"><div className="overflow-x-auto"><table className="min-w-full divide-y divide-white/10 text-left text-sm"><thead className="bg-white/[0.04] text-xs uppercase tracking-[0.2em] text-slate-400"><tr><th className="px-5 py-4">Member</th><th className="px-5 py-4">Member ID</th><th className="px-5 py-4">Status</th><th className="px-5 py-4">Issued</th><th className="px-5 py-4">Verification</th><th className="px-5 py-4">Actions</th></tr></thead><tbody className="divide-y divide-white/10">{rows.map((row) => <tr key={row.id} className="align-top"><td className="px-5 py-5 font-semibold text-white">{row.displayName}</td><td className="px-5 py-5 text-slate-300">{row.memberId}</td><td className="px-5 py-5"><OneGodianIdStatusBadge status={row.status} /></td><td className="px-5 py-5 text-slate-300"><p>{row.issueDateGregorian || "Pending"}</p><p className="text-xs text-cyan-200">{row.issueDateOT || "OT pending"}</p></td><td className="px-5 py-5">{row.verificationUrl ? <a href={row.verificationUrl} target="_blank" rel="noreferrer" className="break-all text-cyan-200 underline underline-offset-4">{row.qrvRecordId}</a> : <span className="text-slate-400">Pending</span>}</td><td className="px-5 py-5"><div className="flex flex-wrap gap-2">{["Approve", "Pending", "Revoke", "Regenerate"].map((action) => <button key={action} type="button" className="rounded-full border border-white/10 px-3 py-2 text-xs font-bold text-slate-200 transition hover:border-cyan-300/40 hover:bg-cyan-300/10">{action}</button>)}</div></td></tr>)}</tbody></table></div></section>
+        <OneGodianIdComplianceNotice />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/dashboard/id-card/page.tsx
+++ b/src/app/(app)/dashboard/id-card/page.tsx
@@ -1,0 +1,32 @@
+import { OneGodianIdActions } from "@/components/id-card/OneGodianIdActions";
+import { OneGodianIdCardPreview } from "@/components/id-card/OneGodianIdCardPreview";
+import { OneGodianIdComplianceNotice } from "@/components/id-card/OneGodianIdComplianceNotice";
+import { OneGodianIdStatusBadge } from "@/components/id-card/OneGodianIdStatusBadge";
+import { getOneGodianIdCardStatus } from "@/lib/id-card/client";
+
+export default async function OneGodianIdDashboardPage() {
+  const record = await getOneGodianIdCardStatus();
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-white sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 shadow-2xl shadow-black/20 sm:p-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.3em] text-cyan-200">Member Dashboard</p>
+              <h1 className="mt-3 text-4xl font-black tracking-tight">My OneGodian ID Card</h1>
+              <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-300">
+                View your credential status, verification record, issue dates, and available member actions.
+              </p>
+            </div>
+            <OneGodianIdStatusBadge status={record.status} />
+          </div>
+        </section>
+        <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <OneGodianIdCardPreview record={record} />
+          <div className="space-y-6"><OneGodianIdActions record={record} /><OneGodianIdComplianceNotice /></div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/id-card/page.tsx
+++ b/src/app/(app)/id-card/page.tsx
@@ -1,0 +1,34 @@
+import { OneGodianIdComplianceNotice } from "@/components/id-card/OneGodianIdComplianceNotice";
+import { OneGodianIdHero } from "@/components/id-card/OneGodianIdHero";
+import { OneGodianIdCardPreview } from "@/components/id-card/OneGodianIdCardPreview";
+import { mockOneGodianIdRecord } from "@/lib/id-card/mock";
+
+export default function OneGodianIdCardPublicPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-white sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <OneGodianIdHero />
+        <section className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="space-y-5">
+            <h2 className="text-3xl font-black tracking-tight">Tangible identity. Verified record. Institutional clarity.</h2>
+            <p className="text-base leading-8 text-slate-300">
+              The OneGodian ID Card is designed as a bridge between personal belief identity, internal membership records, and verifiable digital credential infrastructure.
+            </p>
+            <div className="grid gap-4">
+              {[
+                "Documents sincerely held belief identity",
+                "Supports internal membership affiliation",
+                "Connects to QR-V verification records",
+                "Maintains clear institutional-safe language",
+              ].map((item) => (
+                <div key={item} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm font-semibold text-slate-100">{item}</div>
+              ))}
+            </div>
+            <OneGodianIdComplianceNotice />
+          </div>
+          <OneGodianIdCardPreview record={mockOneGodianIdRecord} />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/id-card/OneGodianIdActions.tsx
+++ b/src/components/id-card/OneGodianIdActions.tsx
@@ -1,0 +1,45 @@
+import type { OneGodianIdCardRecord } from "@/lib/id-card/types";
+
+export function OneGodianIdActions({
+  record,
+}: {
+  record: OneGodianIdCardRecord;
+}) {
+  const actions = [
+    {
+      label: "View ID",
+      href: `/dashboard/id-card`,
+      description: "Review your active OneGodian ID Card record.",
+    },
+    {
+      label: "Request Update",
+      href: `/dashboard/id-card?mode=update`,
+      description: "Submit a request to update your credential information.",
+    },
+    {
+      label: "Download / Print",
+      href: `/dashboard/id-card?mode=print`,
+      description: "Prepare a printable version after approval.",
+    },
+    {
+      label: "Verify QR-V Record",
+      href: record.verificationUrl || "#",
+      description: "Open public verification record.",
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {actions.map((action) => (
+        <a
+          key={action.label}
+          href={action.href}
+          className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 transition hover:border-cyan-300/40 hover:bg-cyan-300/10"
+        >
+          <p className="font-bold text-white">{action.label}</p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">{action.description}</p>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/components/id-card/OneGodianIdCardPreview.tsx
+++ b/src/components/id-card/OneGodianIdCardPreview.tsx
@@ -1,0 +1,99 @@
+import type { OneGodianIdCardRecord } from "@/lib/id-card/types";
+import { OneGodianIdStatusBadge } from "./OneGodianIdStatusBadge";
+
+export function OneGodianIdCardPreview({
+  record,
+}: {
+  record: OneGodianIdCardRecord;
+}) {
+  return (
+    <article className="relative overflow-hidden rounded-[2rem] border border-cyan-300/20 bg-slate-950 p-6 shadow-2xl shadow-cyan-950/30">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.25),transparent_35%),radial-gradient(circle_at_bottom_right,rgba(245,158,11,0.16),transparent_35%)]" />
+
+      <div className="relative z-10">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.28em] text-cyan-200">
+              OneGodian ID Card™
+            </p>
+            <h2 className="mt-2 text-2xl font-black tracking-tight text-white">
+              {record.displayName}
+            </h2>
+            <p className="mt-1 text-sm text-slate-300">{record.memberId}</p>
+          </div>
+
+          <OneGodianIdStatusBadge status={record.status} />
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+              Identity Statement
+            </p>
+            <p className="mt-2 text-sm font-medium text-white">
+              {record.identityStatement}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+              Issuer
+            </p>
+            <p className="mt-2 text-sm font-medium text-white">
+              {record.issuer}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+              Issue Date
+            </p>
+            <p className="mt-2 text-sm font-medium text-white">
+              {record.issueDateGregorian || "Pending"}
+            </p>
+            <p className="mt-1 text-xs text-cyan-200">
+              {record.issueDateOT || "OT date pending"}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+              Verification
+            </p>
+            <p className="mt-2 break-all text-sm font-medium text-white">
+              {record.qrvRecordId || "QR-V pending"}
+            </p>
+            <p className="mt-1 break-all text-xs text-cyan-200">
+              {record.obp1RecordId || "OBP-1 pending"}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="h-24 w-24 rounded-2xl border border-white/20 bg-white p-3 text-center text-[10px] font-black uppercase text-slate-950">
+            QR-V
+            <br />
+            Scan
+            <br />
+            Code
+          </div>
+
+          {record.verificationUrl ? (
+            <a
+              href={record.verificationUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-5 py-3 text-center text-sm font-bold text-cyan-100 transition hover:bg-cyan-300/20"
+            >
+              Verify QR-V Record
+            </a>
+          ) : (
+            <span className="rounded-full border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-400">
+              Verification Pending
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/id-card/OneGodianIdComplianceNotice.tsx
+++ b/src/components/id-card/OneGodianIdComplianceNotice.tsx
@@ -1,0 +1,10 @@
+import { oneGodianIdComplianceText } from "@/lib/id-card/mock";
+
+export function OneGodianIdComplianceNotice() {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 text-sm leading-6 text-slate-300 shadow-2xl shadow-black/20">
+      <p className="font-semibold text-white">Compliance Notice</p>
+      <p className="mt-2">{oneGodianIdComplianceText}</p>
+    </section>
+  );
+}

--- a/src/components/id-card/OneGodianIdHero.tsx
+++ b/src/components/id-card/OneGodianIdHero.tsx
@@ -1,0 +1,32 @@
+export function OneGodianIdHero() {
+  return (
+    <section className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950 px-6 py-14 shadow-2xl shadow-black/30 sm:px-10">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(34,211,238,0.25),transparent_30%),radial-gradient(circle_at_80%_10%,rgba(245,158,11,0.18),transparent_30%),linear-gradient(135deg,rgba(15,23,42,1),rgba(8,47,73,0.82),rgba(15,23,42,1))]" />
+
+      <div className="relative z-10 grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.35em] text-cyan-200">
+            OneGodian Identity Infrastructure
+          </p>
+          <h1 className="mt-4 max-w-4xl text-4xl font-black tracking-tight text-white sm:text-6xl">OneGodian ID Card™</h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-200">
+            A supplemental religious identity credential for documenting sincerely held belief identity, internal membership affiliation, and QR-V verification inside the OneGodian ecosystem.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a href="/dashboard/id-card" className="rounded-full bg-cyan-300 px-6 py-3 text-center text-sm font-black text-slate-950 transition hover:bg-cyan-200">Open My ID Card</a>
+            <a href="/admin/id-cards" className="rounded-full border border-white/20 px-6 py-3 text-center text-sm font-bold text-white transition hover:bg-white/10">Admin Console</a>
+          </div>
+        </div>
+
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-5">
+          <p className="text-sm font-bold uppercase tracking-[0.25em] text-amber-200">Credential Role</p>
+          <dl className="mt-5 space-y-4 text-sm">
+            <div><dt className="text-slate-400">Legal Position</dt><dd className="mt-1 font-semibold text-white">Sincerely held belief documentation</dd></div>
+            <div><dt className="text-slate-400">Institutional Role</dt><dd className="mt-1 font-semibold text-white">Supplemental identity credential</dd></div>
+            <div><dt className="text-slate-400">Verification Layer</dt><dd className="mt-1 font-semibold text-white">QR-V / OBP-1 ready</dd></div>
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/id-card/OneGodianIdStatusBadge.tsx
+++ b/src/components/id-card/OneGodianIdStatusBadge.tsx
@@ -1,0 +1,33 @@
+import type { OneGodianIdCardStatus } from "@/lib/id-card/types";
+
+const statusLabels: Record<OneGodianIdCardStatus, string> = {
+  not_requested: "Not Requested",
+  pending: "Pending Review",
+  active: "Active",
+  needs_update: "Needs Update",
+  revoked: "Revoked",
+  expired: "Expired",
+};
+
+const statusClasses: Record<OneGodianIdCardStatus, string> = {
+  not_requested: "border-slate-500/30 bg-slate-900/70 text-slate-200",
+  pending: "border-amber-400/40 bg-amber-950/40 text-amber-200",
+  active: "border-emerald-400/40 bg-emerald-950/40 text-emerald-200",
+  needs_update: "border-sky-400/40 bg-sky-950/40 text-sky-200",
+  revoked: "border-red-400/40 bg-red-950/40 text-red-200",
+  expired: "border-zinc-400/40 bg-zinc-950/40 text-zinc-200",
+};
+
+export function OneGodianIdStatusBadge({
+  status,
+}: {
+  status: OneGodianIdCardStatus;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide ${statusClasses[status]}`}
+    >
+      {statusLabels[status]}
+    </span>
+  );
+}

--- a/src/lib/id-card/client.ts
+++ b/src/lib/id-card/client.ts
@@ -1,0 +1,61 @@
+import {
+  mockOneGodianIdAdminRows,
+  mockOneGodianIdRecord,
+  mockOneGodianIdStats,
+} from "./mock";
+import type {
+  OneGodianIdAdminRow,
+  OneGodianIdCardRecord,
+  OneGodianIdCardStats,
+} from "./types";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_ONEGODIAN_API_URL?.replace(/\/$/, "") || "";
+
+async function safeJsonFetch<T>(path: string, fallback: T): Promise<T> {
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) return fallback;
+
+    const data = (await response.json()) as T;
+    return data;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function getOneGodianIdCardStatus(): Promise<OneGodianIdCardRecord> {
+  return safeJsonFetch<OneGodianIdCardRecord>(
+    "/api/id-card/status",
+    mockOneGodianIdRecord,
+  );
+}
+
+export async function getOneGodianIdCardByMemberId(
+  memberId: string,
+): Promise<OneGodianIdCardRecord> {
+  return safeJsonFetch<OneGodianIdCardRecord>(
+    `/api/id-card/${encodeURIComponent(memberId)}`,
+    mockOneGodianIdRecord,
+  );
+}
+
+export async function getOneGodianIdAdminRows(): Promise<OneGodianIdAdminRow[]> {
+  return safeJsonFetch<OneGodianIdAdminRow[]>(
+    "/api/id-card/admin",
+    mockOneGodianIdAdminRows,
+  );
+}
+
+export async function getOneGodianIdStats(): Promise<OneGodianIdCardStats> {
+  return safeJsonFetch<OneGodianIdCardStats>(
+    "/api/id-card/admin/stats",
+    mockOneGodianIdStats,
+  );
+}

--- a/src/lib/id-card/mock.ts
+++ b/src/lib/id-card/mock.ts
@@ -1,0 +1,69 @@
+import type {
+  OneGodianIdAdminRow,
+  OneGodianIdCardRecord,
+  OneGodianIdCardStats,
+} from "./types";
+
+export const oneGodianIdComplianceText =
+  "The OneGodian ID Card is a voluntary religious identity credential issued for internal membership, sincerely held belief documentation, and verification purposes. It does not replace government-issued identification and does not assert exemption from civil law.";
+
+export const mockOneGodianIdRecord: OneGodianIdCardRecord = {
+  id: "ogid_000000001",
+  memberId: "INO-M-000-000-001",
+  displayName: "One Gregory Onegodian™",
+  identityStatement:
+    "OneGodian: related to, resembling, and belonging to One God.",
+  issuer: "Indigenous Nation of Onegodia",
+  credentialType: "supplemental_religious_identity_credential",
+  status: "active",
+  issueDateGregorian: "May 4, 2026",
+  issueDateOT: "Wisdom 18, 0001 OT",
+  expirationDateGregorian: "May 4, 2027",
+  expirationDateOT: "Wisdom 18, 0002 OT",
+  qrvRecordId: "QRV-OGID-000000001",
+  obp1RecordId: "OBP1-OGID-000000001",
+  verificationUrl: "https://verify.qrv.network/QRV-OGID-000000001",
+  registryUrl: "https://registry.qrv.network/QRV-OGID-000000001",
+  createdAt: "2026-05-04T00:00:00.000Z",
+  updatedAt: "2026-05-04T00:00:00.000Z",
+};
+
+export const mockOneGodianIdStats: OneGodianIdCardStats = {
+  total: 7,
+  active: 3,
+  pending: 2,
+  needsUpdate: 1,
+  revoked: 1,
+  expired: 0,
+};
+
+export const mockOneGodianIdAdminRows: OneGodianIdAdminRow[] = [
+  mockOneGodianIdRecord,
+  {
+    ...mockOneGodianIdRecord,
+    id: "ogid_000000002",
+    memberId: "INO-M-000-000-002",
+    displayName: "Member Example Two",
+    status: "pending",
+    qrvRecordId: "QRV-OGID-000000002",
+    verificationUrl: "https://verify.qrv.network/QRV-OGID-000000002",
+  },
+  {
+    ...mockOneGodianIdRecord,
+    id: "ogid_000000003",
+    memberId: "INO-M-000-000-003",
+    displayName: "Member Example Three",
+    status: "needs_update",
+    qrvRecordId: "QRV-OGID-000000003",
+    verificationUrl: "https://verify.qrv.network/QRV-OGID-000000003",
+  },
+  {
+    ...mockOneGodianIdRecord,
+    id: "ogid_000000004",
+    memberId: "INO-M-000-000-004",
+    displayName: "Member Example Four",
+    status: "revoked",
+    qrvRecordId: "QRV-OGID-000000004",
+    verificationUrl: "https://verify.qrv.network/QRV-OGID-000000004",
+  },
+];

--- a/src/lib/id-card/navigation.ts
+++ b/src/lib/id-card/navigation.ts
@@ -1,0 +1,28 @@
+export const oneGodianIdNavigationItems = [
+  {
+    label: "OneGodian ID Card",
+    href: "/id-card",
+    group: "Public",
+    description: "Supplemental religious identity credential overview.",
+  },
+  {
+    label: "My ID Card",
+    href: "/dashboard/id-card",
+    group: "Dashboard",
+    description: "View, request, update, print, or verify your ID card.",
+  },
+  {
+    label: "ID Card Admin",
+    href: "/admin/id-cards",
+    group: "Admin",
+    description: "Manage OneGodian ID Card records and verification status.",
+  },
+];
+
+export const oneGodianIdToolCard = {
+  title: "OneGodian ID Card",
+  href: "/dashboard/id-card",
+  status: "Ready to Build",
+  description:
+    "A member-facing identity credential module with QR-V verification and institutional-safe compliance language.",
+};

--- a/src/lib/id-card/types.ts
+++ b/src/lib/id-card/types.ts
@@ -1,0 +1,47 @@
+export type OneGodianIdCardStatus =
+  | "not_requested"
+  | "pending"
+  | "active"
+  | "needs_update"
+  | "revoked"
+  | "expired";
+
+export type OneGodianIdCredentialType =
+  | "supplemental_religious_identity_credential";
+
+export type OneGodianIdCardRecord = {
+  id: string;
+  memberId: string;
+  displayName: string;
+  identityStatement: string;
+  issuer: "Indigenous Nation of Onegodia";
+  credentialType: OneGodianIdCredentialType;
+  status: OneGodianIdCardStatus;
+  issueDateGregorian?: string;
+  issueDateOT?: string;
+  expirationDateGregorian?: string;
+  expirationDateOT?: string;
+  qrvRecordId?: string;
+  obp1RecordId?: string;
+  verificationUrl?: string;
+  registryUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type OneGodianIdCardStats = {
+  total: number;
+  active: number;
+  pending: number;
+  needsUpdate: number;
+  revoked: number;
+  expired: number;
+};
+
+export type OneGodianIdAdminRow = OneGodianIdCardRecord;
+
+export type IdCardAction =
+  | "view"
+  | "request_update"
+  | "download_print"
+  | "verify_qrv";


### PR DESCRIPTION
### Motivation
- Provide a drop-in App Router frontend module for the OneGodian ID Card so the UI can be integrated before backend endpoints are ready. 
- Ensure pages and components remain usable during development by providing mock data and a client that gracefully falls back when `/api/id-card/*` routes are unavailable. 
- Export navigation metadata so the new pages can be wired into the app shell and developer tooling easily.

### Description
- Add strongly typed domain models in `src/lib/id-card/types.ts` including `OneGodianIdCardRecord`, `OneGodianIdCardStats`, and `OneGodianIdCardStatus` enums. 
- Add seeded mock data in `src/lib/id-card/mock.ts` and a mock-safe client in `src/lib/id-card/client.ts` that uses `safeJsonFetch` to call `/api/id-card/*` and return mocks on network or HTTP failure. 
- Add reusable UI components under `src/components/id-card/` (`OneGodianIdCardPreview`, `OneGodianIdStatusBadge`, `OneGodianIdHero`, `OneGodianIdComplianceNotice`, `OneGodianIdActions`) to compose previews, badges, hero, compliance text, and action tiles. 
- Add App Router pages for public, member, and admin flows at `src/app/(app)/id-card/page.tsx`, `src/app/(app)/dashboard/id-card/page.tsx`, and `src/app/(admin)/admin/id-cards/page.tsx`, plus exported nav metadata in `src/lib/id-card/navigation.ts` and an environment-driven API base via `NEXT_PUBLIC_ONEGODIAN_API_URL`.

### Testing
- Ran `npm run lint`, which failed due to a pre-existing parsing/syntax error in `src/components/app-frame.tsx` and not due to files added in this PR. 
- Ran `npm run build`, which failed for the same pre-existing syntax error in `src/components/app-frame.tsx` and therefore prevented a successful production build. 
- No unit tests were added or run as part of this change; the module was validated locally by attempting `lint` and `build` and by verifying the new files compile in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90d64b118832db265274ed898a14e)