### PR TITLE
Add Hostinger deployment checklist and `deploy-prod.sh` helper

### DIFF
--- a/docs/hostinger-deploy-checklist.md
+++ b/docs/hostinger-deploy-checklist.md
@@ -1,0 +1,63 @@
+# Hostinger deployment checklist (app.onegodian.com)
+
+Use this checklist when promoting the latest `main` build to production.
+
+## 1) Prepare environment
+
+- SSH into the Hostinger/VPS machine.
+- Open the project directory containing this repo.
+- Confirm required environment variables are set (for example `DATABASE_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, and OMOS bridge values).
+
+## 2) Deploy latest code
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+rm -rf .next
+npm install
+npm run build
+```
+
+## 3) Restart runtime
+
+### PM2 runtime
+
+```bash
+pm2 restart onegodian-app
+pm2 save
+```
+
+### Node runtime (no process manager)
+
+```bash
+# stop old process first
+npm run start
+```
+
+## 4) Verify live routes
+
+```bash
+for p in /galaxy /galaxy/planets /systems /games /capital /members /algorithm; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "https://app.onegodian.com$p")
+  echo "$code $p"
+done
+```
+
+All routes above should return `200`.
+
+## 5) Optional one-command deployment
+
+You can use the helper script in this repo:
+
+```bash
+./scripts/deploy-prod.sh
+```
+
+Environment overrides:
+
+- `APP_DIR` (defaults to current directory)
+- `BRANCH` (defaults to `main`)
+- `PM2_APP_NAME` (defaults to `onegodian-app`)
+- `RESTART_MODE` (`pm2` | `node` | `none`)
+- `VERIFY_BASE_URL` (defaults to `https://app.onegodian.com`)

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-$(pwd)}"
+BRANCH="${BRANCH:-main}"
+PM2_APP_NAME="${PM2_APP_NAME:-onegodian-app}"
+RESTART_MODE="${RESTART_MODE:-pm2}"
+VERIFY_BASE_URL="${VERIFY_BASE_URL:-https://app.onegodian.com}"
+
+ROUTES=(
+  "/galaxy"
+  "/galaxy/planets"
+  "/systems"
+  "/games"
+  "/capital"
+  "/members"
+  "/algorithm"
+)
+
+echo "[deploy] app dir: $APP_DIR"
+cd "$APP_DIR"
+
+echo "[deploy] fetching latest from origin/$BRANCH"
+git fetch origin
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+echo "[deploy] removing stale build output"
+rm -rf .next
+
+echo "[deploy] installing dependencies"
+npm install
+
+echo "[deploy] building application"
+npm run build
+
+case "$RESTART_MODE" in
+  pm2)
+    echo "[deploy] restarting PM2 app: $PM2_APP_NAME"
+    pm2 restart "$PM2_APP_NAME"
+    pm2 save
+    ;;
+  node)
+    echo "[deploy] restart mode set to 'node'."
+    echo "[deploy] stop current node process manually if needed, then run: npm run start"
+    ;;
+  none)
+    echo "[deploy] restart skipped (RESTART_MODE=none)"
+    ;;
+  *)
+    echo "[deploy] unknown RESTART_MODE: $RESTART_MODE"
+    exit 1
+    ;;
+esac
+
+echo "[verify] checking production routes at $VERIFY_BASE_URL"
+failed=0
+for route in "${ROUTES[@]}"; do
+  code="$(curl -s -o /dev/null -w "%{http_code}" "$VERIFY_BASE_URL$route")"
+  echo "$code $route"
+  if [[ "$code" != "200" ]]; then
+    failed=1
+  fi
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "[verify] one or more routes did not return 200"
+  exit 2
+fi
+
+echo "[verify] all required routes returned 200"


### PR DESCRIPTION
### Motivation

- Provide an explicit, repeatable checklist and script for promoting the `main` build to production on the Hostinger/VPS environment for app.onegodian.com. 
- Reduce manual steps and common errors by automating fetch/build/restart and route verification. 

### Description

- Add `docs/hostinger-deploy-checklist.md` with step-by-step instructions for preparing the environment, building, restarting, and verifying the site. 
- Add executable `scripts/deploy-prod.sh` which pulls `BRANCH` (default `main`), removes `.next`, runs `npm install` and `npm run build`, and supports restart modes `pm2`, `node`, and `none`. 
- The script exposes environment overrides `APP_DIR`, `BRANCH`, `PM2_APP_NAME`, `RESTART_MODE`, and `VERIFY_BASE_URL`, and verifies a list of production routes via `curl`, failing with non-zero exit if any route does not return `200`.

### Testing

- No automated tests were added or executed for these changes. 
- The script uses `set -euo pipefail` to fail fast on errors during execution. 
- Recommend adding CI linting or integration checks for future changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9391854d4832d905e233d95b84c9b)