### PR TITLE
Add OMOS sync layer, registries, APIs, and dashboard widgets

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,8 +1,9 @@
+import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 
 const port = 4010;
 const base = `http://127.0.0.1:${port}`;
-const routes = ['/', '/omos', '/protocol', '/algorithm', '/ohi', '/docs', '/tools', '/artifacts', '/manifest', '/api/health', '/api/manifest', '/api/pages'];
+const routes = ['/', '/omos', '/protocol', '/algorithm', '/ohi', '/docs', '/tools', '/artifacts', '/manifest', '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health'];
 
 const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe' });
 
@@ -27,6 +28,19 @@ try {
     const res = await fetch(`${base}${route}`);
     if (res.status !== 200) throw new Error(`${route} returned ${res.status}`);
   }
+
+  const properties = await (await fetch(`${base}/api/properties`)).json();
+  assert.equal(Array.isArray(properties.properties), true);
+  assert.equal(properties.total, 7);
+
+  const plugins = await (await fetch(`${base}/api/plugins`)).json();
+  assert.equal(Array.isArray(plugins.plugins), true);
+  assert.equal(plugins.total, 7);
+
+  const dashboard = await (await fetch(`${base}/dashboard`)).text();
+  assert.match(dashboard, /OMOS runtime status/i);
+  assert.match(dashboard, /Last sync UTC/i);
+
   console.log('Smoke tests passed');
 } finally {
   server.kill('SIGTERM');

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,19 @@
 import Link from 'next/link';
 import { dashboardCards } from '@/lib/onegodian-content';
+import { getOmosSyncState } from '@/lib/omos-sync';
+import { pluginRegistry } from '@/lib/plugin-registry';
 
 export default function DashboardPage() {
-  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-400/30 bg-slate-950 p-6"><h1 className="text-3xl font-bold text-cyan-200">ONEGODIAN MEMBER DASHBOARD</h1></header><section className="grid gap-4 md:grid-cols-2">{dashboardCards.map((card) => <article key={card.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><div className="flex items-center justify-between"><h2 className="text-xl font-semibold">{card.title}</h2><span className="text-xs text-cyan-300">{card.status}</span></div><p className="mt-2 text-sm text-slate-300">{card.description}</p><Link href={card.href} className="mt-3 inline-block text-cyan-300">Open</Link></article>)}</section></main>;
+  const sync = getOmosSyncState();
+
+  const widgets = [
+    { label: 'OMOS runtime status', value: String(sync.health?.status ?? 'unknown') },
+    { label: 'Manifest version', value: String(sync.manifest?.version ?? 'unknown') },
+    { label: 'Page registry count', value: String(sync.pages.length) },
+    { label: 'Plugin targets', value: String(pluginRegistry.length) },
+    { label: 'Last sync UTC', value: sync.lastSyncUtc ?? 'not-synced' },
+    { label: 'Failing services', value: sync.errors.length ? sync.errors.join('; ') : 'none' }
+  ];
+
+  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-400/30 bg-slate-950 p-6"><h1 className="text-3xl font-bold text-cyan-200">ONEGODIAN MEMBER DASHBOARD</h1></header><section className="grid gap-4 md:grid-cols-2">{dashboardCards.map((card) => <article key={card.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><div className="flex items-center justify-between"><h2 className="text-xl font-semibold">{card.title}</h2><span className="text-xs text-cyan-300">{card.status}</span></div><p className="mt-2 text-sm text-slate-300">{card.description}</p><Link href={card.href} className="mt-3 inline-block text-cyan-300">Open</Link></article>)}</section><section className="grid gap-4 md:grid-cols-3">{widgets.map((widget) => <article key={widget.label} className="rounded-xl border border-cyan-700/40 bg-slate-900/40 p-4"><h3 className="text-sm text-cyan-200">{widget.label}</h3><p className="mt-2 break-all text-lg font-semibold text-slate-100">{widget.value}</p></article>)}</section></main>;
 }

--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -1,52 +1,14 @@
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
 import manifest from '@/data/manifest.json';
 
 export async function GET() {
-  return Response.json({ ...manifest, generated_at: new Date().toISOString() });
   const host = headers().get('host') ?? '';
   const isConsole = host.includes('console.onegodian.com');
 
-  return NextResponse.json(
-    isConsole
-      ? {
-          app: 'OneGodian Console',
-          domain: 'console.onegodian.com',
-          type: 'internal-control-plane',
-          version: '0.1.0',
-          modules: [
-            'dashboard',
-            'apps',
-            'plugins',
-            'api-status',
-            'deployments',
-            'registry-admin',
-            'certificate-admin',
-            'member-admin',
-            'system-health',
-            'logs',
-            'admin',
-            'settings'
-          ],
-          appDashboard: 'https://app.onegodian.com'
-        }
-      : {
-          app: 'OneGodian App',
-          domain: 'app.onegodian.com',
-          type: 'member-facing-app',
-          version: '0.1.0',
-          modules: [
-            'dashboard',
-            'ecosystem',
-            'membership',
-            'certificates',
-            'campaigns',
-            'media',
-            'products',
-            'learning',
-            'tools',
-            'profile',
-            'settings'
-          ],
-          console: 'https://console.onegodian.com'
-        }
-  );
+  return NextResponse.json({
+    ...manifest,
+    generated_at: new Date().toISOString(),
+    app_profile: isConsole ? 'internal-control-plane' : 'member-facing-app'
+  });
 }

--- a/src/app/api/plugins/route.ts
+++ b/src/app/api/plugins/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { pluginRegistry } from '@/lib/plugin-registry';
+
+export async function GET() {
+  return NextResponse.json({ plugins: pluginRegistry, total: pluginRegistry.length });
+}

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { propertyRegistry } from '@/lib/property-registry';
+
+export async function GET() {
+  return NextResponse.json({ properties: propertyRegistry, total: propertyRegistry.length });
+}

--- a/src/app/api/sync/omos/route.ts
+++ b/src/app/api/sync/omos/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { syncOmos } from '@/lib/omos-sync';
+
+export async function GET() {
+  const result = await syncOmos();
+  return NextResponse.json(result);
+}

--- a/src/app/api/system-health/route.ts
+++ b/src/app/api/system-health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getOmosSyncState } from '@/lib/omos-sync';
+
+export async function GET() {
+  const sync = getOmosSyncState();
+  const failingServices = sync.errors;
+
+  return NextResponse.json({
+    runtime: sync.health?.status ?? 'unknown',
+    manifestVersion: sync.manifest?.version ?? 'unknown',
+    pageRegistryCount: sync.pages.length,
+    lastSyncUtc: sync.lastSyncUtc,
+    failingServices,
+    status: failingServices.length > 0 ? 'degraded' : 'healthy'
+  });
+}

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -5,6 +5,6 @@ import { type ReactNode } from 'react';
 import { appNavigation, ecosystemLinks } from '@/lib/onegodian-content';
 
 export function AppFrame({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   return <div className="min-h-screen bg-slate-950 text-slate-100"><header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur"><div className="flex items-center justify-between"><Link href="/" className="font-semibold text-cyan-300">ONEGODIAN APP · MEMBER DASHBOARD</Link></div><div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"><nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">{appNavigation.map((item) => {const active = pathname === item.href || pathname.startsWith(`${item.href}/`);return <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>{item.label}</Link>;})}</nav></div><div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer" className="hover:text-cyan-300">{item.label}</a>)}</div></header><div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div></div>;
 }

