### PR TITLE
feat: update OneGodian App content and command dashboard structure

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Admin', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function AdminPage() {

--- a/src/app/(app)/campaigns/remember/page.tsx
+++ b/src/app/(app)/campaigns/remember/page.tsx
@@ -1,0 +1,9 @@
+import { rememberCampaign } from '@/lib/onegodian-content';
+
+export const metadata = { title: 'OneGodian App | Remember Campaign', description: 'THE ONEGODIAN: Remember Campaign tools and participation resources.' };
+
+export default function RememberCampaignPage() {
+  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">{rememberCampaign.name}</h1><p className="mt-2 text-slate-300">{rememberCampaign.purpose}</p><p className="mt-2 text-sm text-cyan-300">{rememberCampaign.officialStartDate} / {rememberCampaign.onegodianDate}</p></header>
+  <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6"><h2 className="font-semibold">Core Message</h2><p className="mt-2">{rememberCampaign.coreMessage}</p></section>
+  <section className="grid gap-3 sm:grid-cols-2">{rememberCampaign.sections.map((s)=> <article key={s.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h3 className="font-semibold">{s.title}</h3><p className="mt-2 text-sm text-slate-300">{s.body}</p></article>)}</section></main>;
+}

--- a/src/app/(app)/certificates/page.tsx
+++ b/src/app/(app)/certificates/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Certificates', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function CertificatesPage() {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,110 +1,13 @@
 import Link from 'next/link';
+import { AppStatusPanel } from '@/components/AppStatusPanel';
+import { dashboardCards, whatThisAppDoes } from '@/lib/onegodian-content';
 
-const cards = [
-  { title: 'Systems', href: '/ecosystem' },
-  { title: 'Plugins', href: '/plugins' },
-  { title: 'Registry', href: '/registry' },
-  { title: 'Tools', href: '/tools' },
-  { title: 'Certificates', href: '/certificates' },
-  { title: 'Members', href: '/members' },
-  { title: 'Products', href: '/products' },
-  { title: 'Media', href: '/media' },
-  { title: 'App Bridge', href: '/app-bridge' },
-  { title: 'Production Checklist', href: '/production-checklist' }
-];
+export const metadata = { title: 'OneGodian App | Command Dashboard', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
 
 export default function DashboardPage() {
-  return (
-    <main className="space-y-8">
-      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian App Dashboard</h1>
-        <p className="mt-3 max-w-3xl text-slate-300">Central command interface for systems, plugins, dashboards, tools, registries, media, products, certificates, and ecosystem navigation.</p>
-      </header>
-      <section>
-        <h2 className="mb-3 text-xl font-semibold">Command Modules</h2>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {cards.map((card) => (
-            <Link key={card.href} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 hover:border-cyan-400/60">
-              <h3 className="font-medium">{card.title}</h3>
-              <p className="mt-2 text-sm text-slate-300">Open {card.title} interface.</p>
-            </Link>
-          ))}
-        </div>
-      </section>
-type Status = 'Live' | 'In Development' | 'Needs Setup' | 'Planned';
-
-const modules: { icon: string; title: string; description: string; href: string; status: Status }[] = [
-  { icon: '🧠', title: 'Algorithm', description: 'Four-layer operating framework for command and alignment.', href: '/algorithm', status: 'Live' },
-  { icon: '🧩', title: 'OMOS', description: 'Operational module bridge configuration and runtime hooks.', href: '/omos', status: 'Live' },
-  { icon: '🕒', title: 'Time', description: 'OTS-V5 reference, synchronized clocks, and legal note guidance.', href: '/time', status: 'In Development' },
-  { icon: '📡', title: 'Protocol', description: 'Protocol boundaries and staged implementation controls.', href: '/protocol', status: 'Live' },
-  { icon: '🤖', title: 'AI Prompt', description: 'System prompt standards for reliable and safe behavior.', href: '/ai-system-prompt', status: 'Live' },
-  { icon: '🪪', title: 'Identity', description: 'Institutional records and entity separation references.', href: '/identity', status: 'Live' },
-  { icon: '🔄', title: 'Pipeline', description: 'Compare, filter, normalize, and output workflow map.', href: '/pipeline', status: 'In Development' },
-  { icon: '🎯', title: 'Gen Alpha', description: 'Belief Mapper Lite stages for learner progression.', href: '/gen-alpha', status: 'In Development' },
-  { icon: '📘', title: 'Docs', description: 'Document library with current platform references.', href: '/docs', status: 'Needs Setup' }
-];
-
-const systemStatus: { title: string; status: Status }[] = [
-  { title: 'Node App Live', status: 'Live' },
-  { title: 'Hostinger Deployment Active', status: 'Live' },
-  { title: 'Ecosystem Directory', status: 'Live' },
-  { title: 'Time Converter', status: 'In Development' },
-  { title: 'Docs Library', status: 'Needs Setup' },
-  { title: 'API Gateway', status: 'Needs Setup' },
-  { title: 'GitHub Repo Matrix', status: 'In Development' },
-  { title: 'Alignment Demo', status: 'Planned' }
-];
-
-const statusStyles: Record<Status, string> = {
-  Live: 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
-  'In Development': 'border-cyan-400/60 bg-cyan-500/15 text-cyan-200',
-  'Needs Setup': 'border-amber-400/60 bg-amber-500/15 text-amber-200',
-  Planned: 'border-violet-400/60 bg-violet-500/15 text-violet-200'
-};
-
-export default function DashboardPage() {
-  return (
-    <main className="min-h-screen text-slate-100">
-      <div className="mx-auto max-w-6xl space-y-8">
-        <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-          <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">OneGodian Command Dashboard</p>
-          <h1 className="mt-2 text-3xl font-bold sm:text-4xl">Operational Command Surface</h1>
-          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">Mobile-first command entry for ecosystem modules, documentation, and system readiness. Status labels indicate current maturity only.</p>
-          <div className="mt-4 flex flex-wrap gap-3 text-sm">
-            <Link href="/ecosystem" className="rounded-lg border border-cyan-400/70 px-4 py-2 text-cyan-200">Open Ecosystem</Link>
-            <Link href="/milestones" className="rounded-lg border border-slate-600 px-4 py-2 text-slate-200">View Milestones</Link>
-          </div>
-        </header>
-
-        <section>
-          <h2 className="mb-3 text-xl font-semibold">Command Modules</h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {modules.map((module) => (
-              <Link key={module.title} href={module.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 transition hover:border-cyan-400/60">
-                <div className="flex items-start justify-between gap-3">
-                  <span className="text-xl" aria-hidden>{module.icon}</span>
-                  <span className={`rounded-full border px-2 py-1 text-xs ${statusStyles[module.status]}`}>{module.status}</span>
-                </div>
-                <h3 className="mt-3 font-semibold">{module.title}</h3>
-                <p className="mt-2 text-sm text-slate-300">{module.description}</p>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <section>
-          <h2 className="mb-3 text-xl font-semibold">System Status</h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {systemStatus.map((item) => (
-              <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4">
-                <p className="text-sm text-slate-300">{item.title}</p>
-                <p className={`mt-3 inline-flex rounded-full border px-2 py-1 text-xs ${statusStyles[item.status]}`}>{item.status}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-      </div>
-    </main>
-  );
+  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OneGodian App Dashboard</h1></header>
+  <section><h2 className="mb-3 text-xl font-semibold">Command Modules</h2><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{dashboardCards.map((card)=><Link key={card.href} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h3 className="font-medium">{card.title}</h3><p className="mt-2 text-sm text-slate-300">{card.description}</p><p className="mt-2 text-xs text-cyan-300">{card.status}</p></Link>)}</div></section>
+  <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6"><h2 className="text-xl font-semibold">What This App Does</h2><ul className="mt-3 list-disc space-y-2 pl-6 text-slate-300">{whatThisAppDoes.map((item) => <li key={item}>{item}</li>)}</ul></section>
+  <AppStatusPanel />
+  </main>;
 }

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,27 +1,10 @@
-import { ONEGODIAN_ECOSYSTEM } from '@/lib/ecosystem';
+import Link from 'next/link';
+import { ecosystemPortals } from '@/lib/onegodian-content';
 
-const appStructureStandard = ['Public-facing page', 'Logged-in dashboard', 'Admin/control panel', 'API/bridge endpoint', 'Documentation', 'Production checklist'];
+export const metadata = { title: 'OneGodian App | Ecosystem', description: 'Official OneGodian ecosystem portals for store, public site, education, capital, app, and API.' };
 
 export default function EcosystemPage() {
-  return (
-    <main className="space-y-8">
-      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
-        <p className="mt-3 text-slate-300">The OneGodian App is the central command interface for systems, plugins, dashboards, tools, registries, media, products, certificates, and ecosystem navigation.</p>
-      </header>
-      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6">
-        <h2 className="text-xl font-semibold">OneGodian App Structure Standard</h2>
-        <ul className="mt-3 grid gap-3 sm:grid-cols-2">{appStructureStandard.map((item) => <li key={item} className="rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm">{item}</li>)}</ul>
-      </section>
-      <section aria-label="Ecosystem modules" className="grid gap-4 sm:grid-cols-2">
-        {ONEGODIAN_ECOSYSTEM.map((module) => (
-          <article key={module.id} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5">
-            <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{module.id}</p>
-            <h2 className="mt-2 text-xl font-semibold text-slate-100">{module.name}</h2>
-            <p className="mt-2 text-sm text-slate-300">{module.description}</p>
-          </article>
-        ))}
-      </section>
-    </main>
-  );
+  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">Ecosystem</h1></header>
+  <section className="grid gap-4 sm:grid-cols-2">{ecosystemPortals.map((p)=><article key={p.url} className="rounded-xl border border-cyan-500/20 bg-slate-900/70 p-5"><p className="text-xs text-cyan-300">{p.type}</p><h2 className="mt-2 text-xl font-semibold">{p.name}</h2><p className="mt-2 text-sm text-slate-300">{p.description}</p><Link href={p.url} className="mt-3 inline-block text-sm text-cyan-300">Open portal</Link></article>)}</section>
+  </main>;
 }

--- a/src/app/(app)/media/page.tsx
+++ b/src/app/(app)/media/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Media', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function MediaPage() {

--- a/src/app/(app)/members/page.tsx
+++ b/src/app/(app)/members/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Members', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 export default function MembersPage() {
   return (
     <main className="space-y-6">

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Products', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function ProductsPage() {

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,1 +1,3 @@
+export const metadata = { title: 'OneGodian App | Profile', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 export default function Page(){ return <main><h1 className='text-2xl capitalize'>profile</h1><p>Module foundation with reusable server-first patterns.</p></main>; }

--- a/src/app/(app)/registry/page.tsx
+++ b/src/app/(app)/registry/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Registry', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function RegistryPage() {

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Settings', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 export default function SettingsPage() {
   return (
     <main className="px-6 py-8">

--- a/src/app/(app)/systems-model/page.tsx
+++ b/src/app/(app)/systems-model/page.tsx
@@ -1,0 +1,8 @@
+import { systemsModel } from '@/lib/onegodian-content';
+
+export const metadata = { title: 'OneGodian App | Systems Model', description: 'Identity, ecosystem, registry, execution, and governance layers in the OneGodian app.' };
+
+export default function SystemsModelPage() {
+  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OneGodian Systems Model</h1></header>
+  <section className="grid gap-3 sm:grid-cols-2">{systemsModel.map((layer)=> <article key={layer.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">{layer.title}</h2><ul className="mt-2 list-disc pl-5 text-sm text-slate-300">{layer.items.map((item)=><li key={item}>{item}</li>)}</ul></article>)}</section></main>;
+}

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: 'OneGodian App | Tools', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+
 import { AppShell } from '@/components/app-shell';
 
 export default function ToolsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,53 +1,20 @@
 import Link from 'next/link';
+import { AppStatusPanel } from '@/components/AppStatusPanel';
+import { footerLinks, onegodianAppMeta, whatThisAppDoes } from '@/lib/onegodian-content';
 
-const ctas = [
-  { label: 'Enter Dashboard', href: '/dashboard' },
-  { label: 'View Ecosystem', href: '/ecosystem' },
-  { label: 'Explore Tools', href: '/tools' },
-  { label: 'View Registry', href: '/registry' }
-];
-
-const footerColumns = [
-  { title: 'App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Tools', href: '/tools' }, { label: 'Registry', href: '/registry' }] },
-  { title: 'Systems', links: [{ label: 'Plugins', href: '/plugins' }, { label: 'App Bridge', href: '/app-bridge' }, { label: 'Certificates', href: '/certificates' }, { label: 'Products', href: '/products' }] },
-  { title: 'Resources', links: [{ label: 'Documentation', href: '/docs' }, { label: 'Production Checklist', href: '/production-checklist' }, { label: 'Media', href: '/media' }, { label: 'Settings', href: '/settings' }] },
-  { title: 'Network', links: [{ label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'U.OneGodian.org', href: 'https://u.onegodian.org' }, { label: 'Capital.OneGodian.com', href: 'https://capital.onegodian.com' }] }
-];
+export const metadata = {
+  title: 'OneGodian App | Command Dashboard',
+  description:
+    'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.'
+};
 
 export default function HomePage() {
-  return (
-    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
-      <div className="mx-auto max-w-6xl">
-        <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-8 sm:p-12">
-          <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian Ecosystem</p>
-          <h1 className="mt-3 text-4xl font-bold sm:text-5xl">OneGodian App</h1>
-          <p className="mt-4 max-w-2xl text-lg text-slate-300">The command interface for the OneGodian ecosystem.</p>
-          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {ctas.map((cta) => (
-              <Link key={cta.href} href={cta.href} className="rounded-xl border border-slate-600 bg-slate-950/70 px-4 py-3 text-center text-sm font-medium hover:border-cyan-400/60 hover:text-cyan-200">
-                {cta.label}
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <footer className="mt-10 grid gap-6 border-t border-slate-800 pt-8 sm:grid-cols-2 lg:grid-cols-4">
-          {footerColumns.map((column) => (
-            <div key={column.title}>
-              <h2 className="text-sm font-semibold text-cyan-300">{column.title}</h2>
-              <ul className="mt-3 space-y-2 text-sm text-slate-300">
-                {column.links.map((link) => (
-                  <li key={link.href}>
-                    <Link href={link.href} className="hover:text-cyan-200">
-                      {link.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </footer>
-      </div>
-    </main>
-  );
+  return <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100"><div className="mx-auto max-w-6xl space-y-8">
+    <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-8 sm:p-12"><p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{onegodianAppMeta.eyebrow}</p><h1 className="mt-3 text-4xl font-bold sm:text-5xl">{onegodianAppMeta.title}</h1><p className="mt-4 max-w-2xl text-lg text-slate-300">{onegodianAppMeta.description}</p>
+      <div className="mt-8 flex gap-3"><Link href={onegodianAppMeta.primaryCta.href} className="rounded-xl border border-slate-600 px-4 py-3">{onegodianAppMeta.primaryCta.label}</Link><Link href={onegodianAppMeta.secondaryCta.href} className="rounded-xl border border-slate-600 px-4 py-3">{onegodianAppMeta.secondaryCta.label}</Link></div>
+    </section>
+    <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6"><h2 className="text-xl font-semibold">What This App Does</h2><ul className="mt-3 list-disc space-y-2 pl-6 text-slate-300">{whatThisAppDoes.map((item) => <li key={item}>{item}</li>)}</ul></section>
+    <AppStatusPanel />
+    <footer className="border-t border-slate-800 pt-8"><div className="flex flex-wrap gap-4 text-sm">{footerLinks.map((l)=><Link key={l.href} href={l.href}>{l.label}</Link>)}</div><p className="mt-4 text-xs text-slate-400">© 2026 ONEGODIAN™. Designed and written by One Gregory Onegodian™. All Rights Reserved.</p></footer>
+  </div></main>;
 }

--- a/src/components/AppStatusPanel.tsx
+++ b/src/components/AppStatusPanel.tsx
@@ -1,0 +1,18 @@
+import { appStatus } from '@/lib/onegodian-content';
+
+export function AppStatusPanel() {
+  return (
+    <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6">
+      <h2 className="text-xl font-semibold">App Status</h2>
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div><dt className="text-xs text-slate-400">App URL</dt><dd>{appStatus.appUrl}</dd></div>
+        <div><dt className="text-xs text-slate-400">Store URL</dt><dd>{appStatus.store}</dd></div>
+        <div><dt className="text-xs text-slate-400">Public site URL</dt><dd>{appStatus.publicSite}</dd></div>
+        <div><dt className="text-xs text-slate-400">API URL</dt><dd>{appStatus.api}</dd></div>
+        <div><dt className="text-xs text-slate-400">Active campaign</dt><dd>{appStatus.activeCampaign}</dd></div>
+        <div><dt className="text-xs text-slate-400">System status</dt><dd>{appStatus.environment}</dd></div>
+      </dl>
+      <p className="mt-4 text-xs text-slate-400">Last updated: {appStatus.currentDateRecord}</p>
+    </section>
+  );
+}

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,91 +1,24 @@
 'use client';
-
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { gregorianToOT } from '@/lib/onegodian-time';
+import { type ReactNode } from 'react';
+import { appNavigation } from '@/lib/onegodian-content';
 
-const navItems = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Tools', href: '/tools' },
-  { label: 'Plugins', href: '/plugins' },
-  { label: 'App Bridge', href: '/app-bridge' },
-  { label: 'Media', href: '/media' },
-  { label: 'Products', href: '/products' },
-  { label: 'Certificates', href: '/certificates' },
-  { label: 'Settings', href: '/settings' }
-const desktopNav = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Time', href: '/time' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Docs', href: '/docs' },
-  { label: 'Planets', href: '/planets' }
-];
-
-const mobilePrimary = [
-  { icon: '🧭', label: 'Dashboard', href: '/dashboard' },
-  { icon: '🌐', label: 'Ecosystem', href: '/ecosystem' },
-  { icon: '🧩', label: 'Plugins', href: '/plugins' },
-  { icon: '🛰️', label: 'Bridge', href: '/app-bridge' },
-  { icon: '🛠️', label: 'Tools', href: '/tools' }
-  { icon: '🛰️', label: 'Systems', href: '/systems' },
-  { icon: '🕒', label: 'Time', href: '/time' },
-  { icon: '📘', label: 'Docs', href: '/docs' }
-];
+const mobileNav = appNavigation.slice(0, 5).map((item) => ({ ...item, icon: '•' }));
 
 export function AppFrame({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  const [now, setNow] = useState(new Date());
-
-  useEffect(() => {
-    const timer = setInterval(() => setNow(new Date()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const ot = useMemo(() => gregorianToOT(now).display, [now]);
-
-  return (
-    <div className="min-h-screen bg-slate-950 pb-20 text-slate-100 md:pb-0">
-      <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="font-semibold text-cyan-300">OneGodian App</Link>
-          <p className="hidden text-xs text-slate-300 sm:block">OT {ot}</p>
-        </div>
-        <div className="mt-3 hidden overflow-x-auto [scrollbar-width:none] md:block [&::-webkit-scrollbar]:hidden">
-          <nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">
-            {desktopNav.map((item) => {
-              const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-              return (
-                <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
-      </header>
-      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
-      <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 backdrop-blur md:hidden" aria-label="Mobile navigation">
-        <div className="grid grid-cols-5 gap-1">{mobilePrimary.map((item) => {
+  return <div className="min-h-screen bg-slate-950 pb-20 text-slate-100 md:pb-0">
+    <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
+      <Link href="/" className="font-semibold text-cyan-300">OneGodian App</Link>
+      <nav className="mt-3 hidden gap-2 md:flex md:flex-wrap">
+        {appNavigation.map((item) => {
           const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-          return <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}><span>{item.icon}</span><span>{item.label}</span></Link>;
-        })}</div>
-        <div className="grid grid-cols-4 gap-1">
-          {mobilePrimary.map((item) => {
-            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-            return (
-              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-1 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
-                <span>{item.icon}</span>
-                <span>{item.label}</span>
-              </Link>
-            );
-          })}
-        </div>
+          return <Link key={item.href} href={item.href} className={`rounded-full border px-3 py-1 text-sm ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300'}`}>{item.label}</Link>;
+        })}
       </nav>
-    </div>
-  );
+    </header>
+    <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
+    <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 md:hidden"><div className="grid grid-cols-5 gap-1">{mobileNav.map((item) => <Link key={item.href} href={item.href} className="text-center text-xs text-slate-300">{item.label}</Link>)}</div></nav>
+  </div>;
 }

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,0 +1,99 @@
+export const onegodianAppMeta = {
+  eyebrow: 'ONEGODIAN APP',
+  title: 'Your OneGodian Command Dashboard',
+  description:
+    'Access your OneGodian identity, membership tools, certificates, systems, products, media, campaigns, and ecosystem dashboards from one unified app.',
+  primaryCta: {
+    label: 'Open Dashboard',
+    href: '/dashboard'
+  },
+  secondaryCta: {
+    label: 'Explore Ecosystem',
+    href: '/ecosystem'
+  }
+};
+
+export const appNavigation = [
+  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Systems Model', href: '/systems-model' },
+  { label: 'Remember Campaign', href: '/campaigns/remember' },
+  { label: 'Members', href: '/members' },
+  { label: 'Certificates', href: '/certificates' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Products', href: '/products' },
+  { label: 'Media', href: '/media' },
+  { label: 'Profile', href: '/profile' },
+  { label: 'Settings', href: '/settings' },
+  { label: 'Admin', href: '/admin' }
+];
+
+export const dashboardCards = [
+  { title: 'My OneGodian Profile', description: 'View identity details, member status, and app access.', href: '/profile', status: 'Active' },
+  { title: 'Membership', description: 'Access membership records, plans, benefits, and member tools.', href: '/members', status: 'Available' },
+  { title: 'Certificates', description: 'View, verify, and manage OneGodian certificates.', href: '/certificates', status: 'Available' },
+  { title: 'Remember Campaign', description: 'Access campaign tools, visuals, posts, and participation resources.', href: '/campaigns/remember', status: 'Live' },
+  { title: 'Ecosystem', description: 'Navigate OneGodian systems, stores, education, media, and capital portals.', href: '/ecosystem', status: 'Expanded' },
+  { title: 'Tools', description: 'Access system tools, generators, bridge functions, and app utilities.', href: '/tools', status: 'In Progress' },
+  { title: 'Registry', description: 'Review ODIN, certificate, submission, and verification records.', href: '/registry', status: 'Planned' },
+  { title: 'Media Center', description: 'Access campaign media, brand visuals, audio, videos, and press resources.', href: '/media', status: 'Available' }
+];
+
+export const ecosystemPortals = [
+  { name: 'OneGodian Store', description: 'Commerce, products, apparel, books, memberships, and digital downloads.', url: 'https://onegodian.com', type: 'Store / Commerce' },
+  { name: 'OneGodian Official Site', description: 'Public identity, writings, remembrance, articles, founder content, and public education.', url: 'https://onegodian.org', type: 'Public Site' },
+  { name: 'University of OneGodian', description: 'Education, courses, certificates, learning paths, and curriculum.', url: 'https://u.onegodian.org', type: 'Education' },
+  { name: 'OneGodian Capital', description: 'Capital portal, funding materials, financial instruments, and contributor onboarding.', url: 'https://capital.onegodian.com', type: 'Capital' },
+  { name: 'OneGodian App', description: 'Dashboard, systems access, app bridge, tools, profile, and registry.', url: 'https://app.onegodian.com', type: 'Application' },
+  { name: 'OneGodian API', description: 'Runtime API, bridge layer, system health, manifest, and tool endpoints.', url: 'https://api.onegodian.org', type: 'Runtime / API' }
+];
+
+export const rememberCampaign = {
+  name: 'THE ONEGODIAN: Remember Campaign', officialStartDate: 'May 9, 2026', onegodianDate: 'Wisdom 23, OT 0001',
+  purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.',
+  coreMessage: 'You were always One — you simply forgot. Remember who you are.',
+  primaryAudience: ['members', 'supporters', 'families', 'students', 'creators', 'faith-aligned participants', 'global OneGodian allies'],
+  sections: [
+    { title: 'Why', body: 'To remind people of shared origin, dignity, identity, and belonging through OneGodian remembrance.' },
+    { title: 'What', body: 'A campaign using apparel, media, posts, videos, events, storefront displays, identity tools, and educational content.' },
+    { title: 'Who', body: 'For members, supporters, learners, families, creators, institutions, and respectful observers of OneGodian principles.' },
+    { title: 'When', body: 'Officially launched May 9, 2026 / Wisdom 23, OT 0001.' },
+    { title: 'How', body: 'Through coordinated content, store products, member participation, campaign visuals, public education, and app-based dashboard access.' }
+  ]
+};
+
+export const systemsModel = [
+  { title: 'Identity Layer', items: ['Profile', 'Membership', 'OneGodian ID', 'Certificates', 'QR-V Verification'] },
+  { title: 'Ecosystem Layer', items: ['Store', 'Education', 'Capital', 'Media', 'Products', 'Members'] },
+  { title: 'Registry Layer', items: ['ODIN Registry', 'OBP-1 Records', 'Certificate Archive', 'Submission Logs'] },
+  { title: 'Execution Layer', items: ['Tools', 'Runtime APIs', 'App Bridge', 'Agent Console', 'Status Checks'] },
+  { title: 'Governance / Compliance Layer', items: ['Terms', 'IP Notices', 'System Records', 'Documentation', 'Audit Logs'] }
+];
+
+export const whatThisAppDoes = [
+  'Connects members to OneGodian identity and membership tools.',
+  'Provides access to certificates, verification, and registry records.',
+  'Organizes OneGodian systems into one operational dashboard.',
+  'Links the store, education platform, capital portal, media center, and public sites.',
+  'Supports campaign execution for THE ONEGODIAN: Remember Campaign.',
+  'Prepares the foundation for app bridge, agent tools, API runtime, and administrative control.'
+];
+
+export const appStatus = {
+  environment: 'Production Preparation',
+  appUrl: 'https://app.onegodian.com',
+  publicSite: 'https://onegodian.org',
+  store: 'https://onegodian.com',
+  api: 'https://api.onegodian.org',
+  activeCampaign: 'THE ONEGODIAN: Remember Campaign',
+  currentDateRecord: 'Wisdom 25, OT 0001 / May 11, 2026'
+};
+
+export const footerLinks = [
+  { label: 'OneGodian Store', href: 'https://onegodian.com' },
+  { label: 'Official Site', href: 'https://onegodian.org' },
+  { label: 'University', href: 'https://u.onegodian.org' },
+  { label: 'Capital Portal', href: 'https://capital.onegodian.com' },
+  { label: 'API Status', href: 'https://api.onegodian.org/api/health' }
+];


### PR DESCRIPTION
### Motivation

- Consolidate scattered content into a single reusable data source and reposition the app as the official OneGodian command dashboard.  
- Surface campaign, systems, registry, and ecosystem portals in-app so members can access identity, membership, certificates, and operational tools from one place.  
- Provide simple status and metadata surfaces to prepare the app for production readiness and consistent routing.

### Description

- Add centralized content file `src/lib/onegodian-content.ts` exporting `onegodianAppMeta`, `appNavigation`, `dashboardCards`, `ecosystemPortals`, `rememberCampaign`, `systemsModel`, `whatThisAppDoes`, `appStatus`, and `footerLinks`.  
- Add reusable status component `src/components/AppStatusPanel.tsx` and wire it into the homepage and dashboard.  
- Update navigation frame `src/components/app-frame.tsx` to use `appNavigation`, and update homepage `src/app/page.tsx`, dashboard `src/app/(app)/dashboard/page.tsx`, and ecosystem `src/app/(app)/ecosystem/page.tsx` to consume centralized data and the new sections.  
- Add new routes and pages for the campaign and model at `src/app/(app)/campaigns/remember/page.tsx` and `src/app/(app)/systems-model/page.tsx`, and add page-level `metadata` to the major routes listed in the task.

### Testing

- Ran `npm run lint` which completed with no ESLint warnings or errors.  
- Ran `npm run build` which compiled successfully and generated static pages for the app (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e687b3c4832d86b33982605156c6)