### PR TITLE
feat: expand app navigation and command center modules

### DIFF
--- a/src/app/(app)/community/page.tsx
+++ b/src/app/(app)/community/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function CommunityRedirectPage() {
+  redirect('/algorithm/community');
+}

--- a/src/app/(app)/store/page.tsx
+++ b/src/app/(app)/store/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function StoreRedirectPage() {
+  redirect('/products');
+}

--- a/src/app/(app)/verification/page.tsx
+++ b/src/app/(app)/verification/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function VerificationRedirectPage() {
+  redirect('/verify');
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { CapitalReadinessTable } from './components/CapitalReadinessTable';
 import { readinessItems } from './data';
 
@@ -6,6 +7,26 @@ const boundaryCards = [
   { title: 'Hostinger Node App', detail: 'Capital portal application layer.' },
   { title: 'API / Database', detail: 'Records, ledgers, disclosures, and certificates.' },
   { title: 'QR-V Network', detail: 'Verification infrastructure layer.' }
+];
+
+const commandCenterModules = [
+  { title: 'ODIN Registry', href: '/odin' },
+  { title: 'Planetary Registry', href: '/odin/planetary-registry' },
+  { title: 'Moons & Systems', href: '/moons-systems' },
+  { title: 'Learn Portal', href: '/learn' },
+  { title: 'Identity Wallet', href: '/identity' },
+  { title: 'Verification Tools', href: '/verification' },
+  { title: 'Capital Access', href: '/capital' },
+  { title: 'Media Center', href: '/media' },
+  { title: 'Storefront', href: '/store' },
+  { title: 'OneGodian Time', href: '/time' }
+];
+
+const externalBridges = [
+  { title: 'Student Portal', href: 'https://u.onegodian.org/dashboard' },
+  { title: 'Courses', href: 'https://u.onegodian.org/courses' },
+  { title: 'Onegodianese™ Curriculum', href: 'https://u.onegodian.org/curriculum' },
+  { title: 'Developer/API Access', href: '/developer' }
 ];
 
 export default function HomePage() {
@@ -33,6 +54,37 @@ export default function HomePage() {
         <section>
           <h2 className="mb-4 text-2xl font-semibold">Production Readiness Snapshot</h2>
           <CapitalReadinessTable items={readinessItems} />
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Command Center Modules</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {commandCenterModules.map((card) => (
+              <Link key={card.title} href={card.href} className="rounded-2xl border border-slate-700 bg-slate-900/60 p-5 transition hover:border-cyan-400/60 hover:text-cyan-200">
+                <h3 className="text-lg font-semibold">{card.title}</h3>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">External Platform Bridges</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {externalBridges.map((card) => {
+              const external = card.href.startsWith('http');
+              return (
+                <Link
+                  key={card.title}
+                  href={card.href}
+                  target={external ? '_blank' : undefined}
+                  rel={external ? 'noreferrer noopener' : undefined}
+                  className="rounded-2xl border border-slate-700 bg-slate-900/60 p-5 transition hover:border-cyan-400/60 hover:text-cyan-200"
+                >
+                  <h3 className="text-lg font-semibold">{card.title}</h3>
+                </Link>
+              );
+            })}
+          </div>
         </section>
       </div>
     </main>

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,22 +5,27 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { gregorianToOT } from '@/lib/onegodian-time';
 
-const desktopNav = [
-  { label: 'Dashboard', href: '/dashboard' },
+const topNav = [
+  { label: 'Dashboard', href: '/' },
   { label: 'Ecosystem', href: '/ecosystem' },
   { label: 'Registry', href: '/registry' },
-  { label: 'Galaxy', href: '/galaxy' },
-  { label: 'Tools', href: '/tools' },
-  { label: 'Time', href: '/time' },
-  { label: 'Media', href: '/media' }
+  { label: 'Planets', href: '/odin/planetary-registry' },
+  { label: 'ODIN', href: '/odin' },
+  { label: 'Learn', href: '/learn' },
+  { label: 'Identity', href: '/identity' },
+  { label: 'Verification', href: '/verification' },
+  { label: 'Capital', href: '/capital' },
+  { label: 'Media', href: '/media' },
+  { label: 'Store', href: '/store' },
+  { label: 'Time', href: '/time' }
 ];
 
 const mobilePrimary = [
-  { icon: '🧭', label: 'Dashboard', href: '/dashboard' },
-  { icon: '🌐', label: 'Ecosystem', href: '/ecosystem' },
-  { icon: '🗂️', label: 'Registry', href: '/registry' },
-  { icon: '🛰️', label: 'Galaxy', href: '/galaxy' },
-  { icon: '🛠️', label: 'Tools', href: '/tools' }
+  { icon: '🏠', label: 'Home', href: '/' },
+  { icon: '🌐', label: 'Systems', href: '/ecosystem' },
+  { icon: '📘', label: 'Learn', href: '/learn' },
+  { icon: '🤝', label: 'Community', href: '/community' },
+  { icon: '🪪', label: 'Identity', href: '/identity' }
 ];
 
 export function AppFrame({ children }: { children: ReactNode }) {
@@ -43,9 +48,9 @@ export function AppFrame({ children }: { children: ReactNode }) {
           </Link>
           <p className="hidden text-xs text-slate-300 sm:block">OT {ot}</p>
         </div>
-        <div className="mt-3 hidden overflow-x-auto [scrollbar-width:none] md:block [&::-webkit-scrollbar]:hidden">
+        <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">
-            {desktopNav.map((item) => {
+            {topNav.map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link


### PR DESCRIPTION
### Motivation
- Expand the main app navigation to reflect the new Command Center scope and make navigation easier to use on mobile. 
- Surface the most-used modules on the homepage so users can jump to command functions quickly. 
- Preserve existing pages and the current visual style (dark background, cyan accents, large white headings, rounded dark cards, mobile-first spacing). 

### Description
- Updated `src/components/app-frame.tsx` to replace the old nav with the full top navigation (Dashboard `/`, Ecosystem `/ecosystem`, Registry `/registry`, Planets `/odin/planetary-registry`, ODIN `/odin`, Learn `/learn`, Identity `/identity`, Verification `/verification`, Capital `/capital`, Media `/media`, Store `/store`, Time `/time`) and made the nav horizontally scrollable with `overflow-x-auto`, `flex-nowrap`, preserved spacing, and hidden scrollbar styling. 
- Reworked the mobile bottom nav in `src/components/app-frame.tsx` to provide tabs `Home` (`/`), `Systems` (`/ecosystem`), `Learn` (`/learn`), `Community` (`/community`), and `Identity` (`/identity`) while preserving active and hover states and visual style. 
- Replaced the homepage `src/app/page.tsx` content to add a `Command Center Modules` section with clickable cards linking to internal routes and an `External Platform Bridges` section with cards linking to `https://u.onegodian.org` as requested. 
- Added lightweight redirect pages at `src/app/(app)/verification/page.tsx`, `src/app/(app)/store/page.tsx`, and `src/app/(app)/community/page.tsx` to preserve navigation consistency while keeping existing target pages functional. 

### Testing
- `npm run check` failed due to a pre-existing syntax error in `server.js` (duplicate `OMOSProcess` declaration) and is unrelated to the UI changes. 
- `npm run build` completed successfully and the Next.js production build generated the expected routes. 
- `npm run lint` completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0845c3d2e0832da8f2cf317a6abead)