### PR TITLE
Add OneGodian app content pages and update navigation/manifest

### DIFF
--- a/src/app/(app)/commerce/page.tsx
+++ b/src/app/(app)/commerce/page.tsx
@@ -1,0 +1,11 @@
+export default function CommercePage() {
+  return (
+    <main className="space-y-6">
+      <h1 className="text-3xl font-bold">OneGodian Commerce + Identity Engine</h1>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
+        <p>OneGodian.com is the commerce and identity product engine for ONEGODIAN, LLC offerings including media, education products, software-linked goods, and member-linked services.</p>
+        <p>Commerce operations are managed as private commercial infrastructure with product identity, fulfillment, and campaign integration.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,2 +1,19 @@
 import { ecosystemPortals } from '@/lib/onegodian-content';
-export default function EcosystemPage() { return <main className="space-y-6"><h1 className="text-3xl font-bold">ONEGODIAN ECOSYSTEM PORTALS</h1><section className="grid gap-4 md:grid-cols-2">{ecosystemPortals.map((p)=><article key={p.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="font-semibold">{p.name}</h2><p className="text-sm text-slate-300">{p.role}</p><a href={p.url} target="_blank" rel="noreferrer" className="text-cyan-300">{p.url}</a></article>)}</section></main>; }
+
+export default function EcosystemPage() {
+  return (
+    <main className="space-y-6">
+      <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
+      <p className="text-slate-300">Connected properties across identity, commerce, education, runtime systems, and verification infrastructure.</p>
+      <section className="grid gap-4 md:grid-cols-2">
+        {ecosystemPortals.map((p) => (
+          <article key={p.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+            <h2 className="font-semibold">{p.name}</h2>
+            <p className="text-sm text-slate-300">{p.role}</p>
+            <a href={p.url} target="_blank" rel="noreferrer" className="text-cyan-300">{p.url}</a>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/institutional/page.tsx
+++ b/src/app/(app)/institutional/page.tsx
@@ -1,2 +1,12 @@
-import { ChecklistCard, ModuleHeader } from '@/components/module-ui';
-export default function Page(){return <main className='space-y-6'><ModuleHeader title='Institutional Dossier' description='Institutional-safe overview of legal structure, governance boundaries, and IP posture for OneGodian systems.'/><section className='rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300'><p>ONEGODIAN, LLC is the commercial and intellectual-property entity for founder-defined OneGodian frameworks.</p><p className='mt-2'>The Indigenous Nation of Onegodia is a separate governance body and must not be merged into LLC legal framing.</p><p className='mt-2'>OneGodian is described here as a founder-defined belief identity framework and intellectual property system, not as a religion, sect, denomination, or cult.</p></section><ChecklistCard items={['Add positioning statement summary','Add copyright/IP references','Add valuation placeholder','Add investor, banking, and press inquiry routing']} /></main>}
+export default function InstitutionalPage() {
+  return (
+    <main className="space-y-6">
+      <h1 className="text-3xl font-bold">Institutional Clarity</h1>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
+        <p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity responsible for product operations, platforms, publishing, and technology execution.</p>
+        <p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p>
+        <p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/membership/page.tsx
+++ b/src/app/(app)/membership/page.tsx
@@ -1,0 +1,11 @@
+export default function MembershipPage() {
+  return (
+    <main className="space-y-6">
+      <h1 className="text-3xl font-bold">OneGodian Membership</h1>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300">
+        <p>Membership provides access to profile records, campaign participation, tools, and platform learning resources.</p>
+        <p className="mt-2">Dashboard entry is available from the member node and remains compatible with admin/control-plane reporting via manifest and status surfaces.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,9 +1,23 @@
-import { getOmosBridgeConfig } from '@/lib/omos-bridge';
-
-const restEndpoints = ['/api/omos/status', '/api/manifest', '/api/tools', '/api/stats', '/api/omos/llm/chat'];
-
 export default function OmosPage() {
-  const config = getOmosBridgeConfig();
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OMOS Module</h1><p className="mt-2 text-slate-300">OMOS.OneGodian.com protocol status, bridge operations, tool registry, and gateway telemetry placeholders.</p></header>
-  <section className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">Provider / Bridge Configuration</h2><ul className="mt-2 space-y-1 text-sm text-slate-300"><li>OMOS_REST_BASE_URL: {config.restBaseUrl ?? 'not set'}</li><li>X-OMOS-App-Key: {config.hasBridgeKey ? 'configured (server-side only)' : 'missing'}</li><li>OMOS LLM Gateway: placeholder monitored</li><li>Tool Registry: placeholder data loaded</li></ul></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">REST Endpoints</h2><ul className="mt-2 list-disc pl-5 text-sm text-cyan-300">{restEndpoints.map((ep)=><li key={ep}>{ep}</li>)}</ul></article></section></main>;
+  const omosMindMap = [
+    'Identity architecture and remembrance framework',
+    'Consciousness alignment protocol layers',
+    'Ethics, reflection, and participation modules',
+    'Public app and dashboard synchronization',
+    'Manifest/API interoperability for ecosystem apps'
+  ];
+
+  return (
+    <main className="space-y-6">
+      <h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1>
+      <p className="text-slate-300">OMOS content maps metaphysical operating concepts into practical app modules, governance boundaries, and platform synchronization.</p>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+        <ul className="list-disc space-y-1 pl-5 text-sm text-slate-300">
+          {omosMindMap.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
 }

--- a/src/app/(app)/remember/page.tsx
+++ b/src/app/(app)/remember/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { rememberCampaign } from '@/lib/onegodian-content';
+
+export default function RememberPage() {
+  return (
+    <main className="space-y-6">
+      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OneGodian: Remember</h1>
+        <p className="mt-2 text-slate-300">{rememberCampaign.message}</p>
+        <p className="mt-2 text-sm text-cyan-300">Campaign start: {rememberCampaign.officialStartDate} · {rememberCampaign.onegodianDate}</p>
+      </header>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+        <p className="text-slate-300">{rememberCampaign.purpose}</p>
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-300">
+          {rememberCampaign.dashboardFunctions.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <Link href="/campaigns/remember" className="mt-4 inline-block text-cyan-300">Open campaign module</Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -1,17 +1,12 @@
 export default function TimePage() {
   return (
-    <main className="p-6 text-slate-100 space-y-4">
-      <h1 className="text-3xl font-semibold">Time</h1>
-      <p className="text-slate-300">OTS-V5 is the internal OneGodian time framework used for synchronized application references.</p>
-      <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-slate-300">Live clock placeholder.</div>
-      <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-slate-300">Conversion tool placeholder.</div>
-      <a
-        href="/time/dual-dating"
-        className="inline-block rounded-lg border border-cyan-400/50 bg-slate-900/70 px-4 py-2 text-cyan-200 transition hover:bg-cyan-500/10"
-      >
-        Dual Dating System™
-      </a>
-      <p className="text-sm text-amber-200">Legal note: Gregorian Time remains the controlling legal time standard for formal and external matters.</p>
+    <main className="space-y-6 p-6 text-slate-100">
+      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-2">
+        <p>Dual-date display model: Gregorian civil date + OneGodian internal date notation for synchronized cultural references.</p>
+        <p>Example format: Gregorian Date (UTC) · OneGodian Date (OTS-V5 internal).</p>
+      </section>
+      <p className="text-sm text-amber-200">Legal safety: Gregorian calendar/time remains controlling for legal, financial, compliance, and external institutional matters.</p>
     </main>
   );
 }

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -1,20 +1,6 @@
 {
-  "name": "OMOS™ — OneGodian Metaphysical Operating System™",
-  "version": "1.0.0",
-  "status": "active",
-  "canonical_domain": "omos.onegodian.com",
-  "purpose": "Public runtime for OMOS routes, page registry, and manifest delivery.",
-  "integrations": [
-    "OneGodian App",
-    "WordPress Bridge"
-  ],
-  "wordpress_hosts": [
-    "OneGodian.com",
-    "OneGodian.org",
-    "QuantumOHI.com"
-  ],
   "name": "OMOS Runtime",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "status": "production",
   "canonical_domain": "omos.onegodian.com",
   "purpose": "Public runtime for OMOS routes, page registry, and manifest delivery.",
@@ -22,14 +8,13 @@
   "wordpress_hosts": ["OneGodian.com", "OneGodian.org", "QuantumOHI.com"],
   "routes": [
     "/",
+    "/ecosystem",
     "/omos",
-    "/protocol",
-    "/algorithm",
-    "/ohi",
-    "/docs",
-    "/tools",
-    "/artifacts",
-    "/manifest",
+    "/remember",
+    "/membership",
+    "/time",
+    "/commerce",
+    "/institutional",
     "/api/health",
     "/api/manifest",
     "/api/pages"
@@ -42,18 +27,6 @@
     "https://onegodian.org",
     "https://quantumohi.com"
   ],
-  "appBridge": [
-    "https://app.onegodian.com"
-  ],
-  "commerceBridge": [
-    "https://onegodian.com"
-    "/api/pages",
-    "/api/plugin-consumers",
-    "/api/plugin-shortcodes",
-    "/api/plugin-sync",
-    "/api/tools",
-    "/api/artifacts",
-    "/api/dashboard",
-    "/api/system-health"
-  ]
+  "appBridge": ["https://app.onegodian.com"],
+  "commerceBridge": ["https://onegodian.com"]
 }

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -22,14 +22,21 @@ export const appNavigation = [
   { label: 'OMOS', href: '/omos' },
   { label: 'Architecture', href: '/architecture' },
   { label: 'About', href: '/about' },
-  { label: 'Sitemap', href: '/sitemap' }
+  { label: 'Sitemap', href: '/sitemap' },
+  { label: 'Membership', href: '/membership' },
+  { label: 'Commerce', href: '/commerce' },
+  { label: 'Remember', href: '/remember' },
+  { label: 'Institutional', href: '/institutional' }
 ];
 
 export const appDashboardCards = [
   { title: 'My OneGodian Profile', description: 'View your profile, identity details, membership status, and dashboard access.', href: '/profile', status: 'Active' },
   { title: 'Membership', description: 'Access OneGodian membership records, benefits, onboarding, and participation tools.', href: '/members', status: 'Available' },
   { title: 'Certificates', description: 'View and verify OneGodian certificates, completion records, and issued documents.', href: '/certificates', status: 'Available' },
-  { title: 'Remember Campaign', description: 'Access THE ONEGODIAN: Remember Campaign resources, media, captions, and participation tools.', href: '/campaigns/remember', status: 'Live' },
+  { title: 'Remember Campaign', description: 'Access THE ONEGODIAN: Remember Campaign resources, media, captions, and participation tools.', href: '/remember', status: 'Live' },
+  { title: 'Membership Hub', description: 'Open membership records, onboarding, benefits, and participation routes.', href: '/membership', status: 'Live' },
+  { title: 'Commerce Engine', description: 'Open OneGodian.com commerce and identity engine context.', href: '/commerce', status: 'Live' },
+  { title: 'Institutional Clarity', description: 'Review institutional boundary language for LLC and INO contexts.', href: '/institutional', status: 'Live' },
   { title: 'Media Center', description: 'Access OneGodian media, campaign visuals, music, videos, and brand assets.', href: '/media', status: 'Available' },
   { title: 'Products', description: 'Explore OneGodian products, digital downloads, apparel, books, and ecosystem offerings.', href: '/products', status: 'Available' },
   { title: 'Learning', description: 'Connect to U OneGodian courses, learning paths, student tools, and educational programs.', href: '/learning', status: 'Connected' },
@@ -39,12 +46,12 @@ export const appDashboardCards = [
 export const ecosystemPortals = [
   { name: 'OneGodian.org', role: 'Official public identity, writings, remembrance, articles, and institutional explanation.', url: 'https://onegodian.org' },
   { name: 'OneGodian.com', role: 'Store, products, memberships, commerce, apparel, books, and digital downloads.', url: 'https://onegodian.com' },
-  { name: 'U OneGodian', role: 'Education, LMS, learning paths, student tools, and certificates.', url: 'https://u.onegodian.org' },
+  { name: 'u.OneGodian.com', role: 'Education, LMS, learning paths, student tools, and certificates.', url: 'https://u.onegodian.com' },
   { name: 'Galaxy OneGodian', role: 'Galaxy interface, planet navigator, planet-store gateway, and immersive ecosystem layer.', url: 'https://galaxy.onegodian.com' },
-  { name: 'Capital OneGodian', role: 'Capital portal, disclosure center, contribution materials, and financial readiness.', url: 'https://capital.onegodian.com' },
   { name: 'OMOS OneGodian', role: 'OMOS protocol, specification, alignment system, and consciousness-centered operating model.', url: 'https://omos.onegodian.com' },
-  { name: 'OneGodian Console', role: 'Internal command console for apps, plugins, APIs, deployments, registries, and system operations.', url: 'https://console.onegodian.com' },
-  { name: 'OneGodian App', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' }
+  { name: 'app.OneGodian.com', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' },
+  { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context for OneGodian ecosystem design.', url: 'https://quantumohi.com' },
+  { name: 'QRV.Network', role: 'Verification and trust infrastructure connected to OneGodian records and identity workflows.', url: 'https://qrv.network' }
 ];
 
 export const appFooterBoundary =

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -6,21 +6,22 @@ export { appNavigation, consoleNavigation, ecosystemPortals };
 export const ecosystemLinks = [
   { label: 'OneGodian.org', href: 'https://onegodian.org' },
   { label: 'OneGodian.com', href: 'https://onegodian.com' },
-  { label: 'U OneGodian', href: 'https://u.onegodian.org' },
+  { label: 'u.OneGodian.com', href: 'https://u.onegodian.com' },
   { label: 'Galaxy OneGodian', href: 'https://galaxy.onegodian.com' },
-  { label: 'Capital OneGodian', href: 'https://capital.onegodian.com' },
+  { label: 'app.OneGodian.com', href: 'https://app.onegodian.com' },
   { label: 'OMOS OneGodian', href: 'https://omos.onegodian.com' },
-  { label: 'OneGodian Console', href: 'https://console.onegodian.com' }
+  { label: 'QuantumOHI.com', href: 'https://quantumohi.com' },
+  { label: 'QRV.Network', href: 'https://qrv.network' }
 ];
 
 export const dashboardCards = appDashboardCards;
 export { appDashboardCards, consoleDashboardCards };
 
 export const appStructureLayers = ['Public App', 'Member Dashboard', 'Membership', 'Certificates', 'Campaigns', 'Media', 'Products', 'Learning', 'Tools', 'Profile'];
-export const coreRoutes = ['/dashboard', '/ecosystem', '/members', '/certificates', '/campaigns', '/media', '/products', '/learning', '/tools', '/profile', '/settings', '/api/manifest'];
+export const coreRoutes = ['/', '/dashboard', '/ecosystem', '/omos', '/remember', '/membership', '/time', '/commerce', '/institutional', '/api/manifest'];
 
 export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Membership', href: '/members' }, { label: 'Certificates', href: '/certificates' }, { label: 'Profile', href: '/profile' }] },
+  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Membership', href: '/membership' }, { label: 'Remember', href: '/remember' }, { label: 'Institutional', href: '/institutional' }] },
   { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'U OneGodian', href: 'https://u.onegodian.org' }, { label: 'Capital OneGodian', href: 'https://capital.onegodian.com' }] },
   { title: 'More', links: [{ label: 'Media', href: '/media' }, { label: 'Products', href: '/products' }, { label: 'Learning', href: '/learning' }, { label: 'Tools', href: '/tools' }] }
 ];


### PR DESCRIPTION
### Motivation
- Provide public-facing production content pages and dashboard entries for OneGodian routes required by the App Structure Standard. 
- Expose OneGodian commerce/identity context (`OneGodian.com`) and OMOS mind‑map content to the app surface while keeping public-safe institutional language. 
- Ensure these routes are discoverable by navigation, dashboard cards, and the runtime manifest/API surfaces.

### Description
- Added new pages: `src/app/(app)/commerce/page.tsx`, `src/app/(app)/membership/page.tsx`, and `src/app/(app)/remember/page.tsx` containing production-oriented copy and dashboard entry links. 
- Updated existing pages `src/app/(app)/ecosystem/page.tsx`, `src/app/(app)/omos/page.tsx`, `src/app/(app)/time/page.tsx`, and `src/app/(app)/institutional/page.tsx` to include OMOS content, OneGodian Time™/OTS‑V5 dual‑date language, ecosystem portal listings, and institutional clarity with public‑safe phrasing. 
- Updated navigation, dashboard cards, ecosystem links, and footer/core route lists in `src/lib/app-content.ts` and `src/lib/onegodian-content.ts` so the new routes appear in the main navigation and member dashboard. 
- Updated `src/data/manifest.json` to include the new routes (`/`, `/ecosystem`, `/omos`, `/remember`, `/membership`, `/time`, `/commerce`, `/institutional`) so API/manifest surfaces reflect the current app status.

### Testing
- Ran `npm run lint` and it failed due to a pre-existing JSX/parse error in `src/app/page.tsx` that is unrelated to these changes. 
- Ran `npm run typecheck` and `npm run build` and both failed for the same pre-existing `src/app/page.tsx` syntax issues. 
- Attempted `npm run smoke:pages` and the smoke test could not complete in this environment due to a connection refusal to the local server (`ECONNREFUSED 127.0.0.1:4020`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1600cae65c832db859359bac04046b)