### PR TITLE
Add production verification script for route parity and members bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "check": "node --check server.js",
-    "db:migrate": "node scripts/migrate.js"
+    "db:migrate": "node scripts/migrate.js",
+    "prod:verify": "bash scripts/production-lock-check.sh"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",

--- a/scripts/production-lock-check.sh
+++ b/scripts/production-lock-check.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-${BASE_URL:-https://app.onegodian.com}}"
+WP_BASE_URL="${2:-${WP_BASE_URL:-https://onegodian.org}}"
+
+ROUTES=(
+  "/dashboard"
+  "/ecosystem"
+  "/galaxy"
+  "/galaxy/planets"
+  "/systems"
+  "/members"
+  "/algorithm"
+  "/learn"
+  "/capital"
+  "/games"
+  "/belief-mapper"
+  "/institutional"
+)
+
+HEALTH_ROUTES=(
+  "/health"
+  "/ready"
+  "/version"
+)
+
+MEMBERS_ROUTES=(
+  "/wp-json/onegodian-members/v1/health"
+  "/wp-json/onegodian-members/v1/manifest"
+  "/wp-json/onegodian-members/v1/me"
+  "/wp-json/onegodian-members/v1/admin/summary"
+)
+
+APP_BRIDGE_ROUTES=(
+  "/api/members/health"
+  "/api/members/manifest"
+)
+
+check_route() {
+  local base="$1"
+  local route="$2"
+  local expected_regex="${3:-^200$}"
+
+  local code
+  code=$(curl -sS -o /dev/null -w "%{http_code}" "$base$route" || true)
+
+  if [[ "$code" =~ $expected_regex ]]; then
+    printf "✅ %s%s -> %s\n" "$base" "$route" "$code"
+  else
+    printf "❌ %s%s -> %s\n" "$base" "$route" "$code"
+    return 1
+  fi
+}
+
+echo "Checking app routes at: $BASE_URL"
+for route in "${ROUTES[@]}"; do
+  check_route "$BASE_URL" "$route"
+done
+
+echo "Checking health endpoints at: $BASE_URL"
+for route in "${HEALTH_ROUTES[@]}"; do
+  check_route "$BASE_URL" "$route"
+done
+
+echo "Checking app bridge endpoints at: $BASE_URL"
+for route in "${APP_BRIDGE_ROUTES[@]}"; do
+  check_route "$BASE_URL" "$route" '^(200|401|403)$'
+done
+
+echo "Checking WordPress members endpoints at: $WP_BASE_URL"
+for route in "${MEMBERS_ROUTES[@]}"; do
+  check_route "$WP_BASE_URL" "$route" '^(200|401|403)$'
+done
+
+echo "All checks complete."


### PR DESCRIPTION
### Motivation
- Make the production "lock" validation repeatable by automating route parity and app↔plugin bridge checks. 
- Provide a single, easy-to-run verification step to detect missing pages or broken WordPress members endpoints after deploy.

### Description
- Add an executable script `scripts/production-lock-check.sh` that checks a configurable list of core app routes, health endpoints, app bridge endpoints, and WordPress members plugin endpoints. 
- The script treats normal routes as expecting `200` and allows `200|401|403` for auth-protected bridge endpoints to support unauthenticated checks. 
- Add an npm shortcut `prod:verify` (`bash scripts/production-lock-check.sh`) to `package.json` for quick invocation.

### Testing
- Ran `npm run check`, which failed due to a pre-existing `server.js` syntax error (duplicate `OMOSProcess` declaration) unrelated to this change. 
- Ran `bash scripts/production-lock-check.sh https://app.onegodian.com https://onegodian.org`, which executed correctly and detected a production parity issue where `/galaxy` returned `404`. 
- The verification script is executable and included in the repository with the `prod:verify` npm script, ready for use in post-deploy checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d28e6334832d88febb45928196e5)