### PR TITLE
Harden OMOS runtime and add plugin-sync + inventory endpoints

### DIFF
--- a/docs/live-production-checklist.md
+++ b/docs/live-production-checklist.md
@@ -1,0 +1,17 @@
+# Live Production Checklist
+
+- Canonical host is `https://omos.onegodian.com`.
+- `/`, `/manifest`, and `/health` remain reachable.
+- Verify `/api/health` reports production status and plugin sync availability.
+- Verify `/api/manifest` includes plugin sync endpoint metadata.
+- Verify runtime inventory endpoints:
+  - `/api/tools`
+  - `/api/artifacts`
+  - `/api/dashboard`
+  - `/api/system-health`
+- Verify plugin sync endpoints:
+  - `/api/plugin-consumers`
+  - `/api/plugin-shortcodes`
+  - `/api/plugin-sync`
+- Run smoke tests before deployment.
+- Confirm no secrets are committed.

--- a/docs/wordpress-plugin-sync-contract.md
+++ b/docs/wordpress-plugin-sync-contract.md
@@ -1,0 +1,24 @@
+# WordPress Plugin Sync Contract
+
+OMOS runtime is the canonical plugin sync authority for:
+- OneGodian.com
+- OneGodian.org
+- QuantumOHI.com
+
+## Endpoints
+- `GET /api/plugin-consumers`
+- `GET /api/plugin-shortcodes`
+- `GET /api/plugin-sync`
+- `GET /api/manifest` (includes plugin sync metadata)
+
+## Shortcodes
+- `[omos_manifest]`
+- `[omos_runtime_status]`
+- `[omos_bridge_builder]`
+- `[omos_tool_grid]`
+- `[omos_docs_grid]`
+
+## Response conventions
+- JSON responses return HTTP 200 on success.
+- `?pretty=1` returns formatted JSON for direct browser readability.
+- Default output remains machine-readable JSON.

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -9,7 +9,7 @@ const routes = [
   '/architecture', '/architecture/ohi', '/architecture/runtime', '/architecture/interfaces', '/architecture/infrastructure', '/architecture/omos-sync',
   '/algorithm', '/algorithm/protocol', '/algorithm/experience', '/algorithm/community', '/algorithm/orientation',
   '/registry', '/time', '/portfolio', '/records', '/tools',
-  '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health'
+  '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health', '/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync', '/api/tools', '/api/artifacts', '/api/dashboard'
 ];
 
 const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe' });
