### PR TITLE
Fix lint parse errors and restore successful production build

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -8,7 +8,9 @@ export default function DashboardPage() {
         <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
           <p className="text-xs uppercase tracking-[0.18em] text-cyan-300">OneGodian Command Dashboard</p>
           <h1 className="mt-2 text-3xl font-bold sm:text-4xl">Operational Command Surface</h1>
-          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">Unified view of every OneGodian app system and operating readiness.</p>
+          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">
+            Unified view of every OneGodian app system and operating readiness.
+          </p>
           <div className="mt-4 flex flex-wrap gap-3 text-sm text-slate-300">
             <span>Systems: {appModules.length}</span>
             <span>Live: {liveSystems.length}</span>
@@ -19,13 +21,21 @@ export default function DashboardPage() {
         <section>
           <h2 className="mb-3 text-xl font-semibold">System Modules</h2>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {appModules.map((module) => (
-              <Link key={module.slug} href={module.route} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 transition hover:border-cyan-400/60">
+            {appModules.map((appModule) => (
+              <Link
+                key={appModule.slug}
+                href={appModule.route}
+                className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 transition hover:border-cyan-400/60"
+              >
                 <div className="flex items-center justify-between gap-3">
-                  <h3 className="font-semibold">{module.title}</h3>
-                  <span className="rounded-full border border-slate-600 px-2 py-1 text-xs text-slate-300">{module.productionStatus}</span>
+                  <h3 className="font-semibold">{appModule.title}</h3>
+                  <span className="rounded-full border border-slate-600 px-2 py-1 text-xs text-slate-300">
+                    {appModule.productionStatus}
+                  </span>
                 </div>
-                <p className="mt-2 text-sm text-slate-300">{module.odinCode} · {module.version}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {appModule.odinCode} · {appModule.version}
+                </p>
               </Link>
             ))}
           </div>
@@ -33,15 +43,4 @@ export default function DashboardPage() {
       </div>
     </main>
   );
-import { AppStatusPanel } from '@/components/AppStatusPanel';
-import { dashboardCards, whatThisAppDoes } from '@/lib/onegodian-content';
-
-export const metadata = { title: 'OneGodian App | Command Dashboard', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
-
-export default function DashboardPage() {
-  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OneGodian App Dashboard</h1></header>
-  <section><h2 className="mb-3 text-xl font-semibold">Command Modules</h2><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{dashboardCards.map((card)=><Link key={card.href} href={card.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h3 className="font-medium">{card.title}</h3><p className="mt-2 text-sm text-slate-300">{card.description}</p><p className="mt-2 text-xs text-cyan-300">{card.status}</p></Link>)}</div></section>
-  <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6"><h2 className="text-xl font-semibold">What This App Does</h2><ul className="mt-3 list-disc space-y-2 pl-6 text-slate-300">{whatThisAppDoes.map((item) => <li key={item}>{item}</li>)}</ul></section>
-  <AppStatusPanel />
-  </main>;
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
@@ -37,7 +38,9 @@ export function AppFrame({ children }: { children: ReactNode }) {
     <div className="min-h-screen bg-slate-950 pb-20 text-slate-100 md:pb-0">
       <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
         <div className="flex items-center justify-between">
-          <Link href="/" className="font-semibold text-cyan-300">OneGodian App</Link>
+          <Link href="/" className="font-semibold text-cyan-300">
+            OneGodian App
+          </Link>
           <p className="hidden text-xs text-slate-300 sm:block">OT {ot}</p>
         </div>
         <div className="mt-3 hidden overflow-x-auto [scrollbar-width:none] md:block [&::-webkit-scrollbar]:hidden">
@@ -45,7 +48,15 @@ export function AppFrame({ children }: { children: ReactNode }) {
             {desktopNav.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
-                <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${
+                    active
+                      ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200'
+                      : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'
+                  }`}
+                >
                   {item.label}
                 </Link>
               );
@@ -54,36 +65,28 @@ export function AppFrame({ children }: { children: ReactNode }) {
         </div>
       </header>
       <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
-      <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 backdrop-blur md:hidden" aria-label="Mobile navigation">
+      <nav
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 backdrop-blur md:hidden"
+        aria-label="Mobile navigation"
+      >
         <div className="grid grid-cols-5 gap-1">
           {mobilePrimary.map((item) => {
             const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
             return (
-              <Link key={item.href} href={item.href} className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'}`}>
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex min-h-12 flex-col items-center justify-center rounded-lg px-2 py-1 text-[11px] ${
+                  active ? 'bg-cyan-500/20 text-cyan-200' : 'text-slate-300'
+                }`}
+              >
                 <span>{item.icon}</span>
                 <span>{item.label}</span>
               </Link>
             );
           })}
         </div>
-import { type ReactNode } from 'react';
-import { appNavigation } from '@/lib/onegodian-content';
-
-const mobileNav = appNavigation.slice(0, 5).map((item) => ({ ...item, icon: '•' }));
-
-export function AppFrame({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
-  return <div className="min-h-screen bg-slate-950 pb-20 text-slate-100 md:pb-0">
-    <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
-      <Link href="/" className="font-semibold text-cyan-300">OneGodian App</Link>
-      <nav className="mt-3 hidden gap-2 md:flex md:flex-wrap">
-        {appNavigation.map((item) => {
-          const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-          return <Link key={item.href} href={item.href} className={`rounded-full border px-3 py-1 text-sm ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300'}`}>{item.label}</Link>;
-        })}
       </nav>
-    </header>
-    <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
-    <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-700 bg-slate-950/95 p-2 md:hidden"><div className="grid grid-cols-5 gap-1">{mobileNav.map((item) => <Link key={item.href} href={item.href} className="text-center text-xs text-slate-300">{item.label}</Link>)}</div></nav>
-  </div>;
+    </div>
+  );
 }

--- a/src/lib/app-modules.ts
+++ b/src/lib/app-modules.ts
@@ -55,21 +55,21 @@ export const appModules: AppModule[] = [
 ];
 
 export function getAppModuleBySlug(slug: string) {
-  return appModules.find((module) => module.slug === slug);
+  return appModules.find((appModule) => appModule.slug === slug);
 }
 
 export function getAppModulesByCategory(category: string) {
-  return appModules.filter((module) => module.category === category);
+  return appModules.filter((appModule) => appModule.category === category);
 }
 
 export function getConnectedModules(slug: string) {
-  const module = getAppModuleBySlug(slug);
-  if (!module) return [];
-  return module.connectedSystemIds
+  const appModule = getAppModuleBySlug(slug);
+  if (!appModule) return [];
+  return appModule.connectedSystemIds
     .map((id) => getAppModuleBySlug(id))
     .filter((connectedModule): connectedModule is AppModule => Boolean(connectedModule));
 }
 
-export const liveSystems = appModules.filter((module) => module.productionStatus === 'Live');
+export const liveSystems = appModules.filter((appModule) => appModule.productionStatus === 'Live');
 
-export const criticalSystems = appModules.filter((module) => module.priority === 'Critical');
+export const criticalSystems = appModules.filter((appModule) => appModule.priority === 'Critical');


### PR DESCRIPTION
### Motivation
- Stabilize CI/lint and production build after homepage and systems model updates that introduced parse/lint failures. 
- Remove duplicated/merged-conflict-like content that caused JSX/parse errors and ESLint rule violations.

### Description
- Cleaned up `src/app/(app)/dashboard/page.tsx` by removing duplicated conflicting content and keeping a single valid `DashboardPage` component with consistent JSX formatting. 
- Cleaned up `src/components/app-frame.tsx` by removing duplicated trailing content and restoring a single valid `AppFrame` component with balanced JSX and mobile/desktop nav. 
- Renamed local callback variables from `module` to `appModule` in `src/lib/app-modules.ts` helpers (`getAppModuleBySlug`, `getAppModulesByCategory`, `getConnectedModules`, `liveSystems`, `criticalSystems`) to avoid the Next.js rule `@next/next/no-assign-module-variable`.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors (`next lint` reported "No ESLint warnings or errors").
- Ran `npm run build` which compiled successfully and completed page generation (Next reported "Compiled successfully" and prerendering/route generation completed).
- Both automated checks (`npm run lint` and `npm run build`) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ec37e0d4832d9e22edfb96b2b95d)