### PR TITLE
Add Dual Dating System™ page and link from Time

### DIFF
--- a/src/app/(app)/time/dual-dating/page.tsx
+++ b/src/app/(app)/time/dual-dating/page.tsx
@@ -1,0 +1,105 @@
+const cardClass = "rounded-2xl border border-cyan-500/30 bg-slate-950/70 p-5 shadow-[0_0_30px_rgba(6,182,212,0.08)]";
+
+export default function DualDatingPage() {
+  return (
+    <main className="min-h-screen space-y-6 bg-gradient-to-b from-slate-950 via-slate-900 to-black p-4 pb-10 text-slate-100 sm:p-6">
+      <section className="rounded-3xl border border-cyan-400/30 bg-slate-950/80 p-6 shadow-[0_0_40px_rgba(6,182,212,0.15)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-cyan-300">OTS-V5 Standard</p>
+        <h1 className="mt-2 text-3xl font-bold text-cyan-100 sm:text-4xl">Dual Dating System™</h1>
+        <p className="mt-3 max-w-3xl text-base text-slate-300 sm:text-lg">
+          Gregorian Time controls legally. OneGodian Time provides internal sequencing.
+        </p>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">What Dual Dating Means</h2>
+        <p className="mt-3 text-slate-300">
+          OTS-V5 requires two coordinated references: Gregorian Time (GT) for external/legal clarity and
+          OneGodian Time™ (OT) for supplemental internal sequencing.
+        </p>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Required Format</h2>
+        <p className="mt-3 text-slate-300">Use OT with GT in parentheses for public context:</p>
+        <div className="mt-3 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-cyan-100">
+          Genesis 07, 0000 OT (March 24, 2025)
+        </div>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Legal Priority Rule</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
+          <li>Gregorian Time (GT) remains the controlling legal reference.</li>
+          <li>OneGodian Time™ (OT) is supplemental/internal.</li>
+          <li>
+            Do not use OT-only dates for court, contracts, invoices, taxes, banking, or government
+            correspondence.
+          </li>
+        </ul>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Public Display Examples</h2>
+        <div className="mt-3 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-slate-200">
+          <p className="text-sm uppercase tracking-wide text-slate-400">Public</p>
+          <p className="mt-1 text-cyan-100">Genesis 07, 0000 OT (March 24, 2025)</p>
+        </div>
+        <div className="mt-3 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-slate-200">
+          <p className="text-sm uppercase tracking-wide text-slate-400">Formal</p>
+          <p className="mt-1">Date: March 24, 2025</p>
+          <p>OneGodian Date: Genesis 07, 0000 OT</p>
+        </div>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Governance Record Format</h2>
+        <p className="mt-3 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-slate-200">
+          Recorded on Genesis 07, 0000 OT (March 24, 2025), at 8:45 PM EST, Waterbury, Connecticut.
+        </p>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Financial Instrument Format</h2>
+        <p className="mt-3 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-slate-200">
+          Dated as of March 24, 2025 (Genesis 07, 0000 OT)
+        </p>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Database Storage Rules</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
+          <li>UTC is the system truth for databases.</li>
+          <li>OT must be computed, not stored as the primary source.</li>
+          <li>Store GT/UTC timestamps as canonical values; render OT during presentation.</li>
+        </ul>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Common Mistakes to Avoid</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
+          <li>Publishing OT-only records in legal or financial workflows.</li>
+          <li>Using OT as authoritative database source fields.</li>
+          <li>Omitting GT when displaying public or archived records.</li>
+        </ul>
+      </section>
+
+      <section className={cardClass}>
+        <h2 className="text-xl font-semibold text-amber-200">Implementation Widgets</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className="rounded-xl border border-cyan-500/30 bg-slate-900/70 p-4">Format Builder</div>
+          <div className="rounded-xl border border-cyan-500/30 bg-slate-900/70 p-4">Legal-Safe Example Card</div>
+          <div className="rounded-xl border border-cyan-500/30 bg-slate-900/70 p-4">Database Fields Card</div>
+          <div className="rounded-xl border border-cyan-500/30 bg-slate-900/70 p-4">Do / Don’t Checklist</div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-amber-400/40 bg-amber-400/10 p-5 text-center">
+        <p className="text-sm text-amber-100">Need calendar conversions and references?</p>
+        <a href="/time" className="mt-2 inline-block rounded-lg border border-cyan-400/60 px-4 py-2 font-semibold text-cyan-100 hover:bg-cyan-500/10">
+          ← Back to Time
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -5,6 +5,12 @@ export default function TimePage() {
       <p className="text-slate-300">OTS-V5 is the internal OneGodian time framework used for synchronized application references.</p>
       <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-slate-300">Live clock placeholder.</div>
       <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-slate-300">Conversion tool placeholder.</div>
+      <a
+        href="/time/dual-dating"
+        className="inline-block rounded-lg border border-cyan-400/50 bg-slate-900/70 px-4 py-2 text-cyan-200 transition hover:bg-cyan-500/10"
+      >
+        Dual Dating System™
+      </a>
       <p className="text-sm text-amber-200">Legal note: Gregorian Time remains the controlling legal time standard for formal and external matters.</p>
     </main>
   );


### PR DESCRIPTION
### Motivation
- Provide a dedicated OneGodian OTS-V5 reference page that explains the Dual Dating System™ and the required dual-date formats for public, governance, and financial records.
- Surface legal guidance that Gregorian Time (GT) is the controlling legal reference while OneGodian Time™ (OT) is supplemental and must be computed, not stored as the primary datum.
- Offer implementer-facing guidance and lightweight widgets (format builder, example card, DB fields, checklist) to reduce improper OT-only use in legal/financial workflows.

### Description
- Added a new page at `src/app/(app)/time/dual-dating/page.tsx` implementing all requested sections: Hero, What Dual Dating Means, Required Format, Legal Priority Rule, Public Display Examples, Governance Record Format, Financial Instrument Format, Database Storage Rules, Common Mistakes, Implementation Widgets, and CTA back to `/time`.
- Updated `src/app/(app)/time/page.tsx` to include a link labeled `Dual Dating System™` that navigates to `/time/dual-dating`.
- Page enforces the policy text and examples: GT is controlling legal reference, OT is supplemental/internal, UTC is the system truth for databases, and OT must be computed rather than stored as primary.
- Styling follows the OneGodian app theme with dark navy/black palette, cyan/gold accents, rounded cards, and mobile-first layout; widget areas are added as placeholders without new dependencies.

### Testing
- Ran file-specific lint with `npm run lint -- --file 'src/app/(app)/time/page.tsx' --file 'src/app/(app)/time/dual-dating/page.tsx'` and received `No ESLint warnings or errors`.
- No new dependencies were introduced during the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0fbb4fbc832db6c73d10923e48af)