@@ -44,6 +44,14 @@ try {
   assert.equal(Array.isArray(plugins.plugins), true);
   assert.equal(plugins.total, 7);
 
+  const apiManifest = await (await fetch(`${base}/api/manifest`)).json();
+  assert.equal(Array.isArray(apiManifest.pluginSync?.endpoints), true);
+
+  const consumers = await (await fetch(`${base}/api/plugin-consumers`)).json();
+  assert.equal(consumers.consumers.length >= 3, true);
+
+  const shortcodes = await (await fetch(`${base}/api/plugin-shortcodes`)).json();
+  assert.equal(shortcodes.shortcodes.includes('[omos_manifest]'), true);
 
   console.log('Smoke tests passed');
 } finally {

--- a/src/app/api/artifacts/route.ts
+++ b/src/app/api/artifacts/route.ts
@@ -1,4 +1,4 @@
-import data from '@/data/tools.json';
+import data from '@/data/artifacts.json';
 import { jsonResponse } from '@/lib/api-json';
 
 export async function GET(request: Request) {

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,4 +1,4 @@
-import data from '@/data/tools.json';
+import data from '@/data/dashboard.json';
 import { jsonResponse } from '@/lib/api-json';
 
 export async function GET(request: Request) {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,3 +1,16 @@
-export async function GET() {
-  return Response.json({ app: 'OMOS Runtime', status: 'ok', version: '1.0.0' });
+import { jsonResponse } from '@/lib/api-json';
+
+export async function GET(request: Request) {
+  return jsonResponse(
+    {
+      app: 'OMOS Runtime',
+      status: 'ok',
+      environment: 'production',
+      version: '1.0.1',
+      canonicalHost: 'https://omos.onegodian.com',
+      publicRouteCount: 15,
+      pluginSync: 'available'
+    },
+    request
+  );
 }

--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -1,14 +1,21 @@
 import { headers } from 'next/headers';
-import { NextResponse } from 'next/server';
 import manifest from '@/data/manifest.json';
+import { jsonResponse } from '@/lib/api-json';
 
-export async function GET() {
+export async function GET(request: Request) {
   const host = headers().get('host') ?? '';
   const isConsole = host.includes('console.onegodian.com');
 
-  return NextResponse.json({
-    ...manifest,
-    generated_at: new Date().toISOString(),
-    app_profile: isConsole ? 'internal-control-plane' : 'member-facing-app'
-  });
+  return jsonResponse(
+    {
+      ...manifest,
+      generated_at: new Date().toISOString(),
+      app_profile: isConsole ? 'internal-control-plane' : 'member-facing-app',
+      pluginSync: {
+        endpoints: ['/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync'],
+        consumers: ['OneGodian.com', 'OneGodian.org', 'QuantumOHI.com']
+      }
+    },
+    request
+  );
 }

--- a/src/app/api/plugin-consumers/route.ts
+++ b/src/app/api/plugin-consumers/route.ts
@@ -1,4 +1,4 @@
-import data from '@/data/tools.json';
+import data from '@/data/plugin-consumers.json';
 import { jsonResponse } from '@/lib/api-json';
 
 export async function GET(request: Request) {

--- a/src/app/api/plugin-shortcodes/route.ts
+++ b/src/app/api/plugin-shortcodes/route.ts
@@ -1,4 +1,4 @@
-import data from '@/data/tools.json';
+import data from '@/data/plugin-shortcodes.json';
 import { jsonResponse } from '@/lib/api-json';
 
 export async function GET(request: Request) {

--- a/src/app/api/plugin-sync/route.ts
+++ b/src/app/api/plugin-sync/route.ts
@@ -1,0 +1,17 @@
+import consumers from '@/data/plugin-consumers.json';
+import shortcodes from '@/data/plugin-shortcodes.json';
+import { jsonResponse } from '@/lib/api-json';
+
+export async function GET(request: Request) {
+  return jsonResponse(
+    {
+      status: 'ok',
+      sync: {
+        consumers: consumers.consumers,
+        shortcodes: shortcodes.shortcodes,
+        endpoints: ['/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync']
+      }
+    },
+    request
+  );
+}

--- a/src/app/api/system-health/route.ts
+++ b/src/app/api/system-health/route.ts
@@ -1,16 +1,19 @@
-import { NextResponse } from 'next/server';
 import { getOmosSyncState } from '@/lib/omos-sync';
+import { jsonResponse } from '@/lib/api-json';
 
-export async function GET() {
+export async function GET(request: Request) {
   const sync = getOmosSyncState();
   const failingServices = sync.errors;
 
-  return NextResponse.json({
-    runtime: sync.health?.status ?? 'unknown',
-    manifestVersion: sync.manifest?.version ?? 'unknown',
-    pageRegistryCount: sync.pages.length,
-    lastSyncUtc: sync.lastSyncUtc,
-    failingServices,
-    status: failingServices.length > 0 ? 'degraded' : 'healthy'
-  });
+  return jsonResponse(
+    {
+      runtime: sync.health?.status ?? 'unknown',
+      manifestVersion: sync.manifest?.version ?? 'unknown',
+      pageRegistryCount: sync.pages.length,
+      lastSyncUtc: sync.lastSyncUtc,
+      failingServices,
+      status: failingServices.length > 0 ? 'degraded' : 'healthy'
+    },
+    request
+  );
 }

--- a/src/data/artifacts.json
+++ b/src/data/artifacts.json
@@ -1,0 +1,8 @@
+{
+  "artifacts": [
+    "manifest",
+    "runtime-status",
+    "plugin-sync-contract",
+    "live-production-checklist"
+  ]
+}

--- a/src/data/dashboard.json
+++ b/src/data/dashboard.json
@@ -1,0 +1,9 @@
+{
+  "widgets": [
+    "runtime",
+    "manifest-version",
+    "plugin-sync",
+    "system-health"
+  ],
+  "canonicalHost": "https://omos.onegodian.com"
+}

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -1,10 +1,30 @@
 {
   "name": "OMOS Runtime",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "status": "production",
   "canonical_domain": "omos.onegodian.com",
   "purpose": "Public runtime for OMOS routes, page registry, and manifest delivery.",
   "integrations": ["OneGodian App", "WordPress Bridge"],
   "wordpress_hosts": ["OneGodian.com", "OneGodian.org", "QuantumOHI.com"],
-  "routes": ["/", "/omos", "/protocol", "/algorithm", "/ohi", "/docs", "/tools", "/artifacts", "/manifest", "/api/health", "/api/manifest", "/api/pages"]
+  "routes": [
+    "/",
+    "/omos",
+    "/protocol",
+    "/algorithm",
+    "/ohi",
+    "/docs",
+    "/tools",
+    "/artifacts",
+    "/manifest",
+    "/api/health",
+    "/api/manifest",
+    "/api/pages",
+    "/api/plugin-consumers",
+    "/api/plugin-shortcodes",
+    "/api/plugin-sync",
+    "/api/tools",
+    "/api/artifacts",
+    "/api/dashboard",
+    "/api/system-health"
+  ]
 }

--- a/src/data/plugin-consumers.json
+++ b/src/data/plugin-consumers.json
@@ -1,0 +1,19 @@
+{
+  "consumers": [
+    {
+      "name": "OneGodian.com",
+      "host": "https://onegodian.com",
+      "type": "primary"
+    },
+    {
+      "name": "OneGodian.org",
+      "host": "https://onegodian.org",
+      "type": "public-site"
+    },
+    {
+      "name": "QuantumOHI.com",
+      "host": "https://quantumohi.com",
+      "type": "partner"
+    }
+  ]
+}

--- a/src/data/plugin-shortcodes.json
+++ b/src/data/plugin-shortcodes.json
@@ -1,0 +1,9 @@
+{
+  "shortcodes": [
+    "[omos_manifest]",
+    "[omos_runtime_status]",
+    "[omos_bridge_builder]",
+    "[omos_tool_grid]",
+    "[omos_docs_grid]"
+  ]
+}

--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -1,0 +1,11 @@
+{
+  "tools": [
+    "dashboard",
+    "ecosystem",
+    "registry",
+    "members",
+    "certificates",
+    "campaigns",
+    "media"
+  ]
+}

--- a/src/lib/api-json.ts
+++ b/src/lib/api-json.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export function jsonResponse(data: unknown, request?: Request) {
+  const pretty = request ? new URL(request.url).searchParams.get('pretty') === '1' : false;
+
+  if (pretty) {
+    return new Response(JSON.stringify(data, null, 2), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json; charset=utf-8'
+      }
+    });
+  }
+
+  return NextResponse.json(data);
+}


### PR DESCRIPTION
### Motivation
- Make OMOS the stable manifest and plugin-sync authority for OneGodian domains and partners by exposing explicit plugin-sync metadata and consumers. 
- Improve human readability of core JSON endpoints in browsers while preserving machine-readable API behavior. 
- Surface runtime inventory and system-health endpoints so external services and the control plane can discover tools, artifacts, and dashboard metadata.

### Description
- Added a shared JSON helper `jsonResponse` in `src/lib/api-json.ts` that returns machine-readable JSON by default and supports `?pretty=1` formatted output for browsers. 
- Hardened `/api/health` to the production runtime contract and bumped the runtime version to `1.0.1`. 
- Extended `/api/manifest` to include `pluginSync` metadata and added plugin-sync endpoints to the manifest routes list. 
- Added plugin-sync endpoints: `GET /api/plugin-consumers`, `GET /api/plugin-shortcodes`, and `GET /api/plugin-sync`. 
- Added runtime inventory endpoints: `GET /api/tools`, `GET /api/artifacts`, `GET /api/dashboard`, and updated `GET /api/system-health` to use the shared JSON helper. 
- Created source data files under `src/data/` for `plugin-consumers.json`, `plugin-shortcodes.json`, `tools.json`, `artifacts.json`, and `dashboard.json` with required consumers and shortcodes. 
- Added documentation files `docs/wordpress-plugin-sync-contract.md` and `docs/live-production-checklist.md` describing the contract and checklist. 
- Extended the smoke test script `scripts/smoke-test.mjs` to cover the new endpoints and to assert plugin-sync metadata is present in `/api/manifest`.

### Testing
- Ran `npm run check` which failed due to an existing duplicate declaration error in `server.js` unrelated to these changes. 
- Ran `npm run lint` which failed due to pre-existing JSX parse errors in `src/app/page.tsx` not introduced by this patch. 
- Ran `npm run typecheck` which failed for the same pre-existing JSX/type errors in `src/app/page.tsx`. 
- Ran `npm run build` which failed due to the existing compile errors in `src/app/page.tsx`. 
- Ran `npm run test:smoke` which failed because the site returned HTTP 500 on `/` caused by the compile errors above; the smoke script was expanded to assert the new plugin-sync endpoints and manifest metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e223d304832dafd542cceb66623e)