### PR TITLE
feat: update OneGodian app with live ecosystem content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,230 +1,121 @@
 import Link from 'next/link';
 
-type StatusWidget = {
-  label: string;
-  value: string;
-};
-
-type ModuleCard = {
+type LinkCard = {
   title: string;
-  href: string;
   description: string;
-  stats: string[];
-  glyph: string;
+  href?: string;
+  status?: string;
 };
 
-const statusWidgets: StatusWidget[] = [
-  { label: 'App Status', value: 'Online' },
-  { label: 'ODIN Registry', value: 'Active' },
-  { label: 'OneGodian Time™', value: 'OTS-V5 Active' },
-  { label: 'Ecosystem', value: 'Route Active' },
-  { label: 'Mobile Navigation', value: 'Enabled' }
+const heroActions = [
+  { label: 'Open Dashboard', href: '/dashboard' },
+  { label: 'Open Time System', href: '/time' },
+  { label: 'View OMOS Status', href: '/omos' },
+  { label: 'View Sitemap', href: '/sitemap' }
 ];
 
-const moduleGroups: { title: string; cards: ModuleCard[] }[] = [
-  {
-    title: 'Core Registry',
-    cards: [
-      {
-        title: 'Planetary Registry',
-        href: '/planets',
-        description: 'ODIN-PR planets, civilizations, and registry systems.',
-        stats: ['25 Planets', 'ODIN-PR', 'Canon'],
-        glyph: '🪐'
-      },
-      {
-        title: 'ODIN Registry',
-        href: '/odin',
-        description: 'Canonical registry hub for series, platforms, verification, worlds, and planetary records.',
-        stats: ['Registry', 'Verification', 'Canon'],
-        glyph: '🧭'
-      },
-      {
-        title: 'OneGodian Time™',
-        href: '/time',
-        description: 'OTS-V5 dual-date clock, Gregorian → OneGodian converter, epoch rules, and timestamp governance.',
-        stats: ['OTS-V5', 'UTC Truth', '13 Months'],
-        glyph: '⏱️'
-      },
-      {
-        title: 'Certificates',
-        href: '/certificates',
-        description: 'Certificate views, registry references, and OneGodian verification records.',
-        stats: ['Records', 'Identity', 'Archive'],
-        glyph: '📜'
-      }
-    ]
-  },
-  {
-    title: 'Worlds & Systems',
-    cards: [
-      {
-        title: 'Moons & Systems',
-        href: '/moons-systems',
-        description: 'Moon systems, orbital continuity, and expansion interfaces.',
-        stats: ['Moons', 'Orbits', 'Systems'],
-        glyph: '🌙'
-      },
-      {
-        title: 'Ecosystem',
-        href: '/ecosystem',
-        description: 'Connected OneGodian systems and infrastructure layers.',
-        stats: ['Routes', 'Modules', 'Infrastructure'],
-        glyph: '🌐'
-      },
-      {
-        title: 'Media Center',
-        href: '/media',
-        description: 'Visual media, banners, assets, and content presentation layers.',
-        stats: ['Media', 'Assets', 'Visuals'],
-        glyph: '🎬'
-      },
-      {
-        title: 'Products',
-        href: '/products',
-        description: 'Product surfaces, digital assets, app-linked offerings, and commerce expansion.',
-        stats: ['Store', 'Digital', 'Commerce'],
-        glyph: '🛍️'
-      }
-    ]
-  },
-  {
-    title: 'Tools & Operations',
-    cards: [
-      {
-        title: 'Tools',
-        href: '/tools',
-        description: 'Operational utilities, converters, dashboards, and app functions.',
-        stats: ['Utilities', 'Engines', 'Workflow'],
-        glyph: '🧰'
-      },
-      {
-        title: 'Registry',
-        href: '/registry',
-        description: 'Unified registry access for app-level records and canonical systems.',
-        stats: ['Index', 'Records', 'Links'],
-        glyph: '📚'
-      },
-      {
-        title: 'Dashboard',
-        href: '/dashboard',
-        description: 'Operational dashboard for the OneGodian App interface.',
-        stats: ['Modules', 'Status', 'Navigation'],
-        glyph: '📊'
-      },
-      {
-        title: 'Profile',
-        href: '/profile',
-        description: 'Identity profile, app presence, and user-facing account layer.',
-        stats: ['Identity', 'Account', 'Access'],
-        glyph: '👤'
-      }
-    ]
-  }
+const platformNetwork: LinkCard[] = [
+  { title: 'OneGodian.org', description: 'Organization, public identity, education, cultural records, and institutional home.', href: 'https://onegodian.org' },
+  { title: 'OneGodian.com', description: 'Store, product commerce, certificates, digital downloads, and campaign collections.', href: 'https://onegodian.com' },
+  { title: 'u.OneGodian.com', description: 'Education platform, LMS, courses, learning modules, and training access.', href: 'https://u.onegodian.org' },
+  { title: 'app.OneGodian.com', description: 'Public/member app node, dashboard, registry access, tools, time system, OMOS status, and records.', href: 'https://app.onegodian.com' },
+  { title: 'OMOS.OneGodian.com', description: 'Protocol and specification node for OMOS, manifest data, algorithm framework, and runtime architecture.', href: 'https://omos.onegodian.com' },
+  { title: 'Capital.OneGodian.com', description: 'Capital, valuation, contributor, product, payment, and finance-related platform layer.', href: 'https://capital.onegodian.com' },
+  { title: 'Galaxy.OneGodian.com', description: 'Planetary canon, galaxy navigation, world-building, media, and lore-linked app layer.', href: 'https://galaxy.onegodian.com' },
+  { title: 'QuantumOHI.com', description: 'Quantum-OHI, advanced system architecture, intelligence infrastructure, and protocol positioning.', href: 'https://quantumohi.com' }
 ];
 
-const appWireframe = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Planetary Systems', href: '/planets' },
-  { label: 'Time', href: '/time' },
-  { label: 'Tools', href: '/tools' },
-  { label: 'Profile', href: '/profile' }
+const capabilities: LinkCard[] = [
+  { title: 'Open the Dashboard', description: 'View live system cards, OMOS sync indicators, app modules, production status, and platform routing.', href: '/dashboard' },
+  { title: 'Use OneGodian Time™', description: 'Access the live clock, dual dating system, OTS-V5 references, timestamps, calendar tools, and date conversion.', href: '/time' },
+  { title: 'View Registry Records', description: 'Browse ODIN records, certificates, systems, products, identity records, planetary records, and verified entries.', href: '/registry' },
+  { title: 'Explore OMOS', description: 'View OMOS manifest status, page registry, sync health, plugins, properties, runtime checks, and bridge readiness.', href: '/omos' },
+  { title: 'Review System Architecture', description: 'Access the OneGodian hierarchy, OHI/OMOS architecture, app structure, plugin bridge model, and platform layers.', href: '/architecture' },
+  { title: 'Access Tools', description: 'Use registry lookup, certificate verification, system status tools, API diagnostics, converters, and platform utilities.', href: '/tools' },
+  { title: 'Open Education Pathways', description: 'Connect to OneGodian Learn and u.OneGodian.com for learning modules, courses, guides, and educational records.', href: '/learning' },
+  { title: 'Review Public Records', description: 'Access founder records, authorship, chronology, institutional positioning, platform history, and portfolio documentation.', href: '/records' }
 ];
 
-const milestones = [
-  {
-    title: 'Ecosystem Route Added',
-    text: 'Production-safe ecosystem module and route added to the app.'
-  },
-  {
-    title: 'ODIN Registry Expanded',
-    text: 'ODIN landing pages, registry datasets, navigation, and reusable components added.'
-  },
-  {
-    title: 'Navigation Upgraded',
-    text: 'Glyph cards, accents, mobile navigation, and stronger dashboard identity added.'
-  },
-  {
-    title: 'OneGodian Time™ Added',
-    text: 'OTS-V5 deterministic conversion library and dashboard widgets merged.'
-  }
+const productionStatus: LinkCard[] = [
+  { title: 'App Node: Live', description: 'app.onegodian.com is active as the public/member app surface.', status: 'Live' },
+  { title: 'Deployment: Active', description: 'Hostinger Node/Next.js deployment.', status: 'Active' },
+  { title: 'OMOS Sync Layer: Active', description: 'app APIs can read OMOS manifest, health, pages, plugin registry, property registry, and system-health data.', status: 'Active' },
+  { title: 'Public Sitemap: Pending Merge', description: 'PR #237 adds the structured public sitemap, OMOS pages, architecture pages, and system-health surface.', status: 'Pending Merge' },
+  { title: 'Console Separation: Documented', description: 'console.onegodian.com remains the operator/admin runtime surface and should not be mixed with app.onegodian.com public/member routes.', status: 'Documented' },
+  { title: 'Next Priority', description: 'Fix and merge PR #237, then redeploy app.onegodian.com from latest main.', status: 'Action Required' }
 ];
+
+function SectionCard({ card }: { card: LinkCard }) {
+  const body = (
+    <article className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5">
+      <h3 className="text-lg font-semibold text-cyan-100">{card.title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-slate-300">{card.description}</p>
+      {card.status ? <p className="mt-3 text-xs uppercase tracking-[0.2em] text-amber-200">{card.status}</p> : null}
+    </article>
+  );
+
+  if (!card.href) return body;
+  const isExternal = card.href.startsWith('http');
+  return isExternal ? (
+    <a href={card.href} target="_blank" rel="noreferrer" className="block transition hover:opacity-90">
+      {body}
+    </a>
+  ) : (
+    <Link href={card.href} className="block transition hover:opacity-90">
+      {body}
+    </Link>
+  );
+}
 
 export default function HomePage() {
   return (
     <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 sm:px-6 sm:py-10 lg:px-8">
       <div className="mx-auto max-w-6xl space-y-8">
         <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-6 sm:p-8">
-          <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">ONEGODIAN PLATFORM</p>
-          <h1 className="mt-3 text-3xl font-bold sm:text-4xl">OneGodian Everything App</h1>
-          <p className="mt-3 text-lg text-cyan-100">Central command interface for the OneGodian ecosystem.</p>
-          <p className="mt-4 max-w-4xl text-base leading-relaxed text-slate-300 sm:text-lg">
-            Access registry systems, planetary worlds, moon systems, OneGodian Time™, ODIN records, ecosystem
-            infrastructure, media, tools, products, certificates, and profile services from one synchronized app
-            interface.
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">ONEGODIAN PLATFORM · PUBLIC / MEMBER NODE</p>
+          <h1 className="mt-3 text-3xl font-bold sm:text-4xl">OneGodian App</h1>
+          <p className="mt-4 max-w-5xl text-base leading-relaxed text-slate-300 sm:text-lg">
+            The OneGodian App is the public/member-facing node of the OneGodian ecosystem. It connects app.onegodian.com with OMOS.OneGodian.com, OneGodian.org, OneGodian.com, u.OneGodian.com, Capital.OneGodian.com, Galaxy.OneGodian.com, and QuantumOHI.com through structured modules, public records, system health checks, and synchronized platform data.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
-            <Link className="rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-5 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/30" href="/dashboard">Open Dashboard</Link>
-            <Link className="rounded-xl border border-slate-500/60 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-400/50 hover:text-cyan-100" href="/registry">Explore Registry</Link>
-            <Link className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-5 py-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/20" href="/time">OneGodian Time™</Link>
-          </div>
-        </section>
-
-        <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          {statusWidgets.map((widget) => (
-            <article key={widget.label} className="rounded-2xl border border-slate-700 bg-slate-900/80 p-4">
-              <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300">{widget.label}</p>
-              <p className="mt-2 text-sm font-semibold text-amber-100">{widget.value}</p>
-            </article>
-          ))}
-        </section>
-
-        {moduleGroups.map((group) => (
-          <section key={group.title} className="space-y-4">
-            <h2 className="text-xl font-semibold text-cyan-200 sm:text-2xl">{group.title}</h2>
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              {group.cards.map((card) => (
-                <Link key={card.title} href={card.href} className="group rounded-2xl border border-slate-700 bg-slate-900/70 p-5 transition hover:border-cyan-400/50 hover:bg-slate-900">
-                  <p className="text-2xl">{card.glyph}</p>
-                  <h3 className="mt-3 text-lg font-semibold text-slate-100 group-hover:text-cyan-100">{card.title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-slate-300">{card.description}</p>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {card.stats.map((stat) => (
-                      <span key={stat} className="rounded-full border border-cyan-500/25 bg-slate-950 px-2.5 py-1 text-xs text-cyan-200">
-                        {stat}
-                      </span>
-                    ))}
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        ))}
-
-        <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6 sm:p-8">
-          <h2 className="text-2xl font-semibold text-cyan-200">App Wireframe</h2>
-          <p className="mt-3 text-base leading-relaxed text-slate-300 sm:text-lg">
-            The OneGodian App organizes registry, planetary, timekeeping, media, product, and identity systems into one synchronized interface.
-          </p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {appWireframe.map((node) => (
-              <Link key={node.label} href={node.href} className="rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-400/50 hover:text-cyan-100">
-                {node.label}
+            {heroActions.map((action) => (
+              <Link key={action.href} className="rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-5 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/30" href={action.href}>
+                {action.label}
               </Link>
             ))}
           </div>
-          <p className="mt-4 text-sm text-amber-100">Flow: Dashboard → Registry → Planetary Systems → Time → Tools → Profile</p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-cyan-200">Live Platform Network</h2>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {platformNetwork.map((card) => (
+              <SectionCard key={card.title} card={card} />
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-cyan-200">What You Can Do Here</h2>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {capabilities.map((card) => (
+              <SectionCard key={card.title} card={card} />
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6 sm:p-8">
+          <h2 className="text-2xl font-semibold text-cyan-200">Entity Structure</h2>
+          <p className="mt-4 text-base leading-relaxed text-slate-300">ONEGODIAN, LLC is the commercial, technology, publishing, intellectual property, software, education, and platform-development entity.</p>
+          <p className="mt-4 text-base leading-relaxed text-slate-300">The Indigenous Nation of Onegodia™ is separate from ONEGODIAN, LLC and should only be referenced in the app where membership, religious society records, internal governance, or cultural/community records require that distinction.</p>
+          <p className="mt-4 text-base leading-relaxed text-slate-300">The OneGodian App is not a government portal. It is a public/member-facing digital interface operated as part of the OneGodian platform ecosystem.</p>
         </section>
 
         <section className="space-y-4 pb-4">
-          <h2 className="text-2xl font-semibold text-cyan-200">Recent App Milestones</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {milestones.map((item) => (
-              <article key={item.title} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5">
-                <h3 className="text-lg font-semibold text-slate-100">{item.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-300">{item.text}</p>
-              </article>
+          <h2 className="text-2xl font-semibold text-cyan-200">Current Production Status</h2>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {productionStatus.map((card) => (
+              <SectionCard key={card.title} card={card} />
             ))}
           </div>
         </section>

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -15,14 +15,12 @@ export const appHomeHero = {
 
 export const appNavigation = [
   { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Time', href: '/time' },
+  { label: 'Dual Dating', href: '/time/dual-dating' },
+  { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Registry', href: '/registry' },
   { label: 'OMOS', href: '/omos' },
   { label: 'Architecture', href: '/architecture' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Time', href: '/time' },
-  { label: 'Portfolio', href: '/portfolio' },
-  { label: 'Records', href: '/records' },
-  { label: 'Tools', href: '/tools' },
   { label: 'Sitemap', href: '/sitemap' }
 ];
 


### PR DESCRIPTION
### Motivation
- Replace the generic placeholder homepage copy with production-ready OneGodian public/member app content and surface the broader platform network. 
- Clarify the app’s role as the public/member-facing node and provide direct entrypoints to dashboard, time, OMOS status, and sitemap. 
- Provide clear production status and legal-safe entity structure while avoiding exposure of console/operator-only routes in the public surface. 

### Description
- Updated the homepage (`src/app/page.tsx`) to use the exact hero label/title/description, added required CTA buttons, and replaced the placeholder wireframe with structured sections: `Live Platform Network`, `What You Can Do Here`, `Entity Structure`, and `Current Production Status`. 
- Introduced a reusable `SectionCard` rendering pattern and simplified page data into `heroActions`, `platformNetwork`, `capabilities`, and `productionStatus` arrays inside `src/app/page.tsx`. 
- Updated navigation in `src/lib/app-content.ts` to the requested public ordering: `Dashboard`, `Time`, `Dual Dating`, `Ecosystem`, `Registry`, `OMOS`, `Architecture`, `Sitemap`. 
- Did not rebase/merge the open PR #237 because its branch was not available locally; the homepage changes were implemented on main and the sitemap/OMOS route work is noted as `Pending Merge` in the production status block. 

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm run test` (smoke tests); the smoke test was flaky in this environment and ultimately failed with a `server start timeout` from `scripts/smoke-test.mjs`, so automated tests are marked as needing attention. 
- Ran `npm run build` (`next build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1475df0ab4832da5e5d0b859b239f9)