### PR TITLE
Separate app.onegodian.com and console.onegodian.com with host-based guards

### DIFF
--- a/DOMAIN_SEPARATION.md
+++ b/DOMAIN_SEPARATION.md
@@ -1,0 +1,13 @@
+# OneGodian Domain Separation
+
+## app.onegodian.com
+Public/member OneGodian App surface.
+
+## console.onegodian.com
+Internal OneGodian Console surface with privileged controls.
+
+## Enforcement
+- Host-aware route allowlists in `src/middleware.ts`
+- Member surface and operator surface have different navigation labels
+- Console responses include noindex headers
+- Console route rewrites to `/admin/*` internal structure

--- a/README_APP.md
+++ b/README_APP.md
@@ -1,0 +1,10 @@
+# OneGodian App (app.onegodian.com)
+Public/member-facing surface for dashboards, tools, ecosystem browsing, registry viewing, onboarding, certificates, products, media, settings, and docs.
+
+## Allowed routes
+/dashboard, /ecosystem, /registry, /tools, /members, /certificates, /products, /media, /settings, /docs
+
+## Allowed APIs
+/api/health, /api/manifest, /api/tools, /api/stats
+
+Internal operator/admin controls are disabled on this surface.

--- a/README_CONSOLE.md
+++ b/README_CONSOLE.md
@@ -1,0 +1,8 @@
+# OneGodian Console (console.onegodian.com)
+Internal operator/admin control plane for ACC™, OCP, OEG, workflows, policies, approvals, audit logs, adapters, deployment controls, and kill-switch governance.
+
+## Console responsibilities
+- Operator/admin-only routes and APIs
+- OCP authorization for privileged actions
+- No autonomous self-authorization for agents
+- No public signup/indexing

