### PR TITLE
Upgrade OneGodian command dashboard homepage and navigation

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,24 +1,79 @@
 import Link from 'next/link';
 
-const cards = [
-  { title: 'Ecosystem', description: 'Core OneGodian ecosystem map and module status.', href: '/ecosystem' },
-  { title: 'Registry', description: 'ODIN registry systems and canonical record continuity.', href: '/registry' },
-  { title: 'Galaxy', description: 'OneGodian Galaxy hub for Galactic Canon, Planets, Moons & Systems, and Realms.', href: '/galaxy' },
-  { title: 'Time', description: 'OneGodian Time™ synchronization and daily references.', href: '/time' },
-  { title: 'OHI', description: 'OHI™ and Quantum OHI™ system interfaces.', href: '/ohi' },
-  { title: 'Algorithm', description: 'The Onegodian Algorithm™ command layers.', href: '/algorithm' },
-  { title: 'AI System Prompt', description: 'Operational prompt standards and alignment rules.', href: '/ai-system-prompt' },
-  { title: 'Assets', description: 'Digital assets, certificates, and property modules.', href: '/assets' },
-  { title: 'Economics', description: 'Economic intelligence and ecosystem economics.', href: '/economics' },
-  { title: 'Institutional Clarity', description: 'Institutional continuity, legal clarity, and governance surfaces.', href: '/identity' },
-  { title: 'Galactic Canon', description: 'Interactive registry for the OneGodian Galaxy™, planetary canon, moons, species, realms, lineages, figures, and temporal structures.', href: '/galactic-canon' },
+type Status = 'Live' | 'In Development' | 'Needs Setup' | 'Planned';
 
-  { title: 'Belief Mapper Lite', description: 'Consent-first identity mapper for stage-aware pathways.', href: '/belief-mapper' },
-  { title: 'Learn', description: 'Public knowledge-layer index aligned to onegodian.org/learn.', href: '/learn' },
-  { title: 'OneGodian U', description: 'Course execution platform and certification flows.', href: 'https://u.onegodian.org' },
-  { title: 'Visual Cover Standards', description: 'Rule set requiring title-encoded visual covers.', href: '/standards/visual-covers' },
-  { title: 'Institutional Dossier', description: 'Legal, IP, and governance-positioning command page.', href: '/institutional' },
-  { title: 'Divine 9 Covers', description: 'Companion gallery route for Divine 9 cover assets.', href: '/media/divine-9' },
+const modules: { icon: string; title: string; description: string; href: string; status: Status }[] = [
+  { icon: '🧠', title: 'Algorithm', description: 'Four-layer operating framework for command and alignment.', href: '/algorithm', status: 'Live' },
+  { icon: '🧩', title: 'OMOS', description: 'Operational module bridge configuration and runtime hooks.', href: '/omos', status: 'Live' },
+  { icon: '🕒', title: 'Time', description: 'OTS-V5 reference, synchronized clocks, and legal note guidance.', href: '/time', status: 'In Development' },
+  { icon: '📡', title: 'Protocol', description: 'Protocol boundaries and staged implementation controls.', href: '/protocol', status: 'Live' },
+  { icon: '🤖', title: 'AI Prompt', description: 'System prompt standards for reliable and safe behavior.', href: '/ai-system-prompt', status: 'Live' },
+  { icon: '🪪', title: 'Identity', description: 'Institutional records and entity separation references.', href: '/identity', status: 'Live' },
+  { icon: '🔄', title: 'Pipeline', description: 'Compare, filter, normalize, and output workflow map.', href: '/pipeline', status: 'In Development' },
+  { icon: '🎯', title: 'Gen Alpha', description: 'Belief Mapper Lite stages for learner progression.', href: '/gen-alpha', status: 'In Development' },
+  { icon: '📘', title: 'Docs', description: 'Document library with current platform references.', href: '/docs', status: 'Needs Setup' }
 ];
 
-export default function DashboardPage() { return <main className="min-h-screen px-6 py-10 text-slate-100"><div className="mx-auto max-w-6xl space-y-8"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">Dashboard</h1><p className="mt-4 text-slate-300">The central Node/Next.js command interface for the core OneGodian ecosystem: ODIN registry systems, OneGodian Time™, OHI™, Quantum OHI™, The Onegodian Algorithm™, certificates, planets, assets, and synchronized platform infrastructure.</p></header><section><h2 className="text-xl font-semibold">Production Status</h2><p className="mt-2 text-sm text-slate-300">Core services are synchronized with active route and module health checks.</p></section><section><h2 className="text-xl font-semibold">Today in OneGodian Time™</h2><p className="mt-2 text-sm text-slate-300">Use the Time module for live UTC ↔ OT alignment and platform clock references.</p></section><section><h2 className="mb-3 text-xl font-semibold">Core Systems</h2><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{cards.map((card) => <Link key={card.title} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 hover:border-cyan-400/60"><h3 className="font-medium">{card.title}</h3><p className="mt-2 text-sm text-slate-300">{card.description}</p></Link>)}</div></section></div></main>; }
+const systemStatus: { title: string; status: Status }[] = [
+  { title: 'Node App Live', status: 'Live' },
+  { title: 'Hostinger Deployment Active', status: 'Live' },
+  { title: 'Ecosystem Directory', status: 'Live' },
+  { title: 'Time Converter', status: 'In Development' },
+  { title: 'Docs Library', status: 'Needs Setup' },
+  { title: 'API Gateway', status: 'Needs Setup' },
+  { title: 'GitHub Repo Matrix', status: 'In Development' },
+  { title: 'Alignment Demo', status: 'Planned' }
+];
+
+const statusStyles: Record<Status, string> = {
+  Live: 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
+  'In Development': 'border-cyan-400/60 bg-cyan-500/15 text-cyan-200',
+  'Needs Setup': 'border-amber-400/60 bg-amber-500/15 text-amber-200',
+  Planned: 'border-violet-400/60 bg-violet-500/15 text-violet-200'
+};
+
+export default function DashboardPage() {
+  return (
+    <main className="min-h-screen text-slate-100">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">OneGodian Command Dashboard</p>
+          <h1 className="mt-2 text-3xl font-bold sm:text-4xl">Operational Command Surface</h1>
+          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">Mobile-first command entry for ecosystem modules, documentation, and system readiness. Status labels indicate current maturity only.</p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm">
+            <Link href="/ecosystem" className="rounded-lg border border-cyan-400/70 px-4 py-2 text-cyan-200">Open Ecosystem</Link>
+            <Link href="/milestones" className="rounded-lg border border-slate-600 px-4 py-2 text-slate-200">View Milestones</Link>
+          </div>
+        </header>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold">Command Modules</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {modules.map((module) => (
+              <Link key={module.title} href={module.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 transition hover:border-cyan-400/60">
+                <div className="flex items-start justify-between gap-3">
+                  <span className="text-xl" aria-hidden>{module.icon}</span>
+                  <span className={`rounded-full border px-2 py-1 text-xs ${statusStyles[module.status]}`}>{module.status}</span>
+                </div>
+                <h3 className="mt-3 font-semibold">{module.title}</h3>
+                <p className="mt-2 text-sm text-slate-300">{module.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold">System Status</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {systemStatus.map((item) => (
+              <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4">
+                <p className="text-sm text-slate-300">{item.title}</p>
+                <p className={`mt-3 inline-flex rounded-full border px-2 py-1 text-xs ${statusStyles[item.status]}`}>{item.status}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/identity/page.tsx
+++ b/src/app/(app)/identity/page.tsx
@@ -1,3 +1,24 @@
-import Link from 'next/link';
-const cards=[{title:'Identity Records',description:'Identity records, ownership continuity, and profile linkage.'},{title:'Verification Status',description:'Membership verification state and certificate validation routes.'},{title:'Access Permissions',description:'Access roles, permission states, and registry continuity.'}];
-export default function IdentityPage(){return <main className="space-y-8"><section className="rounded-2xl border border-cyan-400/30 bg-slate-900/70 p-6 sm:p-8"><p className="text-xs uppercase tracking-[0.22em] text-cyan-300">ONEGODIAN APP · IDENTITY</p><h1 className="mt-3 text-3xl font-bold sm:text-4xl">Identity & Verification</h1><p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-300 sm:text-base">Identity records, verification states, QR-V lookup, certificate ownership, and access permissions.</p><div className="mt-6 flex flex-wrap gap-3"><Link href="/members" className="rounded-lg bg-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950">Open Members</Link><Link href="/" className="rounded-lg border border-cyan-400/60 px-4 py-2 text-sm font-semibold text-cyan-200">Back to Dashboard</Link></div></section><section className="grid gap-4 md:grid-cols-3">{cards.map(c=><article key={c.title} className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5"><h2 className="text-xl font-semibold text-white">{c.title}</h2><p className="mt-3 text-sm leading-relaxed text-slate-300">{c.description}</p></article>)}</section><section className="rounded-2xl border border-cyan-400/20 bg-cyan-400/5 p-6 text-sm text-slate-300">Status: Verification schema planned • QR-V API pending • Member integration pending.</section></main>}
+export default function IdentityPage() {
+  return (
+    <main className="space-y-6 text-slate-100">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">Identity</h1>
+        <p className="mt-3 text-slate-300">Identity defines how OneGodian records, ownership references, and institutional context are represented across software.</p>
+      </section>
+      <section className="grid gap-3 md:grid-cols-2">
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="font-semibold">Copyright + Commercial Context</h2>
+          <p className="mt-2 text-sm text-slate-300">ONEGODIAN, LLC is the commercial and technology operating entity for software, IP, and implementation assets.</p>
+        </article>
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="font-semibold">Entity Separation</h2>
+          <p className="mt-2 text-sm text-slate-300">INO remains separate for spiritual and community governance functions and is not represented here as a commercial authority.</p>
+        </article>
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 md:col-span-2">
+          <h2 className="font-semibold">Institutional Records</h2>
+          <p className="mt-2 text-sm text-slate-300">Institutional records include dated filings, certificates, and internal continuity notes used for operational reference.</p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/milestones/page.tsx
+++ b/src/app/(app)/milestones/page.tsx
@@ -1,9 +1,24 @@
 const milestones = [
-  'Foundational identity and records established',
-  'OneGodian software routes expanded to ecosystem modules',
-  'OTS-V5 reference implementation documented',
-  'Command dashboard modules and status model released'
+  { date: 'April 17, 2026', title: 'Operational milestone record logged', detail: 'Internal milestone package compiled for command dashboard continuity.' },
+  { date: 'April 28, 2026', title: 'Decision log migration added', detail: 'Database migration added to track software decision records.' },
+  { date: 'May 2026', title: 'Command module routes aligned', detail: 'Core routes for algorithm, time, docs, identity, pipeline, and Gen Alpha aligned.' },
+  { date: 'May 2026', title: 'Dashboard status model standardized', detail: 'Live, In Development, Needs Setup, and Planned labels adopted across command cards.' }
 ];
+
 export default function MilestonesPage() {
-  return <main className="p-6 text-slate-100"><h1 className="text-3xl font-semibold">Milestones</h1><div className="mt-4 space-y-3">{milestones.map((item, index)=> <div key={item} className="rounded-lg border border-slate-700 bg-slate-900/60 p-4"><p className="text-cyan-200">M{index+1}</p><p className="text-slate-300">{item}</p></div>)}</div></main>;
+  return (
+    <main className="space-y-5 text-slate-100">
+      <h1 className="text-3xl font-semibold">Milestones</h1>
+      <p className="text-slate-300">Major OneGodian records and software milestones used for operational reference.</p>
+      <div className="space-y-3">
+        {milestones.map((item) => (
+          <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4">
+            <p className="text-xs uppercase tracking-wide text-cyan-300">{item.date}</p>
+            <h2 className="mt-1 font-semibold">{item.title}</h2>
+            <p className="mt-2 text-sm text-slate-300">{item.detail}</p>
+          </article>
+        ))}
+      </div>
+    </main>
+  );
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,52 +5,21 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const navGroups = [
-  {
-    label: 'Identity + Intelligence',
-    items: [
-      { label: 'Onegodian Algorithm', href: '/algorithm' },
-      { label: 'Protocol Layer', href: '/algorithm/protocol' },
-      { label: 'Experience Layer', href: '/algorithm/experience' },
-      { label: 'Community Layer', href: '/algorithm/community' },
-      { label: 'Orientation Layer', href: '/algorithm/orientation' },
-      { label: 'Belief Mapper Lite', href: '/belief-mapper' }
-    ]
-  },
-  {
-    label: 'Education',
-    items: [
-      { label: 'Learn', href: '/learn' },
-      { label: 'OneGodian U', href: 'https://u.onegodian.org' }
-    ]
-  },
-  {
-    label: 'Media + Standards',
-    items: [
-      { label: 'Divine 9 Covers', href: '/media/divine-9' },
-      { label: 'Visual Cover Standards', href: '/standards/visual-covers' }
-    ]
-  },
-  {
-    label: 'Core',
-    items: [
-      { label: 'Dashboard', href: '/dashboard' },
-      { label: 'Ecosystem', href: '/ecosystem' },
-      { label: 'Registry', href: '/registry' },
-      { label: 'Institutional Dossier', href: '/institutional' },
-      { label: 'Settings', href: '/settings' }
-    ]
-  }
+const desktopNav = [
+  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Algorithm', href: '/algorithm' },
+  { label: 'Time', href: '/time' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Docs', href: '/docs' },
+  { label: 'Planets', href: '/planets' }
 ];
-
-const navItems = navGroups.flatMap((group) => group.items);
 
 const mobilePrimary = [
   { icon: '🧭', label: 'Dashboard', href: '/dashboard' },
-  { icon: '🌌', label: 'Galaxy', href: '/galaxy' },
-  { icon: '🪪', label: 'Registry', href: '/registry' },
   { icon: '🛰️', label: 'Systems', href: '/systems' },
-  { icon: '👥', label: 'Members', href: '/members' }
+  { icon: '🕒', label: 'Time', href: '/time' },
+  { icon: '📘', label: 'Docs', href: '/docs' }
 ];
 
 export function AppFrame({ children }: { children: ReactNode }) {
@@ -71,9 +40,9 @@ export function AppFrame({ children }: { children: ReactNode }) {
           <p className="font-semibold text-cyan-300">OneGodian Command</p>
           <p className="hidden text-xs text-slate-300 sm:block">OT {ot}</p>
         </div>
-        <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="mt-3 hidden overflow-x-auto [scrollbar-width:none] md:block [&::-webkit-scrollbar]:hidden">
           <nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">
-            {navItems.map((item) => {
+            {desktopNav.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link
@@ -96,11 +65,11 @@ export function AppFrame({ children }: { children: ReactNode }) {
       <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
 
       <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 backdrop-blur md:hidden" aria-label="Mobile navigation">
-        <div className="grid grid-cols-5 gap-1">
+        <div className="grid grid-cols-4 gap-1">
           {mobilePrimary.map((item) => {
             const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
             return (
-              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
+              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-1 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
                 <span>{item.icon}</span>
                 <span>{item.label}</span>
               </Link>


### PR DESCRIPTION
### Motivation
- Convert the existing homepage/dashboard into a mobile-first OneGodian command dashboard with quick-access modules and clear system status.
- Replace the previous navigation with the requested mobile and desktop primary menus to simplify routing and command discovery.
- Surface module maturity using standardized status labels to avoid overstating production readiness.
- Keep the existing dark navy/black identity with cyan accents, rounded cards, and mobile-friendly layout to match the visual system.

### Description
- Updated desktop and mobile navigation in `src/components/app-frame.tsx` to the requested menus and adjusted responsive behavior for mobile-first bottom nav. 
- Reworked the dashboard at `src/app/(app)/dashboard/page.tsx` into a command module grid containing the nine modules (`/algorithm`, `/omos`, `/time`, `/protocol`, `/ai-system-prompt`, `/identity`, `/pipeline`, `/gen-alpha`, `/docs`) with icon, title, short description, status badge, and link, and added a `System Status` card grid with standardized status styling. 
- Updated `src/app/(app)/identity/page.tsx` with concise, production-safe copy clarifying `ONEGODIAN, LLC` as the commercial/IP entity and `INO` as a separate spiritual/community governance entity. 
- Replaced `src/app/(app)/milestones/page.tsx` with a concise dated timeline of major OneGodian records and software milestones and introduced `statusStyles` mapping for consistent badges. 

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran `npm run lint` and received `✔ No ESLint warnings or errors`. 
- Ran `npm run build` and the Next.js build completed successfully with pages generated and the new routes compiled. 
- Verified the build route list includes the new/updated routes (`/algorithm`, `/omos`, `/time`, `/protocol`, `/ai-system-prompt`, `/identity`, `/pipeline`, `/gen-alpha`, `/docs`, `/milestones`) and there were no hydration or compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d142dadc832d8437ae3ee467c32d)