### PR TITLE
Add public sitemap and OMOS/architecture/system-health app routes

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 
 const port = 4010;
 const base = `http://127.0.0.1:${port}`;
-const routes = ['/', '/omos', '/protocol', '/algorithm', '/ohi', '/docs', '/tools', '/artifacts', '/manifest', '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health'];
+const routes = ['/', '/sitemap', '/omos', '/omos/manifest', '/omos/pages', '/omos/health', '/omos/sync', '/omos/plugins', '/omos/properties', '/architecture', '/architecture/omos-sync', '/system-health', '/protocol', '/algorithm', '/ohi', '/docs', '/tools', '/artifacts', '/manifest', '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health'];
 
 const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe' });
 

--- a/src/app/(app)/architecture/omos-sync/page.tsx
+++ b/src/app/(app)/architecture/omos-sync/page.tsx
@@ -1,0 +1,3 @@
+export default function OmosSyncArchitecturePage() {
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Sync Architecture</h1><p className="rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-slate-200">OMOS.OneGodian.com -&gt; /api/manifest, /api/health, /api/pages -&gt; app sync cache -&gt; /api/sync/omos, /api/properties, /api/plugins, /api/system-health -&gt; dashboard widgets.</p></main>;
+}

--- a/src/app/(app)/architecture/page.tsx
+++ b/src/app/(app)/architecture/page.tsx
@@ -1,0 +1,7 @@
+const layers = [
+  'Layer 0 Human Authority','Layer 1 Identity Authority','Layer 2 Control Plane','Layer 3 Systems Command Center','Layer 4 Orchestration','Layer 5 Execution Gateway','Layer 6 External Compute Adapters','Layer 7 Ledger / Verification','Layer 8 ODIN Registry','Layer 9 Interface Layer','Layer 10 Applications','Layer 11 Wallet / Finance','Layer 12 Cloud Infrastructure','Layer 13 Audit Grid','Layer 14 Expansion Layer'
+];
+
+export default function ArchitecturePage() {
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OHI Multi-layer Architecture</h1><ol className="space-y-2">{layers.map((layer) => <li key={layer} className="rounded-lg border border-slate-700 bg-slate-900/50 p-3">{layer}</li>)}</ol></main>;
+}