--- a/src/lib/omos-sync.ts
+++ b/src/lib/omos-sync.ts
@@ -1,0 +1,50 @@
+const OMOS_BASE_URL = 'https://omos.onegodian.com';
+
+export type OmosSyncState = {
+  lastSyncUtc: string | null;
+  manifest: Record<string, unknown> | null;
+  health: Record<string, unknown> | null;
+  pages: unknown[];
+  errors: string[];
+};
+
+const state: OmosSyncState = {
+  lastSyncUtc: null,
+  manifest: null,
+  health: null,
+  pages: [],
+  errors: []
+};
+
+async function fetchJson(path: string) {
+  const response = await fetch(`${OMOS_BASE_URL}${path}`, { cache: 'no-store' });
+  if (!response.ok) throw new Error(`${path} failed (${response.status})`);
+  return response.json();
+}
+
+export async function syncOmos() {
+  const errors: string[] = [];
+  const [manifestResult, healthResult, pagesResult] = await Promise.allSettled([
+    fetchJson('/api/manifest'),
+    fetchJson('/api/health'),
+    fetchJson('/api/pages')
+  ]);
+
+  if (manifestResult.status === 'fulfilled') state.manifest = manifestResult.value;
+  else errors.push(`manifest: ${manifestResult.reason instanceof Error ? manifestResult.reason.message : 'unknown error'}`);
+
+  if (healthResult.status === 'fulfilled') state.health = healthResult.value;
+  else errors.push(`health: ${healthResult.reason instanceof Error ? healthResult.reason.message : 'unknown error'}`);
+
+  if (pagesResult.status === 'fulfilled') state.pages = Array.isArray(pagesResult.value?.pages) ? pagesResult.value.pages : [];
+  else errors.push(`pages: ${pagesResult.reason instanceof Error ? pagesResult.reason.message : 'unknown error'}`);
+
+  state.errors = errors;
+  state.lastSyncUtc = new Date().toISOString();
+
+  return getOmosSyncState();
+}
+
+export function getOmosSyncState(): OmosSyncState {
+  return { ...state, pages: [...state.pages], errors: [...state.errors] };
+}

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -1,0 +1,16 @@
+export type PluginRegistryEntry = {
+  id: string;
+  name: string;
+  target: string;
+  description: string;
+};
+
+export const pluginRegistry: PluginRegistryEntry[] = [
+  { id: 'public-identity', name: 'Public Identity Plugin', target: 'app.onegodian.com/identity', description: 'Public/member identity and profile surfaces.' },
+  { id: 'commerce', name: 'Commerce Plugin', target: 'onegodian.com', description: 'Commerce routing and storefront integrations.' },
+  { id: 'lms', name: 'LMS Plugin', target: 'u.onegodian.com', description: 'Learning management and curriculum experiences.' },
+  { id: 'galaxy', name: 'Galaxy Plugin', target: 'galaxy.onegodian.com', description: 'Galaxy world and planetary modules.' },
+  { id: 'capital', name: 'Capital Plugin', target: 'capital.onegodian.com', description: 'Capital workflows and member tooling.' },
+  { id: 'omos-bridge', name: 'OMOS Bridge Plugin', target: 'omos.onegodian.com', description: 'Spec/runtime bridge from app to OMOS.' },
+  { id: 'quantumohi-platform', name: 'QuantumOHI Platform Plugin', target: 'quantumohi.com', description: 'QuantumOHI platform connection layer.' }
+];

