### PR TITLE
Refocus app.Onegodian.com as OneGodian App command interface

### DIFF
--- a/src/app/(app)/app-bridge/page.tsx
+++ b/src/app/(app)/app-bridge/page.tsx
@@ -1,0 +1,14 @@
+const endpoints = ['/api/health', '/api/manifest', '/api/tools', '/api/stats', '/api/verify'];
+
+export default function AppBridgePage() {
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian App Bridge</h1>
+        <p className="mt-2 text-slate-300">Unified bridge layer connecting app surfaces, plugins, and APIs.</p>
+      </section>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{endpoints.map((endpoint) => <article key={endpoint} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">{endpoint}</h2><p className="mt-2 text-sm text-slate-300">Bridge endpoint card for module integration.</p></article>)}</section>
+      <p className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">Use X-OMOS-App-Key for bridge authentication.</p>
+    </main>
+  );
+}

--- a/src/app/(app)/certificates/page.tsx
+++ b/src/app/(app)/certificates/page.tsx
@@ -1,5 +1,5 @@
 import { AppShell } from '@/components/app-shell';
 
-export default function Page() {
-  return <AppShell title="Certificates" modules={[{ title: 'Certificates Placeholder', description: 'Foundation placeholder for certificates module.' }]} />;
+export default function CertificatesPage() {
+  return <AppShell title="Certificates" modules={[{ title: 'Credential Registry', description: 'Track issued certificates and verification states across the ecosystem.' }, { title: 'Verification API', description: 'Integrate certificate checks through secure bridge endpoints.', href: '/app-bridge' }]} />;
 }

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,24 +1,36 @@
 import Link from 'next/link';
 
 const cards = [
-  { title: 'Ecosystem', description: 'Core OneGodian ecosystem map and module status.', href: '/ecosystem' },
-  { title: 'Registry', description: 'ODIN registry systems and canonical record continuity.', href: '/registry' },
-  { title: 'Galaxy', description: 'OneGodian Galaxy hub for Galactic Canon, Planets, Moons & Systems, and Realms.', href: '/galaxy' },
-  { title: 'Time', description: 'OneGodian Time™ synchronization and daily references.', href: '/time' },
-  { title: 'OHI', description: 'OHI™ and Quantum OHI™ system interfaces.', href: '/ohi' },
-  { title: 'Algorithm', description: 'The Onegodian Algorithm™ command layers.', href: '/algorithm' },
-  { title: 'AI System Prompt', description: 'Operational prompt standards and alignment rules.', href: '/ai-system-prompt' },
-  { title: 'Assets', description: 'Digital assets, certificates, and property modules.', href: '/assets' },
-  { title: 'Economics', description: 'Economic intelligence and ecosystem economics.', href: '/economics' },
-  { title: 'Institutional Clarity', description: 'Institutional continuity, legal clarity, and governance surfaces.', href: '/identity' },
-  { title: 'Galactic Canon', description: 'Interactive registry for the OneGodian Galaxy™, planetary canon, moons, species, realms, lineages, figures, and temporal structures.', href: '/galactic-canon' },
-
-  { title: 'Belief Mapper Lite', description: 'Consent-first identity mapper for stage-aware pathways.', href: '/belief-mapper' },
-  { title: 'Learn', description: 'Public knowledge-layer index aligned to onegodian.org/learn.', href: '/learn' },
-  { title: 'OneGodian U', description: 'Course execution platform and certification flows.', href: 'https://u.onegodian.org' },
-  { title: 'Visual Cover Standards', description: 'Rule set requiring title-encoded visual covers.', href: '/standards/visual-covers' },
-  { title: 'Institutional Dossier', description: 'Legal, IP, and governance-positioning command page.', href: '/institutional' },
-  { title: 'Divine 9 Covers', description: 'Companion gallery route for Divine 9 cover assets.', href: '/media/divine-9' },
+  { title: 'Systems', href: '/ecosystem' },
+  { title: 'Plugins', href: '/plugins' },
+  { title: 'Registry', href: '/registry' },
+  { title: 'Tools', href: '/tools' },
+  { title: 'Certificates', href: '/certificates' },
+  { title: 'Members', href: '/members' },
+  { title: 'Products', href: '/products' },
+  { title: 'Media', href: '/media' },
+  { title: 'App Bridge', href: '/app-bridge' },
+  { title: 'Production Checklist', href: '/production-checklist' }
 ];
 
-export default function DashboardPage() { return <main className="min-h-screen px-6 py-10 text-slate-100"><div className="mx-auto max-w-6xl space-y-8"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">Dashboard</h1><p className="mt-4 text-slate-300">The central Node/Next.js command interface for the core OneGodian ecosystem: ODIN registry systems, OneGodian Time™, OHI™, Quantum OHI™, The Onegodian Algorithm™, certificates, planets, assets, and synchronized platform infrastructure.</p></header><section><h2 className="text-xl font-semibold">Production Status</h2><p className="mt-2 text-sm text-slate-300">Core services are synchronized with active route and module health checks.</p></section><section><h2 className="text-xl font-semibold">Today in OneGodian Time™</h2><p className="mt-2 text-sm text-slate-300">Use the Time module for live UTC ↔ OT alignment and platform clock references.</p></section><section><h2 className="mb-3 text-xl font-semibold">Core Systems</h2><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{cards.map((card) => <Link key={card.title} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 hover:border-cyan-400/60"><h3 className="font-medium">{card.title}</h3><p className="mt-2 text-sm text-slate-300">{card.description}</p></Link>)}</div></section></div></main>; }
+export default function DashboardPage() {
+  return (
+    <main className="space-y-8">
+      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian App Dashboard</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Central command interface for systems, plugins, dashboards, tools, registries, media, products, certificates, and ecosystem navigation.</p>
+      </header>
+      <section>
+        <h2 className="mb-3 text-xl font-semibold">Command Modules</h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {cards.map((card) => (
+            <Link key={card.href} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 hover:border-cyan-400/60">
+              <h3 className="font-medium">{card.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">Open {card.title} interface.</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,30 +1,27 @@
 import { ONEGODIAN_ECOSYSTEM } from '@/lib/ecosystem';
 
+const appStructureStandard = ['Public-facing page', 'Logged-in dashboard', 'Admin/control panel', 'API/bridge endpoint', 'Documentation', 'Production checklist'];
+
 export default function EcosystemPage() {
   return (
-    <main className="min-h-screen px-6 py-12 sm:py-16">
-      <div className="mx-auto max-w-6xl">
-        <header className="max-w-3xl">
-          <p className="text-sm uppercase tracking-[0.22em] text-neon">OneGodian Galaxy™</p>
-          <h1 className="mt-3 text-3xl font-bold leading-tight sm:text-4xl">Ecosystem</h1>
-          <p className="mt-4 text-base leading-7 text-slate-300">
-            Core production modules mirrored for deployment while preserving compatibility with the current Hostinger build.
-          </p>
-        </header>
-
-        <section aria-label="Ecosystem modules" className="mt-10 grid gap-4 sm:grid-cols-2">
-          {ONEGODIAN_ECOSYSTEM.map((module) => (
-            <article key={module.id} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5">
-              <p className="text-xs uppercase tracking-[0.2em] text-neon">{module.id}</p>
-              <h2 className="mt-2 text-xl font-semibold text-slate-100">{module.name}</h2>
-              <p className="mt-2 text-sm text-slate-300">{module.description}</p>
-              <p className="mt-3 text-xs text-slate-400">
-                {module.category} · {module.productionStatus}
-              </p>
-            </article>
-          ))}
-        </section>
-      </div>
+    <main className="space-y-8">
+      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
+        <p className="mt-3 text-slate-300">The OneGodian App is the central command interface for systems, plugins, dashboards, tools, registries, media, products, certificates, and ecosystem navigation.</p>
+      </header>
+      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6">
+        <h2 className="text-xl font-semibold">OneGodian App Structure Standard</h2>
+        <ul className="mt-3 grid gap-3 sm:grid-cols-2">{appStructureStandard.map((item) => <li key={item} className="rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm">{item}</li>)}</ul>
+      </section>
+      <section aria-label="Ecosystem modules" className="grid gap-4 sm:grid-cols-2">
+        {ONEGODIAN_ECOSYSTEM.map((module) => (
+          <article key={module.id} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5">
+            <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{module.id}</p>
+            <h2 className="mt-2 text-xl font-semibold text-slate-100">{module.name}</h2>
+            <p className="mt-2 text-sm text-slate-300">{module.description}</p>
+          </article>
+        ))}
+      </section>
     </main>
   );
 }

--- a/src/app/(app)/media/page.tsx
+++ b/src/app/(app)/media/page.tsx
@@ -1,5 +1,5 @@
 import { AppShell } from '@/components/app-shell';
 
-export default function Page() {
-  return <AppShell title="Media" modules={[{ title: 'Media Placeholder', description: 'Foundation placeholder for media module.' }]} />;
+export default function MediaPage() {
+  return <AppShell title="Media" modules={[{ title: 'Media Library', description: 'Store and manage campaign media, launch assets, and ecosystem visuals.' }, { title: 'Standards', description: 'Keep media aligned with OneGodian visual and documentation standards.', href: '/standards/visual-covers' }]} />;
 }

--- a/src/app/(app)/plugins/page.tsx
+++ b/src/app/(app)/plugins/page.tsx
@@ -1,0 +1,16 @@
+const layers = ['Public App Layer', 'Dashboard Layer', 'Admin Layer', 'API / App Bridge Layer', 'Data Layer', 'Security Layer', 'UI / UX Layer', 'Documentation Layer', 'Compliance Layer', 'Deployment Layer'];
+
+export default function PluginsPage() {
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian Plugin Development Framework</h1>
+        <p className="mt-3 text-slate-300">Build plugins as full lifecycle modules aligned to the OneGodian App command interface.</p>
+      </section>
+      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6">
+        <h2 className="text-xl font-semibold">10-layer plugin architecture</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">{layers.map((layer) => <article key={layer} className="rounded-xl border border-slate-700 bg-slate-950/60 p-4 text-sm">{layer}</article>)}</div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/production-checklist/page.tsx
+++ b/src/app/(app)/production-checklist/page.tsx
@@ -1,0 +1,13 @@
+const checklist = ['Define module', 'Build WordPress plugin layer', 'Add App Bridge endpoints', 'Build admin UI', 'Build frontend dashboard', 'Connect ecosystem data', 'Add documentation files', 'Validate plugin', 'Package ZIP', 'Build and redeploy frontend'];
+
+export default function ProductionChecklistPage() {
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">Build Process / Production Checklist</h1>
+        <p className="mt-2 text-slate-300">Use this checklist for every OneGodian plugin or app module release.</p>
+      </section>
+      <ol className="space-y-3">{checklist.map((item, i) => <li key={item} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><span className="mr-2 text-cyan-300">{i + 1}.</span>{item}</li>)}</ol>
+    </main>
+  );
+}

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -1,5 +1,5 @@
 import { AppShell } from '@/components/app-shell';
 
-export default function Page() {
-  return <AppShell title="Products" modules={[{ title: 'Products Placeholder', description: 'Foundation placeholder for products module.' }]} />;
+export default function ProductsPage() {
+  return <AppShell title="Products" modules={[{ title: 'Product Catalog', description: 'Central listing of OneGodian products, bundles, and active offerings.' }, { title: 'Release Controls', description: 'Coordinate release readiness with production checklist standards.', href: '/production-checklist' }]} />;
 }

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -1,5 +1,5 @@
 import { AppShell } from '@/components/app-shell';
 
-export default function Page() {
-  return <AppShell title="Tools" modules={[{ title: 'Tools Placeholder', description: 'Foundation placeholder for tools module.' }]} />;
+export default function ToolsPage() {
+  return <AppShell title="Tools" modules={[{ title: 'Command Utilities', description: 'Operational tools for app diagnostics, sync workflows, and execution support.' }, { title: 'Data Connectors', description: 'Bridge ecosystem registries, member records, and product/media data.' }, { title: 'Automation', description: 'Run repeatable build and deployment workflows across modules.', href: '/production-checklist' }]} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,53 @@
-import { redirect } from 'next/navigation';
+import Link from 'next/link';
+
+const ctas = [
+  { label: 'Enter Dashboard', href: '/dashboard' },
+  { label: 'View Ecosystem', href: '/ecosystem' },
+  { label: 'Explore Tools', href: '/tools' },
+  { label: 'View Registry', href: '/registry' }
+];
+
+const footerColumns = [
+  { title: 'App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Tools', href: '/tools' }, { label: 'Registry', href: '/registry' }] },
+  { title: 'Systems', links: [{ label: 'Plugins', href: '/plugins' }, { label: 'App Bridge', href: '/app-bridge' }, { label: 'Certificates', href: '/certificates' }, { label: 'Products', href: '/products' }] },
+  { title: 'Resources', links: [{ label: 'Documentation', href: '/docs' }, { label: 'Production Checklist', href: '/production-checklist' }, { label: 'Media', href: '/media' }, { label: 'Settings', href: '/settings' }] },
+  { title: 'Network', links: [{ label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'U.OneGodian.org', href: 'https://u.onegodian.org' }, { label: 'Capital.OneGodian.com', href: 'https://capital.onegodian.com' }] }
+];
 
 export default function HomePage() {
-  redirect('/dashboard');
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
+      <div className="mx-auto max-w-6xl">
+        <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-8 sm:p-12">
+          <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian Ecosystem</p>
+          <h1 className="mt-3 text-4xl font-bold sm:text-5xl">OneGodian App</h1>
+          <p className="mt-4 max-w-2xl text-lg text-slate-300">The command interface for the OneGodian ecosystem.</p>
+          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {ctas.map((cta) => (
+              <Link key={cta.href} href={cta.href} className="rounded-xl border border-slate-600 bg-slate-950/70 px-4 py-3 text-center text-sm font-medium hover:border-cyan-400/60 hover:text-cyan-200">
+                {cta.label}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <footer className="mt-10 grid gap-6 border-t border-slate-800 pt-8 sm:grid-cols-2 lg:grid-cols-4">
+          {footerColumns.map((column) => (
+            <div key={column.title}>
+              <h2 className="text-sm font-semibold text-cyan-300">{column.title}</h2>
+              <ul className="mt-3 space-y-2 text-sm text-slate-300">
+                {column.links.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="hover:text-cyan-200">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </footer>
+      </div>
+    </main>
+  );
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,52 +5,25 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const navGroups = [
-  {
-    label: 'Identity + Intelligence',
-    items: [
-      { label: 'Onegodian Algorithm', href: '/algorithm' },
-      { label: 'Protocol Layer', href: '/algorithm/protocol' },
-      { label: 'Experience Layer', href: '/algorithm/experience' },
-      { label: 'Community Layer', href: '/algorithm/community' },
-      { label: 'Orientation Layer', href: '/algorithm/orientation' },
-      { label: 'Belief Mapper Lite', href: '/belief-mapper' }
-    ]
-  },
-  {
-    label: 'Education',
-    items: [
-      { label: 'Learn', href: '/learn' },
-      { label: 'OneGodian U', href: 'https://u.onegodian.org' }
-    ]
-  },
-  {
-    label: 'Media + Standards',
-    items: [
-      { label: 'Divine 9 Covers', href: '/media/divine-9' },
-      { label: 'Visual Cover Standards', href: '/standards/visual-covers' }
-    ]
-  },
-  {
-    label: 'Core',
-    items: [
-      { label: 'Dashboard', href: '/dashboard' },
-      { label: 'Ecosystem', href: '/ecosystem' },
-      { label: 'Registry', href: '/registry' },
-      { label: 'Institutional Dossier', href: '/institutional' },
-      { label: 'Settings', href: '/settings' }
-    ]
-  }
+const navItems = [
+  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Plugins', href: '/plugins' },
+  { label: 'App Bridge', href: '/app-bridge' },
+  { label: 'Media', href: '/media' },
+  { label: 'Products', href: '/products' },
+  { label: 'Certificates', href: '/certificates' },
+  { label: 'Settings', href: '/settings' }
 ];
-
-const navItems = navGroups.flatMap((group) => group.items);
 
 const mobilePrimary = [
   { icon: '🧭', label: 'Dashboard', href: '/dashboard' },
-  { icon: '🌌', label: 'Galaxy', href: '/galaxy' },
-  { icon: '🪪', label: 'Registry', href: '/registry' },
-  { icon: '🛰️', label: 'Systems', href: '/systems' },
-  { icon: '👥', label: 'Members', href: '/members' }
+  { icon: '🌐', label: 'Ecosystem', href: '/ecosystem' },
+  { icon: '🧩', label: 'Plugins', href: '/plugins' },
+  { icon: '🛰️', label: 'Bridge', href: '/app-bridge' },
+  { icon: '🛠️', label: 'Tools', href: '/tools' }
 ];
 
 export function AppFrame({ children }: { children: ReactNode }) {
@@ -68,7 +41,7 @@ export function AppFrame({ children }: { children: ReactNode }) {
     <div className="min-h-screen bg-slate-950 pb-20 text-slate-100 md:pb-0">
       <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
         <div className="flex items-center justify-between">
-          <p className="font-semibold text-cyan-300">OneGodian Command</p>
+          <Link href="/" className="font-semibold text-cyan-300">OneGodian App</Link>
           <p className="hidden text-xs text-slate-300 sm:block">OT {ot}</p>
         </div>
         <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -76,15 +49,7 @@ export function AppFrame({ children }: { children: ReactNode }) {
             {navItems.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${
-                    active
-                      ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200'
-                      : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'
-                  }`}
-                >
+                <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>
                   {item.label}
                 </Link>
               );
@@ -92,21 +57,12 @@ export function AppFrame({ children }: { children: ReactNode }) {
           </nav>
         </div>
       </header>
-
       <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
-
       <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 backdrop-blur md:hidden" aria-label="Mobile navigation">
-        <div className="grid grid-cols-5 gap-1">
-          {mobilePrimary.map((item) => {
-            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-            return (
-              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
-                <span>{item.icon}</span>
-                <span>{item.label}</span>
-              </Link>
-            );
-          })}
-        </div>
+        <div className="grid grid-cols-5 gap-1">{mobilePrimary.map((item) => {
+          const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+          return <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}><span>{item.icon}</span><span>{item.label}</span></Link>;
+        })}</div>
       </nav>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Centralize the OneGodian frontend into a single command interface that surfaces systems, plugins, dashboards, tools, registries, media, products, certificates, and navigation.
- Provide a formal Plugin Development Framework, App Bridge endpoints, and a repeatable production checklist so modules can be developed and released consistently.
- Update navigation, homepage, dashboard, and footer so the site clearly presents the OneGodian App as the authoritative command surface.

### Description
- Reworked the homepage by replacing the redirect with a hero title/subtitle, CTAs (`Enter Dashboard`, `View Ecosystem`, `Explore Tools`, `View Registry`) and a four-column footer; changes in `src/app/page.tsx`.
- Replaced and simplified main navigation and mobile nav to include `Dashboard`, `Ecosystem`, `Registry`, `Tools`, `Plugins`, `App Bridge`, `Media`, `Products`, `Certificates`, and `Settings` in `src/components/app-frame.tsx`.
- Added the Plugin Development Framework page at `src/app/(app)/plugins/page.tsx` implementing the requested 10-layer architecture list and content.
- Added the App Bridge page at `src/app/(app)/app-bridge/page.tsx` with endpoint cards for `/api/health`, `/api/manifest`, `/api/tools`, `/api/stats`, `/api/verify` and the `X-OMOS-App-Key` authentication note.
- Added the Build Process / Production Checklist page at `src/app/(app)/production-checklist/page.tsx` with the 10 checklist steps provided.
- Updated the Dashboard (`src/app/(app)/dashboard/page.tsx`) to use reusable card links for Systems, Plugins, Registry, Tools, Certificates, Members, Products, Media, App Bridge, and Production Checklist, and refreshed `ecosystem`, `tools`, `certificates`, `products`, and `media` pages to real content using the `AppShell` pattern.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with static pages generated and no build errors.
- Build output includes the new and updated routes such as `/`, `/dashboard`, `/ecosystem`, `/registry`, `/tools`, `/members`, `/certificates`, `/products`, `/media`, `/settings`, `/plugins`, `/app-bridge`, and `/production-checklist`, confirming pages are routable and pre-rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d655b654832db48ff0359dab06be)