### PR TITLE
docs: add DNS & deployment guidance for app.onegodian.com and console.onegodian.com

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,28 +1,58 @@
-# Hostinger Node Deployment — ONEGODIAN Capital Portal
+# Hostinger Node Deployment — ONEGODIAN Surfaces
 
-This repository runs the Hostinger Node app for `capital.onegodian.com`.
+This deployment guide covers both OneGodian production surfaces and their DNS prerequisites.
 
-- WordPress/WooCommerce remains the checkout and marketing layer.
-- This Next.js application is the capital portal application layer.
-- API/database integration is the next phase where not yet implemented.
+## Surface separation
 
-## Deploy Steps
+### App surface (`app.onegodian.com`)
+- **Repository:** `ohi-stack/onegodian-app-deploy`
+- **Purpose:** OneGodian App, public/member-facing experience layer
+- **Required production URL:** `https://app.onegodian.com`
+- **DNS requirement:** Create an `A` or `CNAME` record named `app`
 
-1. `npm install`
-2. `npm run build`
-3. `npm run start`
+### Console surface (`console.onegodian.com`)
+- **Repository:** `ohi-stack/ohi-control-plane` (or designated console deployment repository)
+- **Purpose:** OneGodian Control Plane / Console, operator-facing control layer
+- **Required production URL:** `https://console.onegodian.com`
+- **DNS requirement:** Create an `A` or `CNAME` record named `console`
 
-## Required Environment Variable
+> Do not document or expose console-only tools/features as app (`app.onegodian.com`) functionality.
 
-- `NEXT_PUBLIC_SITE_URL=https://capital.onegodian.com`
+## Critical DNS prerequisite for browser testing
 
-## Smoke Test Routes
+Before any browser-based verification, both subdomains must resolve publicly:
+- `app.onegodian.com`
+- `console.onegodian.com`
 
-- `/`
-- `/offerings`
-- `/investor-portal`
-- `/disclosures`
-- `/certificates`
-- `/production-readiness`
-- `/api/health`
-- `/api/readiness`
+If either DNS record is missing or still propagating, browser tests are not valid.
+
+## Deployment checklist
+
+Use this checklist for each release:
+
+1. **DNS**
+   - Confirm `app.onegodian.com` has an active `A` or `CNAME` record named `app`
+   - Confirm `console.onegodian.com` has an active `A` or `CNAME` record named `console`
+2. **SSL/TLS**
+   - Verify certificates are issued and valid for both production URLs
+3. **Build**
+   - Run `npm install`
+   - Run `npm run build`
+4. **Start/Deploy**
+   - Run `npm run start` (or platform equivalent)
+5. **Route verification**
+   - Verify app URL: `https://app.onegodian.com`
+   - Verify console URL: `https://console.onegodian.com`
+6. **Health checks**
+   - App/API endpoints return expected status codes after deploy
+
+## Troubleshooting
+
+- **`ERR_NAME_NOT_RESOLVED`**
+  - DNS record is missing, incorrect, or not yet propagated.
+- **HTTP `404`**
+  - DNS resolves, but routing/deployment target is incorrect.
+- **HTTP `500`**
+  - Deployment is reachable, but runtime/server-side failure exists.
+- **SSL warning/certificate error**
+  - DNS may resolve, but HTTPS certificate has not been issued/attached yet.


### PR DESCRIPTION
### Motivation

- Ensure both OneGodian production surfaces (`app.onegodian.com` and `console.onegodian.com`) have clear, discrete deployment documentation and explicit DNS prerequisites to avoid invalid browser testing.
- Preserve separation between the public/member-facing App and the operator-facing Console so console-only tools are not documented as app features.
- Provide operators a concise checklist covering DNS, SSL, build, and route verification to reduce common deployment failures.
- Give quick troubleshooting guidance that maps common browser/HTTP errors to likely DNS, routing, runtime, or certificate causes.

### Description

- Rewrote `DEPLOYMENT.md` to add separate sections for the App surface (`app.onegodian.com`) and Console surface (`console.onegodian.com`) with repository, purpose, required production URL, and DNS record instructions.
- Added a prominent note that both `app.onegodian.com` and `console.onegodian.com` must resolve publicly before any browser-based testing is performed.
- Added a deployment checklist that explicitly includes DNS verification, SSL/TLS certificate verification, build steps (`npm install`, `npm run build`), start/deploy, and route verification for both subdomains.
- Added a troubleshooting section mapping `ERR_NAME_NOT_RESOLVED`, HTTP `404`, HTTP `500`, and SSL certificate warnings to likely root causes.

### Testing

- No automated application tests were executed because this is a documentation-only change.
- The updated `DEPLOYMENT.md` content was inspected to confirm the requested DNS and checklist items were added as specified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a146b3118f8832db81d241a93f8a84d)