### PR TITLE
Set up qrv.network production marketing surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 NODE_ENV=production
 PORT=3000
 OMOS_CANONICAL_DOMAIN=omos.onegodian.com
+NEXT_PUBLIC_ISSUER_URL=https://issuer.qrv.network
+NEXT_PUBLIC_DEVELOPER_URL=https://developers.qrv.network
+NEXT_PUBLIC_STATUS_URL=https://status.qrv.network
+NEXT_PUBLIC_DEMO_CERT_ID=QRV-PROD-CERT-000001

--- a/src/app/components/CapitalFooter.tsx
+++ b/src/app/components/CapitalFooter.tsx
@@ -1,6 +1,16 @@
 import Link from 'next/link';
-import { footerSections } from '@/lib/onegodian-content';
 
 export function CapitalFooter() {
-  return <footer className="mt-16 border-t border-slate-800 bg-slate-950/80"><div className="mx-auto grid max-w-7xl gap-8 px-4 py-10 text-sm text-slate-300 md:grid-cols-3">{footerSections.map((section)=><div key={section.title}><h3 className="mb-3 font-semibold text-slate-100">{section.title}</h3><ul className="space-y-2">{section.links.map((link)=><li key={link.href}>{link.href.startsWith('http') ? <a href={link.href} target="_blank" rel="noreferrer">{link.label}</a> : <Link href={link.href}>{link.label}</Link>}</li>)}</ul></div>)}</div><div className="border-t border-slate-800 px-4 py-4 text-center text-xs text-slate-400">© 2026 ONEGODIAN™. Designed and written by One Gregory Onegodian™. All Rights Reserved.</div></footer>;
+  return (
+    <footer className="mt-16 border-t border-slate-800 bg-slate-950/80">
+      <div className="mx-auto max-w-7xl px-4 py-10 text-sm text-slate-300">
+        <div className="flex flex-wrap items-center gap-4">
+          <Link href="/legal">Legal</Link>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
+        </div>
+      </div>
+      <div className="border-t border-slate-800 px-4 py-4 text-center text-xs text-slate-400">© 2026 QRV Network</div>
+    </footer>
+  );
 }

--- a/src/app/components/CapitalNavigation.tsx
+++ b/src/app/components/CapitalNavigation.tsx
@@ -1,13 +1,26 @@
 import Link from 'next/link';