--- a/src/app/(admin)/admin/adapters/page.tsx
+++ b/src/app/(admin)/admin/adapters/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · adapters</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/agents/health/page.tsx
+++ b/src/app/(admin)/admin/agents/health/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · agents/health</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/agents/page.tsx
+++ b/src/app/(admin)/admin/agents/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · agents</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/agents/registry/page.tsx
+++ b/src/app/(admin)/admin/agents/registry/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · agents/registry</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/approvals/page.tsx
+++ b/src/app/(admin)/admin/approvals/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · approvals</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/audit/page.tsx
+++ b/src/app/(admin)/admin/audit/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · audit</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · dashboard</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/logs/page.tsx
+++ b/src/app/(admin)/admin/logs/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · logs</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/ocp/decisions/page.tsx
+++ b/src/app/(admin)/admin/ocp/decisions/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · ocp/decisions</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/ocp/page.tsx
+++ b/src/app/(admin)/admin/ocp/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · ocp</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/ocp/policies/page.tsx
+++ b/src/app/(admin)/admin/ocp/policies/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · ocp/policies</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/oeg/page.tsx
+++ b/src/app/(admin)/admin/oeg/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · oeg</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/oeg/routes/page.tsx
+++ b/src/app/(admin)/admin/oeg/routes/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · oeg/routes</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,9 +1,1 @@
-import Link from 'next/link';
-
-const panels = ['Dashboard', 'Settings', 'App Bridge', 'API Keys', 'Submissions', 'Tools', 'Status', 'Production Checklist', 'Documentation', 'Logs / audit trail'];
-
-export default function AdminPage() {
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">Admin / Control Panel</h1><p className="mt-2 text-slate-300">Role-based admin gating placeholder with secure bridge key handling and environment review.</p></header>
-  <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{panels.map((item)=><article key={item} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">{item}</h2><p className="mt-2 text-xs text-slate-300">Operational placeholder</p></article>)}</section>
-  <Link href="/docs" className="inline-block text-cyan-300">Open documentation</Link></main>;
-}
+export default function Page() { return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">OneGodian Console · admin</h1><p className="mt-2 text-slate-300">Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · settings</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/status/page.tsx
+++ b/src/app/(admin)/admin/status/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · status</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/tasks/page.tsx
+++ b/src/app/(admin)/admin/tasks/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · tasks</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/(admin)/admin/workflows/page.tsx
+++ b/src/app/(admin)/admin/workflows/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · workflows</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function GET() { return NextResponse.json({ service: 'agents', surface: 'console', status: 'ok' }); }

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function GET() { return NextResponse.json({ surface: 'console', status: 'ok', logs: [] }); }

--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -1,2 +1,12 @@
 import { NextResponse } from 'next/server';
-export async function GET() { return NextResponse.json({ app: 'OneGodian Control Plane', domain: 'app.onegodian.com', type: 'control-plane', modules: ['dashboard','ecosystem','apps','plugins','registry','certificates','members','tools','campaigns','media','api-status','admin'] }); }
+import { headers } from 'next/headers';
+
+export async function GET() {
+  const host = headers().get('host') ?? '';
+  const isConsole = host.startsWith('console.onegodian.com');
+  return NextResponse.json(
+    isConsole
+      ? { app: 'OneGodian Console', domain: 'console.onegodian.com', type: 'internal-control-plane', modules: ['admin','dashboard','agents','tasks','workflows','ocp','oeg','adapters','approvals','audit','logs','settings','status'] }
+      : { app: 'OneGodian App', domain: 'app.onegodian.com', type: 'public-member-app', modules: ['dashboard','ecosystem','registry','tools','members','certificates','products','media','settings','docs'] }
+  );
+}

--- a/src/app/api/ocp/authorize/route.ts
+++ b/src/app/api/ocp/authorize/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function POST() { return NextResponse.json({ authorized: false, reason: 'ocp_review_required' }, { status: 403 }); }

--- a/src/app/api/oeg/execute/route.ts
+++ b/src/app/api/oeg/execute/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function POST() { return NextResponse.json({ executed: false, reason: 'ocp_authorization_required' }, { status: 403 }); }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function GET() { return NextResponse.json({ service: 'tasks', surface: 'console', status: 'ok' }); }

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server';
+export async function GET() { return NextResponse.json({ service: 'workflows', surface: 'console', status: 'ok' }); }

--- a/src/app/components/CapitalNavigation.tsx
+++ b/src/app/components/CapitalNavigation.tsx
@@ -1,6 +1,13 @@
 import Link from 'next/link';
-import { appNavigation, ecosystemLinks } from '@/lib/onegodian-content';
+import { headers } from 'next/headers';
+import { appNavigation, consoleNavigation, ecosystemLinks } from '@/lib/onegodian-content';
 
 export function CapitalNavigation() {
-  return <header className="capital-header"><div className="capital-header-inner"><Link href="/" className="capital-logo"><span className="capital-logo-mark">OG</span> OneGodian Control Plane</Link><nav className="capital-nav" aria-label="Primary">{appNavigation.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}</nav><nav className="capital-ecosystem-nav" aria-label="Ecosystem">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer">{item.label}</a>)}</nav></div></header>;
+  const host = headers().get('host') ?? '';
+  const isConsole = host.startsWith('console.onegodian.com');
+  const title = isConsole ? 'OneGodian Console' : 'OneGodian App';
+  const nav = isConsole ? consoleNavigation : appNavigation;
+  const env = process.env.ONEGODIAN_ENV ?? process.env.NODE_ENV ?? 'dev';
+
+  return <header className="capital-header"><div className="capital-header-inner"><Link href={isConsole ? '/admin' : '/dashboard'} className="capital-logo"><span className="capital-logo-mark">OG</span> {title}</Link>{isConsole ? <span className="rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs text-amber-200">{env}</span> : null}<nav className="capital-nav" aria-label="Primary">{nav.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}</nav><nav className="capital-ecosystem-nav" aria-label="Ecosystem">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer">{item.label}</a>)}</nav></div></header>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { CapitalNavigation } from './components/CapitalNavigation';
 import { CapitalFooter } from './components/CapitalFooter';
 
-export const metadata: Metadata = { title: 'OneGodian Control Plane', description: 'OneGodian App Command Dashboard for app.onegodian.com' };
+export const metadata: Metadata = { title: 'OneGodian Domain Surfaces', description: 'Separated app.onegodian.com member app and console.onegodian.com operator console.' };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return <html lang="en"><body><CapitalNavigation />{children}<CapitalFooter /></body></html>;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/admin', '/agents', '/tasks', '/workflows', '/ocp', '/oeg', '/adapters', '/approvals', '/audit', '/logs']
+    }
+  };
+}

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,6 +1,6 @@
 export const appMeta = {
-  eyebrow: 'APP.ONEGODIAN.COM · CONTROL PLANE',
-  title: 'OneGodian Control Plane',
+  eyebrow: 'APP.ONEGODIAN.COM · MEMBER APP',
+  title: 'OneGodian App',
   description:
     'The unified command dashboard for OneGodian apps, plugins, registries, certificates, campaigns, media, tools, and ecosystem operations.',
   primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
@@ -8,9 +8,15 @@ export const appMeta = {
 };
 
 export const appNavigation = [
-  { label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Apps', href: '/apps' }, { label: 'Plugins', href: '/plugins' },
-  { label: 'Registry', href: '/registry' }, { label: 'Certificates', href: '/certificates' }, { label: 'Members', href: '/members' }, { label: 'Tools', href: '/tools' },
-  { label: 'Campaigns', href: '/campaigns' }, { label: 'Media', href: '/media' }, { label: 'API Status', href: '/api-status' }, { label: 'Admin', href: '/admin' }
+  { label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Registry', href: '/registry' },
+  { label: 'Tools', href: '/tools' }, { label: 'Members', href: '/members' }, { label: 'Certificates', href: '/certificates' },
+  { label: 'Products', href: '/products' }, { label: 'Media', href: '/media' }, { label: 'Settings', href: '/settings' }, { label: 'Docs', href: '/docs' }
+];
+
+export const consoleNavigation = [
+  { label: 'Admin', href: '/admin' }, { label: 'Dashboard', href: '/dashboard' }, { label: 'Agents', href: '/agents' },
+  { label: 'Tasks', href: '/tasks' }, { label: 'Workflows', href: '/workflows' }, { label: 'OCP', href: '/ocp' },
+  { label: 'OEG', href: '/oeg' }, { label: 'Audit', href: '/audit' }, { label: 'Logs', href: '/logs' }, { label: 'Status', href: '/status' }
 ];
 
 export const ecosystemLinks = [
@@ -30,7 +36,7 @@ export const dashboardCards = [
 ];
 
 export const appStructureLayers = ['Public App', 'Dashboard', 'Admin', 'API / Bridge', 'Data', 'Security', 'UI / UX', 'Documentation', 'Compliance', 'Deployment'];
-export const coreRoutes = ['/dashboard', '/ecosystem', '/registry', '/tools', '/members', '/certificates', '/products', '/media', '/settings', '/admin', '/api/health', '/api/manifest', '/api/tools', '/api/stats'];
+export const coreRoutes = ['/dashboard', '/ecosystem', '/registry', '/tools', '/members', '/certificates', '/products', '/media', '/settings', '/docs', '/api/health', '/api/manifest', '/api/tools', '/api/stats'];
 
 export const pluginCategories = [{ title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }, { title: 'Commerce Plugins', plugins: ['OneGodian Store Plugin', 'OneGodian Products Plugin', 'OneGodian Contributor Plugin', 'OneGodian Affiliate Plugin', 'OneGodian Capital Plugin'] }, { title: 'Education Plugins', plugins: ['U OneGodian LMS Plugin', 'OneGodian Courses Plugin', 'OneGodian Certificates for Learning Plugin', 'OneGodian Student Portal Plugin'] }, { title: 'Media & Campaign Plugins', plugins: ['OneGodian Media Center Plugin', 'Remember Campaign Plugin', 'OneGodian Creator Network Plugin', 'OneGodian Press Kit Plugin'] }, { title: 'Runtime / API Plugins', plugins: ['OneGodian API Bridge Plugin', 'OneGodian Tools Runtime Plugin', 'OneGodian Manifest Plugin', 'OneGodian Status Monitor Plugin'] }];
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const APP_ALLOWED = new Set([
+  '/dashboard','/ecosystem','/registry','/tools','/members','/certificates','/products','/media','/settings','/docs','/api/health','/api/manifest','/api/tools','/api/stats'
+]);
+
+const CONSOLE_ALLOWED_PREFIXES = ['/admin','/dashboard','/agents','/tasks','/workflows','/ocp','/oeg','/adapters','/approvals','/audit','/logs','/settings','/status','/api/health','/api/manifest','/api/agents','/api/tasks','/api/workflows','/api/ocp/authorize','/api/oeg/execute','/api/audit'];
+
+function roleForRequest(req: NextRequest): 'member' | 'operator' | 'admin' {
+  const role = req.headers.get('x-onegodian-role') || req.cookies.get('onegodian_role')?.value || 'member';
+  return role === 'admin' || role === 'operator' ? role : 'member';
+}
+
+export function middleware(req: NextRequest) {
+  const host = req.headers.get('host') ?? '';
+  const path = req.nextUrl.pathname;
+  const role = roleForRequest(req);
+
+  if (host.startsWith('app.onegodian.com')) {
+    if (path === '/' || path === '') return NextResponse.redirect(new URL('/dashboard', req.url));
+    if (![...APP_ALLOWED].some((p) => path === p || path.startsWith(`${p}/`))) {
+      return NextResponse.rewrite(new URL('/dashboard', req.url));
+    }
+    if (role === 'operator' || role === 'admin') {
+      const res = NextResponse.next();
+      res.headers.set('x-onegodian-surface', 'app');
+      return res;
+    }
+  }
+
+  if (host.startsWith('console.onegodian.com')) {
+    if (path === '/' || path === '') return NextResponse.redirect(new URL('/admin', req.url));
+    if (!CONSOLE_ALLOWED_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`))) {
+      return NextResponse.rewrite(new URL('/admin', req.url));
+    }
+    if (path !== '/admin' && !path.startsWith('/admin/')) {
+      return NextResponse.rewrite(new URL(`/admin${path}`, req.url));
+    }
+    if (role !== 'operator' && role !== 'admin') {
+      return NextResponse.json({ error: 'operator_or_admin_required' }, { status: 403 });
+    }
+    const res = NextResponse.next();
+    res.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
+    res.headers.set('x-onegodian-surface', 'console');
+    return res;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = { matcher: ['/((?!_next|favicon.ico).*)'] };


### PR DESCRIPTION
### Motivation
- Enforce strict separation between the public/member-facing App surface and the internal operator Console to avoid mixing public content with privileged control-plane functionality.
- Prevent autonomous/agent self-authorization and ensure privileged actions require OCP authorization and operator/admin context.
- Make Console clearly visually and programmatically distinct (labels, environment badge, noindex) and document domain model.

### Description
- Added host-aware middleware in `src/middleware.ts` that enforces allowlists: `app.onegodian.com` only serves approved public/member routes and `console.onegodian.com` only serves console/operator routes and rewrites non-`/admin/*` console paths into the internal `/admin/*` structure.
- Implemented role derivation from `x-onegodian-role` header or `onegodian_role` cookie and enforced operator/admin gating for console routes (returns `403` for non-operators), and set response headers (`x-onegodian-surface`, `X-Robots-Tag`).
- Updated navigation and layout to show distinct headers: `OneGodian App` for the public surface and `OneGodian Console` for the operator surface with an environment badge, and extracted `consoleNavigation` in `src/lib/onegodian-content.ts`.
- Made `/api/manifest` host-aware in `src/app/api/manifest/route.ts` to return domain-specific metadata, and added console API stubs for `agents`, `tasks`, `workflows`, `ocp/authorize`, `oeg/execute`, and `audit` that enforce OCP-first/stubbed 403 behavior for privileged execution.
- Added console internal routes under `src/app/(admin)/admin/*` for `admin`, `dashboard`, `agents`, `agents/registry`, `agents/health`, `tasks`, `workflows`, `ocp`, `ocp/policies`, `ocp/decisions`, `oeg`, `oeg/routes`, `adapters`, `approvals`, `audit`, `logs`, `settings`, and `status`.
- Added `src/app/robots.ts` and `X-Robots-Tag` responses to protect console from indexing, and added documentation files `README_APP.md`, `README_CONSOLE.md`, and `DOMAIN_SEPARATION.md` describing the domain model and allowed routes/APIs.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors (success).
- Ran `npm run build` which compiled successfully and generated the production build and static pages (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b451558c0832d82cbc2488efa0883)