### PR TITLE
Fix scheduler/db merge artifacts breaking lint and build

### DIFF
--- a/src/db/postgres.js
+++ b/src/db/postgres.js
@@ -2,8 +2,6 @@ import pkg from 'pg';
 import { ENV } from '../config/env.js';
 
 const { Pool } = pkg;
-const { Pool } = require('pg');
-const { ENV } = require('../config/env');
 
 let pool;
 
@@ -15,13 +13,11 @@ if (ENV.ENABLE_DATABASE) {
 }
 
 export async function query(text, params) {
-async function query(text, params) {
   if (!pool) throw new Error('database_not_enabled');
   return pool.query(text, params);
 }
 
 export async function checkDatabase() {
-async function checkDatabase() {
   if (!pool) return { enabled: false };
 
   try {
@@ -31,5 +27,3 @@ async function checkDatabase() {
     return { enabled: true, ok: false };
   }
 }
-
-module.exports = { query, checkDatabase };

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,7 +1,5 @@
 import express from 'express';
 import { checkDatabase } from '../db/postgres.js';
-const express = require('express');
-const { checkDatabase } = require('../db/postgres');
 
 const router = express.Router();
 
@@ -16,4 +14,3 @@ router.get('/ready', async (_req, res) => {
 });
 
 export default router;
-module.exports = router;

--- a/src/storage/memory-scheduler-store.js
+++ b/src/storage/memory-scheduler-store.js
@@ -1,26 +1,8 @@
+import { v4 as uuidv4 } from 'uuid';
+
 const events = new Map();
 
 export async function listEvents(filters = {}) {
-  let all = Array.from(events.values());
-  if (filters.from) all = all.filter((e) => new Date(e.timestamp_utc) >= new Date(filters.from));
-  if (filters.to) all = all.filter((e) => new Date(e.timestamp_utc) <= new Date(filters.to));
-  if (filters.status) all = all.filter((e) => e.status === filters.status);
-  return all;
-}
-
-export async function getEvent(id) {
-  return events.get(id);
-}
-
-export async function createEvent(data) {
-  const id = `evt_mem_${Date.now()}`;
-  const now = new Date().toISOString();
-  const row = {
-const { v4: uuidv4 } = require('uuid');
-
-const events = new Map();
-
-function listEvents(filters = {}) {
   const rows = Array.from(events.values());
 
   return rows.filter((event) => {
@@ -31,11 +13,11 @@ function listEvents(filters = {}) {
   });
 }
 
-function getEvent(id) {
+export async function getEvent(id) {
   return events.get(id);
 }
 
-function createEvent(data) {
+export async function createEvent(data) {
   const id = `evt_${uuidv4()}`;
   const now = new Date().toISOString();
   const event = {
@@ -54,21 +36,14 @@ function createEvent(data) {
     updated_at_utc: now,
     metadata: data.metadata || {}
   };
-  events.set(id, row);
-  return row;
-}
-
-export async function updateEvent(id, data) {
-  const existing = events.get(id);
-  if (!existing) return null;
 
   events.set(id, event);
   return event;
 }
 
-function updateEvent(id, data) {
+export async function updateEvent(id, data) {
   const existing = events.get(id);
-  if (!existing) return undefined;
+  if (!existing) return null;
 
   const updated = {
     ...existing,
@@ -80,12 +55,6 @@ function updateEvent(id, data) {
   return updated;
 }
 
-function deleteEvent(id) {
 export async function deleteEvent(id) {
   return events.delete(id);
 }
-async function deleteEvent(id) {
-  return events.delete(id);
-}
-
-module.exports = { listEvents, getEvent, createEvent, updateEvent, deleteEvent };

--- a/src/storage/postgres-scheduler-store.js
+++ b/src/storage/postgres-scheduler-store.js
@@ -2,10 +2,6 @@ import { query } from '../db/postgres.js';
 import { v4 as uuidv4 } from 'uuid';
 
 export async function listEvents(filters = {}) {
-const { query } = require('../db/postgres');
-const { v4: uuidv4 } = require('uuid');
-
-async function listEvents(filters = {}) {
   let sql = 'SELECT * FROM scheduler_events WHERE 1=1';
   const params = [];
 
@@ -38,8 +34,6 @@ export async function createEvent(data) {
 
   const res = await query(
     `INSERT INTO scheduler_events (
-    `
-    INSERT INTO scheduler_events (
       id, title, description, type, status,
       timestamp_utc, timestamp_local, timezone,
       duration_minutes, price_usd, payment_status
@@ -67,8 +61,6 @@ export async function createEvent(data) {
 export async function updateEvent(id, data) {
   const res = await query(
     `UPDATE scheduler_events
-    `
-    UPDATE scheduler_events
     SET title=$2, description=$3, updated_at_utc=NOW()
     WHERE id=$1
     RETURNING *`,
@@ -82,9 +74,3 @@ export async function deleteEvent(id) {
   await query('DELETE FROM scheduler_events WHERE id=$1', [id]);
   return true;
 }
-async function deleteEvent(id) {
-  await query('DELETE FROM scheduler_events WHERE id=$1', [id]);
-  return true;
-}
-
-module.exports = { listEvents, getEvent, createEvent, updateEvent, deleteEvent };

--- a/src/storage/scheduler-store.js
+++ b/src/storage/scheduler-store.js
@@ -10,17 +10,3 @@ export const getEvent = store.getEvent;
 export const createEvent = store.createEvent;
 export const updateEvent = store.updateEvent;
 export const deleteEvent = store.deleteEvent;
-const { ENV } = require('../config/env');
-
-const memory = require('./memory-scheduler-store');
-const postgres = require('./postgres-scheduler-store');
-
-const store = ENV.ENABLE_DATABASE ? postgres : memory;
-
-module.exports = {
-  listEvents: store.listEvents,
-  getEvent: store.getEvent,
-  createEvent: store.createEvent,
-  updateEvent: store.updateEvent,
-  deleteEvent: store.deleteEvent
-};


### PR DESCRIPTION
### Motivation
- Recent merged changes introduced mixed CommonJS and ESM fragments and duplicated function bodies across scheduler and DB modules which caused parse errors and broke linting and the production build.
- The intent is to restore consistent ESM modules and correct scheduler storage implementations so the project can lint and build successfully.

### Description
- Removed duplicate CommonJS `require`/`module.exports` fragments and duplicate declarations to make `src/db/postgres.js` a valid ESM module and keep a single `Pool` definition. 
- Rewrote `src/routes/health.js` to import `express` and `checkDatabase` with ESM imports and export the router as default. 
- Restored a single coherent in-memory scheduler implementation in `src/storage/memory-scheduler-store.js` using `uuid` IDs and consistent async ESM exports. 
- Fixed malformed SQL template strings and duplicate code in `src/storage/postgres-scheduler-store.js` and unified the conditional store selection and ESM exports in `src/storage/scheduler-store.js`.

### Testing
- Ran `npm ci` successfully with dependency installation completed. 
- Ran `npm run lint` twice: it initially failed due to the merge artifacts and then succeeded with `✔ No ESLint warnings or errors` after the fixes. 
- Ran `npm run build` twice: it initially failed for the same parse errors and then completed successfully producing a Next.js production build and generated static pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c9f53d68832d913aa90d056e1310)