-import { headers } from 'next/headers';
-import { appNavigation, consoleNavigation, ecosystemLinks } from '@/lib/onegodian-content';
+
+const navItems = [
+  { href: '/', label: 'Home' },
+  { href: '/pricing', label: 'Pricing' },
+  { href: '/use-cases', label: 'Use Cases' }
+];
 
 export function CapitalNavigation() {
-  const host = headers().get('host') ?? '';
-  const isConsole = host.startsWith('console.onegodian.com');
-  const title = isConsole ? 'OneGodian Console' : 'OneGodian App';
-  const nav = isConsole ? consoleNavigation : appNavigation;
-  const env = process.env.ONEGODIAN_ENV ?? process.env.NODE_ENV ?? 'dev';
-
-  return <header className="capital-header"><div className="capital-header-inner"><Link href={isConsole ? '/admin' : '/dashboard'} className="capital-logo"><span className="capital-logo-mark">OG</span> {title}</Link>{isConsole ? <span className="rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs text-amber-200">{env}</span> : null}<nav className="capital-nav" aria-label="Primary">{nav.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}</nav><nav className="capital-ecosystem-nav" aria-label="Ecosystem">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer">{item.label}</a>)}</nav></div></header>;
+  return (
+    <header className="capital-header">
+      <div className="capital-header-inner">
+        <Link href="/" className="capital-logo">
+          <span className="capital-logo-mark">QRV</span> qrv.network
+        </Link>
+        <nav className="capital-nav" aria-label="Primary">
+          {navItems.map((item) => (
+            <Link key={item.href} href={item.href}>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
 }

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,0 +1,3 @@
+export default function LegalPage() {
+  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Legal</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network legal content.</p></main>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,234 +1,46 @@
 import Link from 'next/link';
 
-type StatusWidget = {
-  label: string;
-  value: string;
-};
-
-type ModuleCard = {
-  title: string;
-  href: string;
-  description: string;
-  stats: string[];
-  glyph: string;
-};
-
-const statusWidgets: StatusWidget[] = [
-  { label: 'App Status', value: 'Online' },
-  { label: 'ODIN Registry', value: 'Active' },
-  { label: 'OneGodian Time™', value: 'OTS-V5 Active' },
-  { label: 'Ecosystem', value: 'Route Active' },
-  { label: 'Mobile Navigation', value: 'Enabled' }
-];
-
-const moduleGroups: { title: string; cards: ModuleCard[] }[] = [
-  {
-    title: 'Core Registry',
-    cards: [
-      {
-        title: 'Planetary Registry',
-        href: '/planets',
-        description: 'ODIN-PR planets, civilizations, and registry systems.',
-        stats: ['25 Planets', 'ODIN-PR', 'Canon'],
-        glyph: '🪐'
-      },
-      {
-        title: 'ODIN Registry',
-        href: '/odin',
-        description: 'Canonical registry hub for series, platforms, verification, worlds, and planetary records.',
-        stats: ['Registry', 'Verification', 'Canon'],
-        glyph: '🧭'
-      },
-      {
-        title: 'OneGodian Time™',
-        href: '/time',
-        description: 'OTS-V5 dual-date clock, Gregorian → OneGodian converter, epoch rules, and timestamp governance.',
-        stats: ['OTS-V5', 'UTC Truth', '13 Months'],
-        glyph: '⏱️'
-      },
-      {
-        title: 'Certificates',
-        href: '/certificates',
-        description: 'Certificate views, registry references, and OneGodian verification records.',
-        stats: ['Records', 'Identity', 'Archive'],
-        glyph: '📜'
-      }
-    ]
-  },
-  {
-    title: 'Worlds & Systems',
-    cards: [
-      {
-        title: 'Moons & Systems',
-        href: '/moons-systems',
-        description: 'Moon systems, orbital continuity, and expansion interfaces.',
-        stats: ['Moons', 'Orbits', 'Systems'],
-        glyph: '🌙'
-      },
-      {
-        title: 'Ecosystem',
-        href: '/ecosystem',
-        description: 'Connected OneGodian systems and infrastructure layers.',
-        stats: ['Routes', 'Modules', 'Infrastructure'],
-        glyph: '🌐'
-      },
-      {
-        title: 'Media Center',
-        href: '/media',
-        description: 'Visual media, banners, assets, and content presentation layers.',
-        stats: ['Media', 'Assets', 'Visuals'],
-        glyph: '🎬'
-      },
-      {
-        title: 'Products',
-        href: '/products',
-        description: 'Product surfaces, digital assets, app-linked offerings, and commerce expansion.',
-        stats: ['Store', 'Digital', 'Commerce'],
-        glyph: '🛍️'
-      }
-    ]
-  },
-  {
-    title: 'Tools & Operations',
-    cards: [
-      {
-        title: 'Tools',
-        href: '/tools',
-        description: 'Operational utilities, converters, dashboards, and app functions.',
-        stats: ['Utilities', 'Engines', 'Workflow'],
-        glyph: '🧰'
-      },
-      {
-        title: 'Registry',
-        href: '/registry',
-        description: 'Unified registry access for app-level records and canonical systems.',
-        stats: ['Index', 'Records', 'Links'],
-        glyph: '📚'
-      },
-      {
-        title: 'Dashboard',
-        href: '/dashboard',
-        description: 'Operational dashboard for the OneGodian App interface.',
-        stats: ['Modules', 'Status', 'Navigation'],
-        glyph: '📊'
-      },
-      {
-        title: 'Profile',
-        href: '/profile',
-        description: 'Identity profile, app presence, and user-facing account layer.',
-        stats: ['Identity', 'Account', 'Access'],
-        glyph: '👤'
-      }
-    ]
-  }
-];
-
-const appWireframe = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Registry', href: '/registry' },
-  { label: 'Planetary Systems', href: '/planets' },
-  { label: 'Time', href: '/time' },
-  { label: 'Tools', href: '/tools' },
-  { label: 'Profile', href: '/profile' }
-];
-
-const milestones = [
-  {
-    title: 'Ecosystem Route Added',
-    text: 'Production-safe ecosystem module and route added to the app.'
-  },
-  {
-    title: 'ODIN Registry Expanded',
-    text: 'ODIN landing pages, registry datasets, navigation, and reusable components added.'
-  },
-  {
-    title: 'Navigation Upgraded',
-    text: 'Glyph cards, accents, mobile navigation, and stronger dashboard identity added.'
-  },
-  {
-    title: 'OneGodian Time™ Added',
-    text: 'OTS-V5 deterministic conversion library and dashboard widgets merged.'
-  }
-];
+const issuerUrl = process.env.NEXT_PUBLIC_ISSUER_URL ?? 'https://issuer.qrv.network';
+const developerUrl = process.env.NEXT_PUBLIC_DEVELOPER_URL ?? 'https://developers.qrv.network';
+const statusUrl = process.env.NEXT_PUBLIC_STATUS_URL ?? 'https://status.qrv.network';
+const demoCertId = process.env.NEXT_PUBLIC_DEMO_CERT_ID ?? 'QRV-PROD-CERT-000001';
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 sm:px-6 sm:py-10 lg:px-8">
-      <div className="mx-auto max-w-6xl space-y-8">
-        <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-6 sm:p-8">
-          <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">ONEGODIAN PLATFORM</p>
-          <h1 className="mt-3 text-3xl font-bold sm:text-4xl">OneGodian Everything App</h1>
-          <p className="mt-3 text-lg text-cyan-100">Central command interface for the OneGodian ecosystem.</p>
-          <p className="mt-4 max-w-4xl text-base leading-relaxed text-slate-300 sm:text-lg">
-            Access registry systems, planetary worlds, moon systems, OneGodian Time™, ODIN records, ecosystem
-            infrastructure, media, tools, products, certificates, and profile services from one synchronized app
-            interface.
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <Link className="rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-5 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/30" href="/dashboard">Open Dashboard</Link>
-            <Link className="rounded-xl border border-slate-500/60 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-400/50 hover:text-cyan-100" href="/registry">Explore Registry</Link>
-            <Link className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-5 py-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/20" href="/time">OneGodian Time™</Link>
-          </div>
-        </section>
+    <main className="mx-auto min-h-screen w-full max-w-6xl px-4 py-10">
+      <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">QRV Production Node</p>
+        <h1 className="mt-3 text-4xl font-bold">Instant Trust Verification for Certificates, Identity, and Assets</h1>
+        <p className="mt-4 max-w-3xl text-slate-300">
+          qrv.network verifies credentials in seconds using tamper-evident proofs and QR-native workflows.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a className="rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-5 py-3 text-sm font-semibold text-cyan-100" href={issuerUrl} target="_blank" rel="noreferrer">Issuer Onboarding</a>
+          <a className="rounded-xl border border-slate-500/60 px-5 py-3 text-sm font-semibold text-slate-100" href={developerUrl} target="_blank" rel="noreferrer">Developer Docs</a>
+          <a className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-5 py-3 text-sm font-semibold text-emerald-100" href={statusUrl} target="_blank" rel="noreferrer">System Status</a>
+        </div>
+      </section>
 
-        <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          {statusWidgets.map((widget) => (
-            <article key={widget.label} className="rounded-2xl border border-slate-700 bg-slate-900/80 p-4">
-              <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300">{widget.label}</p>
-              <p className="mt-2 text-sm font-semibold text-amber-100">{widget.value}</p>
-            </article>
-          ))}
-        </section>
+      <section className="mt-8 rounded-3xl border border-slate-700 bg-slate-900/70 p-8">
+        <h2 className="text-2xl font-semibold text-cyan-200">Live Verification Demo</h2>
+        <p className="mt-2 text-slate-300">Demo Certificate ID: <span className="font-mono text-amber-200">{demoCertId}</span></p>
+        <div className="mt-4 rounded-xl border border-slate-700 bg-slate-950 p-4 text-sm text-slate-300">
+          <p>Status: <span className="text-emerald-300">Verified</span></p>
+          <p>Issuer: QRV Production Authority</p>
+          <p>Type: Production Readiness Certificate</p>
+        </div>
+      </section>
 
-        {moduleGroups.map((group) => (
-          <section key={group.title} className="space-y-4">
-            <h2 className="text-xl font-semibold text-cyan-200 sm:text-2xl">{group.title}</h2>
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              {group.cards.map((card) => (
-                <Link key={card.title} href={card.href} className="group rounded-2xl border border-slate-700 bg-slate-900/70 p-5 transition hover:border-cyan-400/50 hover:bg-slate-900">
-                  <p className="text-2xl">{card.glyph}</p>
-                  <h3 className="mt-3 text-lg font-semibold text-slate-100 group-hover:text-cyan-100">{card.title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-slate-300">{card.description}</p>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {card.stats.map((stat) => (
-                      <span key={stat} className="rounded-full border border-cyan-500/25 bg-slate-950 px-2.5 py-1 text-xs text-cyan-200">
-                        {stat}
-                      </span>
-                    ))}
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        ))}
-
-        <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6 sm:p-8">
-          <h2 className="text-2xl font-semibold text-cyan-200">App Wireframe</h2>
-          <p className="mt-3 text-base leading-relaxed text-slate-300 sm:text-lg">
-            The OneGodian App organizes registry, planetary, timekeeping, media, product, and identity systems into one synchronized interface.
-          </p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {appWireframe.map((node) => (
-              <Link key={node.label} href={node.href} className="rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-400/50 hover:text-cyan-100">
-                {node.label}
-              </Link>
-            ))}
-          </div>
-          <p className="mt-4 text-sm text-amber-100">Flow: Dashboard → Registry → Planetary Systems → Time → Tools → Profile</p>
-        </section>
-
-        <section className="space-y-4 pb-4">
-          <h2 className="text-2xl font-semibold text-cyan-200">Recent App Milestones</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {milestones.map((item) => (
-              <article key={item.title} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5">
-                <h3 className="text-lg font-semibold text-slate-100">{item.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-300">{item.text}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-      </div>
+      <section className="mt-8 grid gap-4 sm:grid-cols-2">
+        <Link className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5" href="/pricing">
+          <h3 className="text-lg font-semibold">Explore Pricing</h3>
+          <p className="mt-2 text-sm text-slate-300">Starter, Pro, and Institution issuer plans.</p>
+        </Link>
+        <Link className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5" href="/use-cases">
+          <h3 className="text-lg font-semibold">Explore Use Cases</h3>
+          <p className="mt-2 text-sm text-slate-300">Certificate, identity, product, and property verification workflows.</p>
+        </Link>
+      </section>
     </main>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,9 @@
+const plans = [
+  { name: 'Starter', price: '$49/mo', features: ['1 issuer seat', '5,000 verifications/mo', 'Email support'] },
+  { name: 'Pro', price: '$299/mo', features: ['5 issuer seats', '100,000 verifications/mo', 'API access + SLA'] },
+  { name: 'Institution', price: 'Contact sales', features: ['Unlimited seats', 'Custom throughput', 'Dedicated compliance support'] }
+];
+
+export default function PricingPage() {
+  return <main className="mx-auto max-w-6xl px-4 py-10"><h1 className="text-3xl font-bold">Issuer Pricing</h1><div className="mt-6 grid gap-4 md:grid-cols-3">{plans.map((plan)=><section key={plan.name} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5"><h2 className="text-xl font-semibold text-cyan-200">{plan.name}</h2><p className="mt-2 text-lg font-bold">{plan.price}</p><ul className="mt-3 space-y-2 text-sm text-slate-300">{plan.features.map((feature)=><li key={feature}>• {feature}</li>)}</ul></section>)}</div></main>;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,3 @@
+export default function PrivacyPage() {
+  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Privacy</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network privacy content.</p></main>;
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,3 @@
+export default function TermsPage() {
+  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Terms</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network terms content.</p></main>;
+}

--- a/src/app/use-cases/page.tsx
+++ b/src/app/use-cases/page.tsx
@@ -1,0 +1,10 @@
+const useCases = [
+  { title: 'Certificate Verification', body: 'Validate training, academic, and professional certificates in real time.' },
+  { title: 'Identity Verification', body: 'Prove identity claims without exposing sensitive personal data.' },
+  { title: 'Product Verification', body: 'Confirm product authenticity across supply chain checkpoints.' },
+  { title: 'Property Verification', body: 'Verify ownership and title history for physical or digital property assets.' }
+];
+
+export default function UseCasesPage() {
+  return <main className="mx-auto max-w-6xl px-4 py-10"><h1 className="text-3xl font-bold">Verification Use Cases</h1><div className="mt-6 grid gap-4 md:grid-cols-2">{useCases.map((item)=><section key={item.title} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5"><h2 className="text-xl font-semibold text-cyan-200">{item.title}</h2><p className="mt-2 text-sm text-slate-300">{item.body}</p></section>)}</div></main>;
+}


### PR DESCRIPTION
### Motivation
- Replace the generic OneGodian homepage and navigation with a focused production marketing surface for qrv.network including CTAs for issuers, developers, and status.
- Provide a simple live verification demo and public-facing pages so the marketing site can be used as the QRV production node.
- Surface runtime-configurable public URLs via `NEXT_PUBLIC_*` env vars so deploy-time values can be injected.

### Description
- Replaced the root landing page with a QRV-focused hero, CTAs, and a Live Verification Demo using `QRV-PROD-CERT-000001` in `src/app/page.tsx`.
- Replaced `CapitalNavigation` and `CapitalFooter` contents to show `Home`, `Pricing`, `Use Cases` nav and footer links to `/legal`, `/privacy`, and `/terms` in `src/app/components/CapitalNavigation.tsx` and `src/app/components/CapitalFooter.tsx`.
- Added new marketing pages: `/pricing` (`src/app/pricing/page.tsx`) and `/use-cases` (`src/app/use-cases/page.tsx`) and scaffolded placeholder pages for `/legal`, `/privacy`, and `/terms` so footer links resolve.
- Added runtime env hints to `.env.example` for `NEXT_PUBLIC_ISSUER_URL`, `NEXT_PUBLIC_DEVELOPER_URL`, `NEXT_PUBLIC_STATUS_URL`, and `NEXT_PUBLIC_DEMO_CERT_ID`.

### Testing
- Ran `npm run check` which failed due to a pre-existing syntax error in `server.js` complaining about `Identifier 'usageMap' has already been declared`, and this failure is unrelated to the marketing page changes.
- Ran `npm run build` and the Next.js production build completed successfully with static pages generated and the build artifacts produced.
- Verified the modified files were staged and committed as part of the change set (commit message: `Set up QRV marketing production node pages and CTAs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a2794c14832dafb3de5c3a1502cb)