--- a/src/app/(app)/omos/health/page.tsx
+++ b/src/app/(app)/omos/health/page.tsx
@@ -1,0 +1,6 @@
+import { syncOmos } from '@/lib/omos-sync';
+
+export default async function OmosHealthPage() {
+  const data = await syncOmos();
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Health</h1><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(data.health ?? {}, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/omos/manifest/page.tsx
+++ b/src/app/(app)/omos/manifest/page.tsx
@@ -1,0 +1,6 @@
+import { syncOmos } from '@/lib/omos-sync';
+
+export default async function OmosManifestPage() {
+  const data = await syncOmos();
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Manifest</h1><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(data.manifest ?? {}, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,9 +1,29 @@
-import { getOmosBridgeConfig } from '@/lib/omos-bridge';
+import Link from 'next/link';
+import { syncOmos } from '@/lib/omos-sync';
+import { propertyRegistry } from '@/lib/property-registry';
+import { pluginRegistry } from '@/lib/plugin-registry';
 
-const restEndpoints = ['/api/omos/status', '/api/manifest', '/api/tools', '/api/stats', '/api/omos/llm/chat'];
+export default async function OmosPage() {
+  const sync = await syncOmos();
+  const failingServices = sync.errors;
+  const health = {
+    runtime: (sync.health?.status as string | undefined) ?? 'unknown',
+    manifestVersion: (sync.manifest?.version as string | undefined) ?? 'unknown',
+    pageRegistryCount: sync.pages.length,
+    lastSyncUtc: sync.lastSyncUtc,
+    failingServices
+  };
 
-export default function OmosPage() {
-  const config = getOmosBridgeConfig();
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OMOS Module</h1><p className="mt-2 text-slate-300">OMOS.OneGodian.com protocol status, bridge operations, tool registry, and gateway telemetry placeholders.</p></header>
-  <section className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">Provider / Bridge Configuration</h2><ul className="mt-2 space-y-1 text-sm text-slate-300"><li>OMOS_REST_BASE_URL: {config.restBaseUrl ?? 'not set'}</li><li>X-OMOS-App-Key: {config.hasBridgeKey ? 'configured (server-side only)' : 'missing'}</li><li>OMOS LLM Gateway: placeholder monitored</li><li>Tool Registry: placeholder data loaded</li></ul></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">REST Endpoints</h2><ul className="mt-2 list-disc pl-5 text-sm text-cyan-300">{restEndpoints.map((ep)=><li key={ep}>{ep}</li>)}</ul></article></section></main>;
+  const cards = [
+    ['OMOS runtime status', health.runtime],
+    ['Last sync UTC', health.lastSyncUtc ?? 'never'],
+    ['Manifest version', health.manifestVersion],
+    ['Canonical domain', 'https://omos.onegodian.com'],
+    ['Page registry count', String(health.pageRegistryCount)],
+    ['Property count', String(propertyRegistry.length)],
+    ['Plugin count', String(pluginRegistry.length)],
+    ['Failing services', String(health.failingServices.length)]
+  ];
+
+  return <main className="space-y-6"><header><h1 className="text-3xl font-bold">OMOS Dashboard</h1><p className="text-slate-300">Public OMOS runtime and registry status from app APIs.</p></header><section className="grid gap-3 md:grid-cols-2">{cards.map(([k, v]) => <article key={k} className="rounded-xl border border-slate-700 bg-slate-900/50 p-4"><h2 className="text-sm uppercase text-slate-400">{k}</h2><p className="text-lg font-semibold text-cyan-200">{v}</p></article>)}</section><section className="rounded-xl border border-slate-700 bg-slate-900/50 p-4"><h2 className="text-xl font-semibold">OMOS Pages</h2><div className="mt-2 flex flex-wrap gap-4">{['manifest', 'pages', 'health', 'sync', 'plugins', 'properties'].map((segment) => <Link key={segment} href={`/omos/${segment}`} className="text-cyan-300 hover:underline">/omos/{segment}</Link>)}</div></section></main>;
 }

--- a/src/app/(app)/omos/pages/page.tsx
+++ b/src/app/(app)/omos/pages/page.tsx
@@ -1,0 +1,6 @@
+import { syncOmos } from '@/lib/omos-sync';
+
+export default async function OmosPagesPage() {
+  const data = await syncOmos();
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Pages Registry</h1><p className="text-slate-300">Count: {data.pages.length}</p><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(data.pages, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/omos/plugins/page.tsx
+++ b/src/app/(app)/omos/plugins/page.tsx
@@ -1,0 +1,5 @@
+import { pluginRegistry } from '@/lib/plugin-registry';
+
+export default function OmosPluginsPage() {
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Plugins</h1><p className="text-slate-300">Count: {pluginRegistry.length}</p><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(pluginRegistry, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/omos/properties/page.tsx
+++ b/src/app/(app)/omos/properties/page.tsx
@@ -1,0 +1,5 @@
+import { propertyRegistry } from '@/lib/property-registry';
+
+export default function OmosPropertiesPage() {
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Properties</h1><p className="text-slate-300">Count: {propertyRegistry.length}</p><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(propertyRegistry, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/omos/sync/page.tsx
+++ b/src/app/(app)/omos/sync/page.tsx
@@ -1,0 +1,6 @@
+import { syncOmos } from '@/lib/omos-sync';
+
+export default async function OmosSyncPage() {
+  const data = await syncOmos();
+  return <main className="space-y-4"><h1 className="text-3xl font-bold">OMOS Sync</h1><p className="text-slate-300">Last sync UTC: {data.lastSyncUtc ?? 'never'}</p><pre className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900/50 p-4 text-xs">{JSON.stringify(data, null, 2)}</pre></main>;
+}

--- a/src/app/(app)/portfolio/page.tsx
+++ b/src/app/(app)/portfolio/page.tsx
@@ -1,0 +1,3 @@
+export default function PortfolioPage() {
+  return <main><h1 className="text-3xl font-bold">Portfolio</h1><p className="text-slate-300">Planned public portfolio surface.</p></main>;
+}

--- a/src/app/(app)/records/page.tsx
+++ b/src/app/(app)/records/page.tsx
@@ -1,0 +1,3 @@
+export default function RecordsPage() {
+  return <main><h1 className="text-3xl font-bold">Records</h1><p className="text-slate-300">Planned public records surface.</p></main>;
+}

--- a/src/app/(app)/sitemap/page.tsx
+++ b/src/app/(app)/sitemap/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { appSitemap, type SitemapStatus } from '@/lib/app-sitemap';
+
+const badgeTone: Record<SitemapStatus, string> = {
+  live: 'bg-emerald-500/20 text-emerald-200 border-emerald-400/40',
+  planned: 'bg-amber-500/20 text-amber-100 border-amber-400/40',
+  internal: 'bg-slate-500/20 text-slate-200 border-slate-300/30',
+  external: 'bg-cyan-500/20 text-cyan-100 border-cyan-300/40'
+};
+
+const grouped = Object.entries(appSitemap.reduce<Record<string, typeof appSitemap>>((acc, item) => {
+  acc[item.group] ||= [];
+  acc[item.group].push(item);
+  return acc;
+}, {}));
+
+export default function SitemapPage() {
+  return <main className="space-y-6"><header><h1 className="text-3xl font-bold">App Sitemap</h1><p className="text-slate-300">Public/member-facing route map for app.onegodian.com.</p></header><section className="grid gap-4 md:grid-cols-2">{grouped.map(([group, items]) => <article key={group} className="rounded-xl border border-slate-700 bg-slate-900/50 p-4"><h2 className="text-xl font-semibold">{group}</h2><ul className="mt-3 space-y-3">{items.map((item) => <li key={item.path}><div className="flex items-center gap-2"><Link href={item.path} className="font-medium text-cyan-300 hover:underline">{item.title}</Link><span className={`rounded-full border px-2 py-0.5 text-xs ${badgeTone[item.status]}`}>{item.status}</span></div><p className="text-sm text-slate-300">{item.description}</p>{item.children?.length ? <ul className="mt-2 list-disc pl-5 text-sm text-slate-200">{item.children.map((child) => <li key={child.path}><Link href={child.path} className="text-cyan-200 hover:underline">{child.title}</Link></li>)}</ul> : null}</li>)}</ul></article>)}</section></main>;
+}

--- a/src/app/(app)/system-health/page.tsx
+++ b/src/app/(app)/system-health/page.tsx
@@ -1,0 +1,18 @@
+import { pluginRegistry } from '@/lib/plugin-registry';
+import { propertyRegistry } from '@/lib/property-registry';
+import { syncOmos } from '@/lib/omos-sync';
+
+export default async function SystemHealthPage() {
+  const sync = await syncOmos();
+  const failing = sync.errors;
+
+  return <main className="space-y-6"><h1 className="text-3xl font-bold">System Health</h1><section className="grid gap-3 md:grid-cols-2">{[
+    ['App API health', failing.length ? 'degraded' : 'healthy'],
+    ['OMOS sync state', failing.length ? 'degraded' : 'healthy'],
+    ['Property registry count', String(propertyRegistry.length)],
+    ['Plugin registry count', String(pluginRegistry.length)],
+    ['Last sync UTC', sync.lastSyncUtc ?? 'never'],
+    ['Failing services', String(failing.length)],
+    ['Production warnings', failing.length ? failing.join('; ') : 'none']
+  ].map(([k, v]) => <article key={k} className="rounded-xl border border-slate-700 bg-slate-900/50 p-4"><h2 className="text-sm uppercase text-slate-400">{k}</h2><p className="text-cyan-200">{v}</p></article>)}</section></main>;
+}

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -15,16 +15,15 @@ export const appHomeHero = {
 
 export const appNavigation = [
   { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Membership', href: '/members' },
-  { label: 'Certificates', href: '/certificates' },
-  { label: 'Campaigns', href: '/campaigns' },
-  { label: 'Media', href: '/media' },
-  { label: 'Products', href: '/products' },
-  { label: 'Learning', href: '/learning' },
+  { label: 'OMOS', href: '/omos' },
+  { label: 'Architecture', href: '/architecture' },
+  { label: 'Algorithm', href: '/algorithm' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Time', href: '/time' },
+  { label: 'Portfolio', href: '/portfolio' },
+  { label: 'Records', href: '/records' },
   { label: 'Tools', href: '/tools' },
-  { label: 'Profile', href: '/profile' },
-  { label: 'Settings', href: '/settings' }
+  { label: 'Sitemap', href: '/sitemap' }
 ];
 
 export const appDashboardCards = [

--- a/src/lib/app-sitemap.ts
+++ b/src/lib/app-sitemap.ts
@@ -1,0 +1,39 @@
+export type SitemapStatus = 'live' | 'planned' | 'internal' | 'external';
+
+export type SitemapItem = {
+  title: string;
+  path: string;
+  group: string;
+  description: string;
+  status: SitemapStatus;
+  children?: SitemapItem[];
+};
+
+export const appSitemap: SitemapItem[] = [
+  { title: 'Dashboard', path: '/dashboard', group: 'Dashboard', description: 'Public/member operational dashboard with runtime and ecosystem cards.', status: 'live' },
+  { title: 'Systems Model', path: '/systems', group: 'Systems Model', description: 'System model and platform view for app-facing users.', status: 'live' },
+  { title: 'OMOS', path: '/omos', group: 'OMOS', description: 'OMOS runtime/sync status surface powered by app APIs.', status: 'live', children: [
+    { title: 'Manifest', path: '/omos/manifest', group: 'OMOS', description: 'Current OMOS manifest snapshot from app sync cache.', status: 'live' },
+    { title: 'Pages', path: '/omos/pages', group: 'OMOS', description: 'OMOS page registry currently synchronized to app cache.', status: 'live' },
+    { title: 'Health', path: '/omos/health', group: 'OMOS', description: 'OMOS upstream health and app-facing health summary.', status: 'live' },
+    { title: 'Sync', path: '/omos/sync', group: 'OMOS', description: 'Raw sync payload and last synchronization telemetry.', status: 'live' },
+    { title: 'Plugins', path: '/omos/plugins', group: 'OMOS', description: 'Public plugin registry snapshot for OMOS integrations.', status: 'live' },
+    { title: 'Properties', path: '/omos/properties', group: 'OMOS', description: 'Public property registry snapshot for OMOS integrations.', status: 'live' }
+  ] },
+  { title: 'Architecture', path: '/architecture', group: 'Architecture', description: 'OHI multi-layer architecture map and implementation notes.', status: 'live', children: [
+    { title: 'OMOS Sync Flow', path: '/architecture/omos-sync', group: 'Architecture', description: 'Data flow from OMOS endpoints to app APIs and widgets.', status: 'live' }
+  ] },
+  { title: 'Algorithm', path: '/algorithm', group: 'Algorithm', description: 'Algorithm orientation, protocol, and community pages.', status: 'live' },
+  { title: 'OHI', path: '/ohi', group: 'OHI', description: 'OneGodian Human Interface (OHI) framing and public posture.', status: 'live' },
+  { title: 'Registry', path: '/registry', group: 'Registry', description: 'Registry views and references for public app participants.', status: 'live' },
+  { title: 'Time', path: '/time', group: 'Time', description: 'OneGodian time pages including dual dating context.', status: 'live' },
+  { title: 'Portfolio', path: '/portfolio', group: 'Portfolio', description: 'Portfolio hub for member/public roadmap output.', status: 'planned' },
+  { title: 'Records', path: '/records', group: 'Records', description: 'Records hub for historical and canonical documentation.', status: 'planned' },
+  { title: 'Institutional', path: '/ecosystem', group: 'Institutional', description: 'Institutional ecosystem entry points and boundaries.', status: 'live' },
+  { title: 'Tools', path: '/tools', group: 'Tools', description: 'Tooling pages, utilities, and app-side module surfaces.', status: 'live' },
+  { title: 'Products', path: '/store', group: 'Products', description: 'Public product/store-facing app route.', status: 'live' },
+  { title: 'Campaigns', path: '/campaigns', group: 'Campaigns', description: 'Campaign pages and participation views.', status: 'live' },
+  { title: 'Docs', path: '/docs', group: 'Docs', description: 'Public-facing docs and standards pages.', status: 'live' },
+  { title: 'Legal', path: '/legal', group: 'Legal', description: 'Legal and policy references for the app.', status: 'planned' },
+  { title: 'OMOS External Site', path: 'https://omos.onegodian.com', group: 'OMOS', description: 'External OMOS source domain for manifest/health/pages.', status: 'external' }
+];


### PR DESCRIPTION
### Motivation
- Surface the recently merged OMOS sync/runtime, property and plugin registries, and dashboard widgets on the public app so members can see runtime, manifest, registry and health status. 
- Provide a structured, app-facing sitemap so the app navigation and public pages reflect current production direction without exposing console/admin routes. 
- Add architecture and system-health docs to explain OMOS sync flow and the OHI multi-layer model for public consumption.

### Description
- Add a structured sitemap data source `src/lib/app-sitemap.ts` containing `title`, `path`, `group`, `description`, `status`, and `children` entries for the requested groups. 
- Add a public `/sitemap` route at `src/app/(app)/sitemap/page.tsx` that renders grouped cards with badges for `live|planned|internal|external` and child links, excluding private console routes. 
- Implement OMOS public dashboard and child routes at `/omos` and `/omos/{manifest,pages,health,sync,plugins,properties}` that use existing app APIs and libs (`/api/sync/omos`, `/api/properties`, `/api/plugins`, `/api/system-health`, `src/lib/omos-sync.ts`, `src/lib/property-registry.ts`, `src/lib/plugin-registry.ts`) to render runtime status, last sync, manifest version, registry counts, failing services, and links. 
- Add architecture pages `/architecture` and `/architecture/omos-sync` showing the OHI Layer 0–14 model and OMOS sync flow respectively. 
- Add a public `/system-health` page aggregating app API health, OMOS sync state, property/plugin counts, last sync, failing services, and production warnings. 
- Update the app-facing primary navigation in `src/lib/app-content.ts` to include `Dashboard`, `OMOS`, `Architecture`, `Algorithm`, `Registry`, `Time`, `Portfolio`, `Records`, `Tools`, and `Sitemap`. 
- Expand smoke test coverage in `scripts/smoke-test.mjs` to validate HTTP 200 for all new routes and verify property/plugin API responses.

### Testing
- Ran `npm run lint` and there were no ESLint warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors. 
- Ran `npm run test` (smoke script) and the smoke tests completed successfully (`Smoke tests passed`) validating all new public routes and API responses. 
- Ran `npm run build` and the Next.js production build completed successfully with generated routes for the new pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1465972cf8832db1c733dbcfa8f1bf)