--- a/src/lib/property-registry.ts
+++ b/src/lib/property-registry.ts
@@ -1,0 +1,17 @@
+export type PropertyRegistryEntry = {
+  name: string;
+  domain: string;
+  role: string;
+  visibility: 'public' | 'member' | 'protocol';
+  commerceRoutedTo?: string;
+};
+
+export const propertyRegistry: PropertyRegistryEntry[] = [
+  { name: 'OneGodian.org', domain: 'onegodian.org', role: 'foundation-presence', visibility: 'public' },
+  { name: 'OneGodian.com', domain: 'onegodian.com', role: 'commerce-hub', visibility: 'public' },
+  { name: 'u.OneGodian.com', domain: 'u.onegodian.com', role: 'learning-campus', visibility: 'member' },
+  { name: 'galaxy.OneGodian.com', domain: 'galaxy.onegodian.com', role: 'galaxy-experience', visibility: 'member' },
+  { name: 'capital.OneGodian.com', domain: 'capital.onegodian.com', role: 'capital-operations', visibility: 'member', commerceRoutedTo: 'onegodian.com' },
+  { name: 'OMOS.OneGodian.com', domain: 'omos.onegodian.com', role: 'protocol-spec-runtime-node', visibility: 'protocol' },
+  { name: 'QuantumOHI.com', domain: 'quantumohi.com', role: 'quantum-platform', visibility: 'public' }
+];


### PR DESCRIPTION
### Motivation
- Provide a production sync between app.onegodian.com and OMOS.OneGodian.com so the app can surface OMOS runtime and manifest state.
- Maintain a canonical, UTC-based cached sync state for dashboards and system APIs.
- Expose property and plugin registries so the app can reference platform, commerce, and protocol routing metadata.

### Description
- Implemented an OMOS polling sync module that fetches `/api/manifest`, `/api/health`, and `/api/pages` from `https://omos.onegodian.com` and caches the results with `lastSyncUtc` in `src/lib/omos-sync.ts`.
- Added local registries with the requested entries in `src/lib/property-registry.ts` and `src/lib/plugin-registry.ts`, including commerce routing metadata and OMOS as a protocol/runtime node.
- Added API endpoints `GET /api/sync/omos`, `GET /api/properties`, `GET /api/plugins`, and `GET /api/system-health` implemented under `src/app/api/*` that return the cached sync state and registries.
- Added dashboard widgets to show OMOS runtime status, manifest version, page registry count, plugin targets, last sync UTC, and failing services in `src/app/(app)/dashboard/page.tsx` and handled minor TypeScript/build issues in `src/app/api/manifest/route.ts` and `src/components/app-frame.tsx`.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully.
- Executed smoke tests via `npm run test` which validated routes, registry shapes (7 properties and 7 plugins), and dashboard widget rendering and they passed.
- Built the production site with `npm run build` and a full production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a146293c524832db23881717a1077f6)