### PR TITLE
Add /api/version endpoint for production build verification

### DIFF
--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+const APP_NAME = 'OneGodian Control Plane';
+const APP_VERSION = process.env.npm_package_version ?? '0.1.0';
+const BUILD_MARKER = process.env.BUILD_MARKER ?? process.env.VERCEL_GIT_COMMIT_SHA ?? 'unknown';
+
+export async function GET() {
+  return NextResponse.json({
+    app: APP_NAME,
+    version: APP_VERSION,
+    buildMarker: BUILD_MARKER,
+    timestamp: new Date().toISOString()
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reliable endpoint to verify that the production server is running the expected compiled build by exposing a version and build marker for troubleshooting stale deployments.

### Description
- Add `src/app/api/version/route.ts`, a Next.js API route that returns JSON with `app`, `version`, `buildMarker`, and `timestamp`, where `version` is derived from `process.env.npm_package_version` and `buildMarker` falls back to `process.env.BUILD_MARKER` or `process.env.VERCEL_GIT_COMMIT_SHA` with an `'unknown'` fallback.

### Testing
- Ran `npm run lint`, `npx tsc --noEmit`, and `npm run build`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085537b790832db9325497b0064748)