### PR TITLE
Add Onegodian University LMS plugin scaffold with admin UI and page generator

### DIFF
--- a/onegodian-university-lms/assets/admin/admin.css
+++ b/onegodian-university-lms/assets/admin/admin.css
@@ -1,0 +1,14 @@
+.ogulms-admin-wrap {
+  max-width: 1200px;
+}
+
+.ogulms-nav {
+  margin: 16px 0;
+}
+
+.ogulms-panel {
+  background: #fff;
+  border: 1px solid #dcdcde;
+  border-radius: 8px;
+  padding: 20px;
+}

--- a/onegodian-university-lms/includes/admin/class-ogulms-admin-courses.php
+++ b/onegodian-university-lms/includes/admin/class-ogulms-admin-courses.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OGULMS\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Courses {
+	public function render(): void {
+		echo '<h2>' . esc_html__( 'Courses', 'onegodian-university-lms' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Course management table scaffold. Integrate CPT and lesson builder in the next iteration.', 'onegodian-university-lms' ) . '</p>';
+	}
+}

--- a/onegodian-university-lms/includes/admin/class-ogulms-admin-dashboard.php
+++ b/onegodian-university-lms/includes/admin/class-ogulms-admin-dashboard.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OGULMS\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Dashboard {
+	public function render(): void {
+		echo '<h2>' . esc_html__( 'LMS Dashboard', 'onegodian-university-lms' ) . '</h2>';
+		echo '<p>' . esc_html__( 'This is the admin shell for upcoming LMS analytics widgets.', 'onegodian-university-lms' ) . '</p>';
+	}
+}

--- a/onegodian-university-lms/includes/admin/class-ogulms-admin-settings.php
+++ b/onegodian-university-lms/includes/admin/class-ogulms-admin-settings.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OGULMS\Admin;
+
+use OGULMS\Page_Generator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Settings {
+	private Page_Generator $page_generator;
+
+	public function __construct( Page_Generator $page_generator ) {
+		$this->page_generator = $page_generator;
+	}
+
+	public function render(): void {
+		$generated = isset( $_GET['generated'] ) ? absint( $_GET['generated'] ) : null;
+		if ( null !== $generated ) {
+			echo '<div class="notice notice-success"><p>';
+			echo esc_html( sprintf( __( 'Auto page generation complete. %d page(s) created or linked.', 'onegodian-university-lms' ), $generated ) );
+			echo '</p></div>';
+		}
+
+		echo '<h2>' . esc_html__( 'Settings', 'onegodian-university-lms' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Use the generator below to create the core LMS public pages.', 'onegodian-university-lms' ) . '</p>';
+
+		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+		echo '<input type="hidden" name="action" value="ogulms_generate_pages" />';
+		wp_nonce_field( 'ogulms_generate_pages' );
+		submit_button( __( 'Auto-Create LMS Pages', 'onegodian-university-lms' ), 'primary' );
+		echo '</form>';
+
+		$pages = $this->page_generator->get_saved_pages();
+		if ( ! empty( $pages ) ) {
+			echo '<h3>' . esc_html__( 'Generated Pages', 'onegodian-university-lms' ) . '</h3><ul>';
+			foreach ( $pages as $slug => $page_id ) {
+				$link = get_permalink( $page_id );
+				echo '<li><strong>' . esc_html( $slug ) . ':</strong> ';
+				echo $link ? '<a href="' . esc_url( $link ) . '" target="_blank" rel="noopener">' . esc_html( $link ) . '</a>' : esc_html__( 'Unavailable', 'onegodian-university-lms' );
+				echo '</li>';
+			}
+			echo '</ul>';
+		}
+	}
+}

--- a/onegodian-university-lms/includes/admin/class-ogulms-admin-students.php
+++ b/onegodian-university-lms/includes/admin/class-ogulms-admin-students.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OGULMS\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Students {
+	public function render(): void {
+		echo '<h2>' . esc_html__( 'Students', 'onegodian-university-lms' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Students CRM and enrollment management placeholders live here.', 'onegodian-university-lms' ) . '</p>';
+	}
+}

--- a/onegodian-university-lms/includes/admin/class-ogulms-admin.php
+++ b/onegodian-university-lms/includes/admin/class-ogulms-admin.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace OGULMS\Admin;
+
+use OGULMS\Page_Generator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Admin {
+	/** @var array<string, callable> */
+	private array $tabs = array();
+
+	public function __construct( Page_Generator $page_generator ) {
+		$this->tabs = array(
+			'dashboard' => array( new Dashboard(), 'render' ),
+			'courses'   => array( new Courses(), 'render' ),
+			'students'  => array( new Students(), 'render' ),
+			'settings'  => array( new Settings( $page_generator ), 'render' ),
+		);
+
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	public function register_menu(): void {
+		add_menu_page(
+			__( 'University LMS', 'onegodian-university-lms' ),
+			__( 'University LMS', 'onegodian-university-lms' ),
+			'manage_options',
+			'ogulms',
+			array( $this, 'render_shell' ),
+			'dashicons-welcome-learn-more',
+			26
+		);
+	}
+
+	public function enqueue_assets( string $hook_suffix ): void {
+		if ( 'toplevel_page_ogulms' !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'ogulms-admin',
+			OGULMS_URL . 'assets/admin/admin.css',
+			array(),
+			OGULMS_VERSION
+		);
+	}
+
+	public function render_shell(): void {
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'dashboard';
+
+		if ( ! isset( $this->tabs[ $tab ] ) ) {
+			$tab = 'dashboard';
+		}
+
+		echo '<div class="wrap ogulms-admin-wrap">';
+		echo '<h1>' . esc_html__( 'Onegodian University LMS', 'onegodian-university-lms' ) . '</h1>';
+		$this->render_tabs( $tab );
+		echo '<section class="ogulms-panel">';
+		call_user_func( $this->tabs[ $tab ] );
+		echo '</section>';
+		echo '</div>';
+	}
+
+	private function render_tabs( string $active_tab ): void {
+		$tabs = array(
+			'dashboard' => __( 'Dashboard', 'onegodian-university-lms' ),
+			'courses'   => __( 'Courses', 'onegodian-university-lms' ),
+			'students'  => __( 'Students', 'onegodian-university-lms' ),
+			'settings'  => __( 'Settings', 'onegodian-university-lms' ),
+		);
+
+		echo '<nav class="nav-tab-wrapper ogulms-nav">';
+		foreach ( $tabs as $slug => $label ) {
+			$class = ( $active_tab === $slug ) ? 'nav-tab nav-tab-active' : 'nav-tab';
+			$url   = add_query_arg(
+				array(
+					'page' => 'ogulms',
+					'tab'  => $slug,
+				),
+				admin_url( 'admin.php' )
+			);
+			echo '<a class="' . esc_attr( $class ) . '" href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
+		}
+		echo '</nav>';
+	}
+}

--- a/onegodian-university-lms/includes/class-ogulms-page-generator.php
+++ b/onegodian-university-lms/includes/class-ogulms-page-generator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace OGULMS;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Page_Generator {
+	private const OPTION_KEY = 'ogulms_core_pages';
+
+	/** @var array<string, array{title: string, shortcode: string}> */
+	private array $pages = array(
+		'catalog' => array(
+			'title'     => 'Course Catalog',
+			'shortcode' => '[og_course_catalog]',
+		),
+		'dashboard' => array(
+			'title'     => 'Student Dashboard',
+			'shortcode' => '[og_student_dashboard]',
+		),
+		'verify-certificate' => array(
+			'title'     => 'Certificate Verification',
+			'shortcode' => '[og_certificate_verify]',
+		),
+		'live-classes' => array(
+			'title'     => 'Live Classes',
+			'shortcode' => '[og_live_classes]',
+		),
+	);
+
+	public function __construct() {
+		add_action( 'admin_post_ogulms_generate_pages', array( $this, 'handle_generate_pages' ) );
+	}
+
+	public function handle_generate_pages(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized', 'onegodian-university-lms' ) );
+		}
+
+		check_admin_referer( 'ogulms_generate_pages' );
+
+		$created = 0;
+		$updated_pages = $this->get_saved_pages();
+
+		foreach ( $this->pages as $slug => $config ) {
+			$page_id = isset( $updated_pages[ $slug ] ) ? (int) $updated_pages[ $slug ] : 0;
+			if ( $page_id > 0 && 'trash' !== get_post_status( $page_id ) ) {
+				continue;
+			}
+
+			$existing = get_page_by_path( $slug, OBJECT, 'page' );
+			if ( $existing instanceof \WP_Post ) {
+				$page_id = (int) $existing->ID;
+			} else {
+				$page_id = wp_insert_post(
+					array(
+						'post_title'   => $config['title'],
+						'post_name'    => $slug,
+						'post_content' => $config['shortcode'],
+						'post_status'  => 'publish',
+						'post_type'    => 'page',
+					),
+					true
+				);
+			}
+
+			if ( ! is_wp_error( $page_id ) && $page_id > 0 ) {
+				$updated_pages[ $slug ] = $page_id;
+				$created++;
+			}
+		}
+
+		update_option( self::OPTION_KEY, $updated_pages );
+
+		$redirect = add_query_arg(
+			array(
+				'page'      => 'ogulms',
+				'tab'       => 'settings',
+				'generated' => (string) $created,
+			),
+			admin_url( 'admin.php' )
+		);
+
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/** @return array<string, int> */
+	public function get_saved_pages(): array {
+		$saved = get_option( self::OPTION_KEY, array() );
+		if ( ! is_array( $saved ) ) {
+			return array();
+		}
+
+		return array_map( 'intval', $saved );
+	}
+}

--- a/onegodian-university-lms/includes/class-ogulms-plugin.php
+++ b/onegodian-university-lms/includes/class-ogulms-plugin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OGULMS;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once OGULMS_PATH . 'includes/class-ogulms-page-generator.php';
+require_once OGULMS_PATH . 'includes/admin/class-ogulms-admin.php';
+require_once OGULMS_PATH . 'includes/admin/class-ogulms-admin-dashboard.php';
+require_once OGULMS_PATH . 'includes/admin/class-ogulms-admin-courses.php';
+require_once OGULMS_PATH . 'includes/admin/class-ogulms-admin-students.php';
+require_once OGULMS_PATH . 'includes/admin/class-ogulms-admin-settings.php';
+
+class Plugin {
+	public static function boot(): void {
+		if ( is_admin() ) {
+			$page_generator = new Page_Generator();
+			new Admin\Admin( $page_generator );
+		}
+	}
+}

--- a/onegodian-university-lms/onegodian-university-lms.php
+++ b/onegodian-university-lms/onegodian-university-lms.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Onegodian University LMS
+ * Description: LMS plugin scaffold with admin UI framework.
+ * Version: 2.0.0
+ * Author: ONEGODIAN, LLC
+ * Text Domain: onegodian-university-lms
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'OGULMS_VERSION', '2.0.0' );
+define( 'OGULMS_FILE', __FILE__ );
+define( 'OGULMS_PATH', plugin_dir_path( __FILE__ ) );
+define( 'OGULMS_URL', plugin_dir_url( __FILE__ ) );
+
+require_once OGULMS_PATH . 'includes/class-ogulms-plugin.php';
+
+\OGULMS\Plugin::boot();


### PR DESCRIPTION
### Motivation
- Introduce a minimal plugin scaffold to provide an admin UI for an LMS and a simple mechanism to generate core public pages.  
- Provide a tabbed admin shell (Dashboard, Courses, Students, Settings) to iterate on analytics, course, and student management features.  
- Add a page generator to auto-create commonly required public pages so initial setup is simpler.

### Description
- Added the main plugin entry `onegodian-university-lms.php` and boot logic in `includes/class-ogulms-plugin.php` which initializes admin functionality when in the admin area.  
- Implemented a tabbed admin interface via `includes/admin/class-ogulms-admin.php` and lightweight tab handlers `Dashboard`, `Courses`, `Students`, and `Settings` under `includes/admin/`.  
- Added `includes/class-ogulms-page-generator.php` which registers an `admin_post` handler `ogulms_generate_pages` to create or link core pages (`catalog`, `dashboard`, `verify-certificate`, `live-classes`) and persist their IDs in the `ogulms_core_pages` option.  
- Included admin styling at `assets/admin/admin.css` and safe usage of WordPress APIs and nonces in the settings form and redirect flow.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7c8d54bc832db87aa8bda2f4980b)