### PR TITLE
fix: resolve merge-corrupted frontend/server modules and restore build

### DIFF
--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,17 +5,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const navItems = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Galaxy', href: '/galaxy' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Systems', href: '/systems' },
-  { label: 'Members', href: '/members' },
-  { label: 'Developers', href: '/developers' },
-  { label: 'Capital', href: '/capital' },
-  { label: 'Media', href: '/media' },
-  { label: 'Games', href: '/games' },
-  { label: 'OMOS', href: '/omos' }
 const navGroups = [
   {
     label: 'Identity + Intelligence',

--- a/src/db/postgres.js
+++ b/src/db/postgres.js
@@ -1,9 +1,5 @@
 const { Pool } = require('pg');
 const { ENV } = require('../config/env');
-import pkg from 'pg';
-import { ENV } from '../config/env.js';
-
-const { Pool } = pkg;
 
 let pool;
 
@@ -15,19 +11,11 @@ if (ENV.ENABLE_DATABASE) {
 }
 
 async function query(text, params) {
-    ssl: ENV.NODE_ENV === 'production'
-      ? { rejectUnauthorized: false }
-      : false
-  });
-}
-
-export async function query(text, params) {
   if (!pool) throw new Error('database_not_enabled');
   return pool.query(text, params);
 }
 
 async function checkDatabase() {
-export async function checkDatabase() {
   if (!pool) return { enabled: false };
 
   try {
@@ -39,7 +27,3 @@ export async function checkDatabase() {
 }
 
 module.exports = { query, checkDatabase };
-  } catch (err) {
-    return { enabled: true, ok: false };
-  }
-}

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -4,12 +4,6 @@ const { checkDatabase } = require('../db/postgres');
 const router = express.Router();
 
 router.get('/ready', async (_req, res) => {
-import express from 'express';
-import { checkDatabase } from '../db/postgres.js';
-
-const router = express.Router();
-
-router.get('/ready', async (req, res) => {
   const db = await checkDatabase();
 
   res.json({
@@ -20,4 +14,3 @@ router.get('/ready', async (req, res) => {
 });
 
 module.exports = router;
-export default router;

--- a/src/storage/memory-scheduler-store.js
+++ b/src/storage/memory-scheduler-store.js
@@ -21,23 +21,6 @@ async function createEvent(data) {
   const id = `evt_${uuidv4()}`;
   const now = new Date().toISOString();
   const event = {
-const events = new Map();
-
-export async function listEvents(filters = {}) {
-  let all = Array.from(events.values());
-  if (filters.from) all = all.filter((e) => new Date(e.timestamp_utc) >= new Date(filters.from));
-  if (filters.to) all = all.filter((e) => new Date(e.timestamp_utc) <= new Date(filters.to));
-  if (filters.status) all = all.filter((e) => e.status === filters.status);
-  return all;
-}
-
-export async function getEvent(id) {
-  return events.get(id);
-}
-
-export async function createEvent(data) {
-  const id = `evt_mem_${Date.now()}`;
-  const row = {
     id,
     title: data.title,
     description: data.description || '',
@@ -62,21 +45,9 @@ async function updateEvent(id, data) {
   const existing = events.get(id);
   if (!existing) return undefined;
 
-    created_at_utc: new Date().toISOString(),
-    updated_at_utc: new Date().toISOString(),
-    metadata: data.metadata || {}
-  };
-  events.set(id, row);
-  return row;
-}
-
-export async function updateEvent(id, data) {
-  const existing = events.get(id);
-  if (!existing) return null;
   const updated = {
     ...existing,
-    title: data.title ?? existing.title,
-    description: data.description ?? existing.description,
+    ...data,
     updated_at_utc: new Date().toISOString()
   };
 
@@ -89,6 +60,3 @@ async function deleteEvent(id) {
 }
 
 module.exports = { listEvents, getEvent, createEvent, updateEvent, deleteEvent };
-export async function deleteEvent(id) {
-  return events.delete(id);
-}

--- a/src/storage/postgres-scheduler-store.js
+++ b/src/storage/postgres-scheduler-store.js
@@ -2,10 +2,6 @@ const { query } = require('../db/postgres');
 const { v4: uuidv4 } = require('uuid');
 
 async function listEvents(filters = {}) {
-import { query } from '../db/postgres.js';
-import { v4 as uuidv4 } from 'uuid';
-
-export async function listEvents(filters = {}) {
   let sql = 'SELECT * FROM scheduler_events WHERE 1=1';
   const params = [];
 
@@ -38,18 +34,6 @@ async function createEvent(data) {
 
   const res = await query(
     `
-export async function getEvent(id) {
-  const res = await query(
-    'SELECT * FROM scheduler_events WHERE id = $1',
-    [id]
-  );
-  return res.rows[0];
-}
-
-export async function createEvent(data) {
-  const id = `evt_${uuidv4()}`;
-
-  const res = await query(`
     INSERT INTO scheduler_events (
       id, title, description, type, status,
       timestamp_utc, timestamp_local, timezone,
@@ -72,19 +56,6 @@ export async function createEvent(data) {
       data.price_usd > 0 ? 'pending' : 'not_required'
     ]
   );
-  `, [
-    id,
-    data.title,
-    data.description || '',
-    data.type || 'standard',
-    data.status || 'scheduled',
-    data.timestamp_utc,
-    data.timestamp_local,
-    data.timezone,
-    data.duration_minutes || 60,
-    data.price_usd || 0,
-    data.price_usd > 0 ? 'pending' : 'not_required'
-  ]);
 
   return res.rows[0];
 }
@@ -92,8 +63,6 @@ export async function createEvent(data) {
 async function updateEvent(id, data) {
   const res = await query(
     `
-export async function updateEvent(id, data) {
-  const res = await query(`
     UPDATE scheduler_events
     SET title=$2, description=$3, updated_at_utc=NOW()
     WHERE id=$1
@@ -101,7 +70,6 @@ export async function updateEvent(id, data) {
   `,
     [id, data.title, data.description]
   );
-  `, [id, data.title, data.description]);
 
   return res.rows[0];
 }
@@ -112,7 +80,3 @@ async function deleteEvent(id) {
 }
 
 module.exports = { listEvents, getEvent, createEvent, updateEvent, deleteEvent };
-export async function deleteEvent(id) {
-  await query('DELETE FROM scheduler_events WHERE id=$1', [id]);
-  return true;
-}

--- a/src/storage/scheduler-store.js
+++ b/src/storage/scheduler-store.js
@@ -12,23 +12,3 @@ module.exports = {
   updateEvent: store.updateEvent,
   deleteEvent: store.deleteEvent
 };
-const { randomUUID } = require('crypto');
-const events = new Map();
-function listEvents({ from, to, status, type } = {}) { let results = Array.from(events.values()); if (from) results = results.filter((e) => e.timestamp_utc >= from); if (to) results = results.filter((e) => e.timestamp_utc <= to); if (status) results = results.filter((e) => e.status === status); if (type) results = results.filter((e) => e.type === type); return results; }
-function getEvent(id) { return events.get(id); }
-function createEvent(data) { const id = `evt_${randomUUID()}`; const now = new Date().toISOString(); const record = { id, title: data.title, description: data.description || '', type: data.type || 'standard', status: data.status || 'scheduled', timestamp_utc: data.timestamp_utc, timestamp_local: data.timestamp_local, timezone: data.timezone, duration_minutes: data.duration_minutes || 60, price_usd: data.price_usd || 0, payment_status: data.price_usd > 0 ? 'pending' : 'not_required', created_at_utc: now, updated_at_utc: now, metadata: data.metadata || {} }; events.set(id, record); return record; }
-function updateEvent(id, data) { const existing = events.get(id); if (!existing) return null; const updated = { ...existing, ...data, updated_at_utc: new Date().toISOString() }; events.set(id, updated); return updated; }
-function deleteEvent(id) { return events.delete(id); }
-module.exports = { listEvents, getEvent, createEvent, updateEvent, deleteEvent };
-import { ENV } from '../config/env.js';
-
-import * as memory from './memory-scheduler-store.js';
-import * as postgres from './postgres-scheduler-store.js';
-
-const store = ENV.ENABLE_DATABASE ? postgres : memory;
-
-export const listEvents = store.listEvents;
-export const getEvent = store.getEvent;
-export const createEvent = store.createEvent;
-export const updateEvent = store.updateEvent;
-export const deleteEvent = store.deleteEvent;


### PR DESCRIPTION
### Motivation
- Resolve parse/merge artifacts that broke lint/typecheck/build and prevented a clean production build.  
- Restore consistent frontend navigation structure and backend scheduler/DB module implementations so server code parses correctly.  
- Allow the repo to produce a valid production Next.js build so it can be deployed by the normal pipeline.

### Description
- Repaired navigation and mobile nav in `src/components/app-frame.tsx` by removing duplicate/malformed fragments and restoring a single `navGroups` -> `navItems` flow.  
- Restored CommonJS-compatible Postgres pool, `query`, and `checkDatabase` implementations in `src/db/postgres.js` and fixed the health route in `src/routes/health.js` to use the corrected DB check.  
- Rewrote scheduler storage implementations to be consistent and parseable by Node: `src/storage/memory-scheduler-store.js`, `src/storage/postgres-scheduler-store.js`, and `src/storage/scheduler-store.js` now export working functions and no longer contain interleaved ESM fragments.  
- Removed merge-noise and ensured the codebase builds with Next.js without changing app behavior or route surface.

### Testing
- Ran dependency install with `npm install` which completed successfully.  
- Ran lint and type checks with `npm run lint` (no ESLint errors) and `npx tsc --noEmit` (typecheck passed).  
- Built production assets with `npm run build` and Next.js completed an optimized production build (static pages generated).  
- Performed automated HTTP checks against `https://app.onegodian.com` for the required routes and recorded responses; the build succeeded locally but many production routes still returned `404`, indicating the live site has not yet been updated with these changes and a production redeploy from your deployment environment is required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f937ba8ba8832db897b0aba519e101)