### PR TITLE
Add Algonquian Real Estate repository scaffold and MVP plugin suite

### DIFF
--- a/.github/workflows/build-plugin-zips.yml
+++ b/.github/workflows/build-plugin-zips.yml
@@ -1,0 +1,27 @@
+name: Build Plugin ZIPs
+
+on:
+  push:
+    paths:
+      - 'algonquian-real-estate/plugins/**'
+      - 'algonquian-real-estate/scripts/build-plugin-zips.sh'
+      - '.github/workflows/build-plugin-zips.yml'
+  pull_request:
+    paths:
+      - 'algonquian-real-estate/plugins/**'
+      - 'algonquian-real-estate/scripts/build-plugin-zips.sh'
+      - '.github/workflows/build-plugin-zips.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
+      - name: Build plugin archives
+        run: bash algonquian-real-estate/scripts/build-plugin-zips.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: algonquian-real-estate-plugin-zips
+          path: algonquian-real-estate/dist/*.zip

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,27 @@
+name: PHPCS
+
+on:
+  push:
+    paths:
+      - 'algonquian-real-estate/**'
+      - '.github/workflows/phpcs.yml'
+  pull_request:
+    paths:
+      - 'algonquian-real-estate/**'
+      - '.github/workflows/phpcs.yml'
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+      - name: Install coding standards
+        run: |
+          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
+      - name: Run PHPCS
+        run: ~/.composer/vendor/bin/phpcs --standard=WordPress --extensions=php algonquian-real-estate/plugins

--- a/.github/workflows/wordpress-lint.yml
+++ b/.github/workflows/wordpress-lint.yml
@@ -1,0 +1,22 @@
+name: WordPress Lint
+
+on:
+  push:
+    paths:
+      - 'algonquian-real-estate/**'
+      - '.github/workflows/wordpress-lint.yml'
+  pull_request:
+    paths:
+      - 'algonquian-real-estate/**'
+      - '.github/workflows/wordpress-lint.yml'
+
+jobs:
+  php-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Lint plugin PHP files
+        run: find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l

--- a/algonquian-real-estate/CHANGELOG.md
+++ b/algonquian-real-estate/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-05-29
+
+- Created the Algonquian Real Estate repository foundation.
+- Added MVP WordPress plugin scaffolds for deal intake, MAO underwriting, creative offers, pipeline CRM, buyer portal, digital products, and command center reporting.
+- Added roadmap documentation and GitHub Actions workflow definitions for linting, PHPCS, and plugin ZIP builds.

--- a/algonquian-real-estate/CONTRIBUTING.md
+++ b/algonquian-real-estate/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Workflow
+
+1. Pick a task from `roadmap/backlog.md`.
+2. Keep each pull request focused on one plugin or one workflow area.
+3. Run PHP syntax validation before submitting changes.
+4. Update documentation when adding shortcodes, database tables, or settings.
+
+## WordPress standards
+
+- Prefix PHP functions, classes, options, nonces, actions, and filters with `algq_` or `ALGQ_`.
+- Escape output with WordPress escaping helpers.
+- Sanitize request input before use.
+- Verify nonces on form submissions and AJAX endpoints.
+- Store module-specific code inside its plugin directory.

--- a/algonquian-real-estate/LICENSE
+++ b/algonquian-real-estate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Algonquian Real Estate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/algonquian-real-estate/README.md
+++ b/algonquian-real-estate/README.md
@@ -1,0 +1,46 @@
+# Algonquian Real Estate
+
+Algonquian Real Estate is a modular WordPress plugin suite for deal intake, underwriting, creative offers, pipeline CRM, buyer distribution, digital product revenue, and executive reporting.
+
+## MVP modules
+
+Version 1.0 targets the modules that move a lead from capture to monetization:
+
+- Deal Intake (`algq-deal-intake`) — seller/property capture, deal IDs, notifications, and admin review.
+- MAO Engine (`algq-mao-engine`) — ARV, rehab, assignment fee, max allowable offer, spread, and risk score.
+- Creative Offer Generator (`algq-offer-generator`) — seller-finance offer UI, amortization, legacy visualization, and document placeholders.
+- Pipeline CRM (`algq-pipeline-crm`) — Kanban stages and activity logging.
+- Buyer Portal (`algq-buyer-portal`) — buyer registration profile, NDA acceptance, downloads, and interest tracking foundations.
+- Digital Product Store (`algq-digital-products`) — WooCommerce-aware product library shortcode and gated download foundations.
+- Admin Command Center (`algq-command-center`) — dashboard widgets for operating metrics.
+
+## Repository layout
+
+```text
+algonquian-real-estate/
+├── assets/      # Shared images, screenshots, and static assets
+├── docs/        # Architecture and implementation documentation
+├── plugins/     # WordPress plugins, one module per directory
+├── roadmap/     # Epic/task backlog and release plans
+├── scripts/     # Build and maintenance scripts
+├── templates/   # Shared template snippets
+└── tests/       # Test scaffolding and fixtures
+```
+
+## Local validation
+
+From the repository root:
+
+```bash
+find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l
+bash algonquian-real-estate/scripts/build-plugin-zips.sh
+```
+
+## Shortcodes
+
+- `[algq_deal_intake]`
+- `[algq_mao_engine]`
+- `[algq_offer_generator]`
+- `[algq_pipeline_crm]`
+- `[algq_buyer_portal]`
+- `[algq_product_library]`

--- a/algonquian-real-estate/assets/README.md
+++ b/algonquian-real-estate/assets/README.md
@@ -1,0 +1,3 @@
+# Shared Assets
+
+Place shared images, screenshots, and static brand assets here.

--- a/algonquian-real-estate/docs/architecture.md
+++ b/algonquian-real-estate/docs/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+The platform is organized as independent WordPress plugins so teams can ship, activate, and license modules separately while preserving shared naming conventions.
+
+## Module boundaries
+
+- **Deal Intake** owns seller/property lead capture and the canonical `wp_algq_deals` table.
+- **MAO Engine** owns underwriting calculations and exposes an underwriter service class.
+- **Offer Generator** owns seller-finance scenario UX, amortization schedules, legacy visualizations, and document generation placeholders.
+- **Pipeline CRM** owns deal stage state and activity events.
+- **Buyer Portal** owns buyer-facing profiles, NDA state, and deal interest signals.
+- **Digital Products** owns WooCommerce-aware product-library presentation and access-control hooks.
+- **Command Center** reads from module tables and WordPress/WooCommerce data for executive widgets.
+
+## Integration conventions
+
+- Tables use the `algq_` namespace after the WordPress table prefix.
+- Shortcodes use `algq_*` names.
+- Each plugin should be independently installable and avoid hard failures when optional companion plugins are inactive.

--- a/algonquian-real-estate/plugins/algq-automation-engine/README.md
+++ b/algonquian-real-estate/plugins/algq-automation-engine/README.md
@@ -1,0 +1,3 @@
+# Algonquian Automation Engine
+
+Planned v1.1+ module for workflow building and email automations such as seller follow-up, buyer notification, offer sent, and deal closed sequences.

--- a/algonquian-real-estate/plugins/algq-buyer-portal/algq-buyer-portal.php
+++ b/algonquian-real-estate/plugins/algq-buyer-portal/algq-buyer-portal.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: Algonquian Buyer Portal
+ * Description: Buyer registration, profile fields, NDA acceptance, downloads, and interest tracking foundations.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_shortcode('algq_buyer_portal', function (): string {
+    if (!is_user_logged_in()) {
+        return '<div class="algq-buyer-login"><p>Please log in or register to access buyer deals.</p>' . wp_login_form(['echo' => false]) . '</div>';
+    }
+
+    $user_id = get_current_user_id();
+    if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_buyer_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['algq_buyer_nonce'])), 'algq_buyer_profile')) {
+        update_user_meta($user_id, 'algq_markets', sanitize_text_field(wp_unslash($_POST['markets'] ?? '')));
+        update_user_meta($user_id, 'algq_cash_available', (float) ($_POST['cash_available'] ?? 0));
+        update_user_meta($user_id, 'algq_buy_box', sanitize_textarea_field(wp_unslash($_POST['buy_box'] ?? '')));
+        update_user_meta($user_id, 'algq_property_types', sanitize_text_field(wp_unslash($_POST['property_types'] ?? '')));
+        update_user_meta($user_id, 'algq_nda_accepted', !empty($_POST['nda_accepted']) ? 'yes' : 'no');
+    }
+
+    ob_start();
+    ?>
+    <form class="algq-buyer-profile" method="post">
+        <?php wp_nonce_field('algq_buyer_profile', 'algq_buyer_nonce'); ?>
+        <p><label>Markets <input name="markets" value="<?php echo esc_attr(get_user_meta($user_id, 'algq_markets', true)); ?>" /></label></p>
+        <p><label>Cash Available <input name="cash_available" type="number" min="0" step="0.01" value="<?php echo esc_attr(get_user_meta($user_id, 'algq_cash_available', true)); ?>" /></label></p>
+        <p><label>Buy Box <textarea name="buy_box"><?php echo esc_textarea(get_user_meta($user_id, 'algq_buy_box', true)); ?></textarea></label></p>
+        <p><label>Property Types <input name="property_types" value="<?php echo esc_attr(get_user_meta($user_id, 'algq_property_types', true)); ?>" /></label></p>
+        <p><label><input name="nda_accepted" type="checkbox" value="1" <?php checked(get_user_meta($user_id, 'algq_nda_accepted', true), 'yes'); ?> /> NDA accepted</label></p>
+        <p><button type="submit">Save Profile</button></p>
+    </form>
+    <div class="algq-interest-tracking">Interest stages: Interested, Requested Call, Offer Submitted, Assigned.</div>
+    <?php
+    return (string) ob_get_clean();
+});

--- a/algonquian-real-estate/plugins/algq-command-center/algq-command-center.php
+++ b/algonquian-real-estate/plugins/algq-command-center/algq-command-center.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Algonquian Command Center
+ * Description: Executive admin dashboard widgets for active deals, pipeline value, offers, buyer activity, and funding status.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action('wp_dashboard_setup', function (): void {
+    wp_add_dashboard_widget('algq_command_center', 'Algonquian Command Center', function (): void {
+        $widgets = ['Active Deals', 'Pipeline Value', 'Offers Sent', 'Buyer Activity', 'Funding Status', 'Monthly Leads', 'Deals Closed', 'Assignment Revenue', 'Product Sales'];
+        echo '<ul class="algq-command-center">';
+        foreach ($widgets as $widget) {
+            echo '<li><strong>' . esc_html($widget) . ':</strong> <span>Connect data source</span></li>';
+        }
+        echo '</ul>';
+    });
+});

--- a/algonquian-real-estate/plugins/algq-deal-intake/algq-deal-intake.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/algq-deal-intake.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Plugin Name: Algonquian Deal Intake
+ * Description: Seller lead intake, property capture, deal ID generation, and admin review for Algonquian Real Estate.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Deal_Intake_Plugin
+{
+    public const VERSION = '0.1.0';
+    public const TABLE = 'algq_deals';
+
+    public function __construct()
+    {
+        add_shortcode('algq_deal_intake', [$this, 'render_shortcode']);
+        add_action('admin_menu', [$this, 'register_admin_page']);
+    }
+
+    public static function activate(): void
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        $charset = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$table} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            deal_id varchar(32) NOT NULL,
+            address text NOT NULL,
+            seller_name varchar(191) NOT NULL,
+            seller_phone varchar(64) NOT NULL,
+            asking_price decimal(12,2) DEFAULT 0,
+            condition_notes longtext NULL,
+            created_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY deal_id (deal_id)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+
+    public function render_shortcode(): string
+    {
+        $message = '';
+        if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_deal_intake_nonce'])) {
+            $message = $this->handle_submission();
+        }
+
+        ob_start();
+        ?>
+        <form class="algq-deal-intake" method="post">
+            <?php wp_nonce_field('algq_deal_intake_submit', 'algq_deal_intake_nonce'); ?>
+            <input type="text" name="algq_website" value="" style="display:none" tabindex="-1" autocomplete="off" />
+            <?php echo wp_kses_post($message); ?>
+            <p><label>Seller Name <input required name="seller_name" type="text" /></label></p>
+            <p><label>Seller Phone <input required name="seller_phone" type="tel" /></label></p>
+            <p><label>Property Address <textarea required name="address"></textarea></label></p>
+            <p><label>Asking Price <input name="asking_price" type="number" min="0" step="0.01" /></label></p>
+            <p><label>Condition Notes <textarea name="condition_notes"></textarea></label></p>
+            <p><button type="submit">Submit Deal</button></p>
+        </form>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    private function handle_submission(): string
+    {
+        if (!wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['algq_deal_intake_nonce'] ?? '')), 'algq_deal_intake_submit')) {
+            return '<div class="algq-error">Security check failed.</div>';
+        }
+
+        if (!empty($_POST['algq_website'])) {
+            return '<div class="algq-error">Submission blocked.</div>';
+        }
+
+        $seller_name = sanitize_text_field(wp_unslash($_POST['seller_name'] ?? ''));
+        $seller_phone = sanitize_text_field(wp_unslash($_POST['seller_phone'] ?? ''));
+        $address = sanitize_textarea_field(wp_unslash($_POST['address'] ?? ''));
+        $asking_price = (float) ($_POST['asking_price'] ?? 0);
+        $condition_notes = sanitize_textarea_field(wp_unslash($_POST['condition_notes'] ?? ''));
+
+        if ('' === $seller_name || '' === $seller_phone || '' === $address) {
+            return '<div class="algq-error">Name, phone, and address are required.</div>';
+        }
+
+        global $wpdb;
+        $deal_id = $this->generate_deal_id();
+        $wpdb->insert(
+            $wpdb->prefix . self::TABLE,
+            [
+                'deal_id' => $deal_id,
+                'address' => $address,
+                'seller_name' => $seller_name,
+                'seller_phone' => $seller_phone,
+                'asking_price' => $asking_price,
+                'condition_notes' => $condition_notes,
+                'created_at' => current_time('mysql'),
+            ],
+            ['%s', '%s', '%s', '%s', '%f', '%s', '%s']
+        );
+
+        wp_mail(get_option('admin_email'), 'New seller lead: ' . $deal_id, "A new deal was submitted for {$address}.");
+
+        return '<div class="algq-success">Deal submitted. Reference ID: ' . esc_html($deal_id) . '</div>';
+    }
+
+    private function generate_deal_id(): string
+    {
+        return 'ALGQ-' . gmdate('Ymd') . '-' . strtoupper(wp_generate_password(6, false, false));
+    }
+
+    public function register_admin_page(): void
+    {
+        add_menu_page('Algonquian Deals', 'Algonquian Deals', 'manage_options', 'algq-deals', [$this, 'render_admin_page'], 'dashicons-building', 26);
+    }
+
+    public function render_admin_page(): void
+    {
+        global $wpdb;
+        $rows = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}" . self::TABLE . ' ORDER BY created_at DESC LIMIT 50');
+        echo '<div class="wrap"><h1>Algonquian Deals</h1><table class="widefat"><thead><tr><th>Deal ID</th><th>Seller</th><th>Phone</th><th>Address</th><th>Asking</th><th>Created</th></tr></thead><tbody>';
+        foreach ($rows as $row) {
+            echo '<tr><td>' . esc_html($row->deal_id) . '</td><td>' . esc_html($row->seller_name) . '</td><td>' . esc_html($row->seller_phone) . '</td><td>' . esc_html($row->address) . '</td><td>' . esc_html(number_format((float) $row->asking_price, 2)) . '</td><td>' . esc_html($row->created_at) . '</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+}
+
+register_activation_hook(__FILE__, ['ALGQ_Deal_Intake_Plugin', 'activate']);
+new ALGQ_Deal_Intake_Plugin();

--- a/algonquian-real-estate/plugins/algq-digital-products/algq-digital-products.php
+++ b/algonquian-real-estate/plugins/algq-digital-products/algq-digital-products.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Algonquian Digital Products
+ * Description: Product library dashboard for contract packs, spreadsheets, calculators, checklists, and training.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_shortcode('algq_product_library', function (): string {
+    $products = ['Contract Packs', 'Spreadsheets', 'Calculators', 'Checklists', 'Training'];
+    ob_start();
+    echo '<div class="algq-product-library"><h2>Product Library</h2><ul>';
+    foreach ($products as $product) {
+        echo '<li><strong>' . esc_html($product) . '</strong><br><span>WooCommerce secure download, license tracking, and access-control hooks ready for integration.</span></li>';
+    }
+    echo '</ul></div>';
+    return (string) ob_get_clean();
+});

--- a/algonquian-real-estate/plugins/algq-document-library/README.md
+++ b/algonquian-real-estate/plugins/algq-document-library/README.md
@@ -1,0 +1,3 @@
+# Algonquian Document Library
+
+Planned v1.1+ module for document categories, versioning, search, tagging, and PDF storage management.

--- a/algonquian-real-estate/plugins/algq-funding-tracker/README.md
+++ b/algonquian-real-estate/plugins/algq-funding-tracker/README.md
@@ -1,0 +1,3 @@
+# Algonquian Funding Tracker
+
+Planned v1.1+ module for lenders, loan requests, commitments, and funding status tracking.

--- a/algonquian-real-estate/plugins/algq-mao-engine/algq-mao-engine.php
+++ b/algonquian-real-estate/plugins/algq-mao-engine/algq-mao-engine.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: Algonquian MAO Engine
+ * Description: Maximum allowable offer calculator and underwriting service.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-underwriter.php';
+
+add_shortcode('algq_mao_engine', function (): string {
+    $result = null;
+    if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_mao_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['algq_mao_nonce'])), 'algq_mao_calculate')) {
+        $underwriter = new ALGQ_Underwriter();
+        $result = $underwriter->analyze((float) ($_POST['arv'] ?? 0), (float) ($_POST['rehab'] ?? 0), (float) ($_POST['assignment_fee'] ?? 0));
+    }
+
+    ob_start();
+    ?>
+    <form class="algq-mao-engine" method="post">
+        <?php wp_nonce_field('algq_mao_calculate', 'algq_mao_nonce'); ?>
+        <p><label>ARV <input required name="arv" type="number" min="0" step="0.01" /></label></p>
+        <p><label>Rehab Estimate <input required name="rehab" type="number" min="0" step="0.01" /></label></p>
+        <p><label>Assignment Fee <input required name="assignment_fee" type="number" min="0" step="0.01" /></label></p>
+        <p><button type="submit">Calculate MAO</button></p>
+    </form>
+    <?php if ($result) : ?>
+        <div class="algq-mao-result">
+            <p><strong>MAO:</strong> <?php echo esc_html(number_format($result['mao'], 2)); ?></p>
+            <p><strong>Profit Spread:</strong> <?php echo esc_html(number_format($result['profit_spread'], 2)); ?></p>
+            <p><strong>Risk Score:</strong> <?php echo esc_html($result['risk_score']); ?></p>
+        </div>
+    <?php endif; ?>
+    <?php
+    return (string) ob_get_clean();
+});

--- a/algonquian-real-estate/plugins/algq-mao-engine/includes/class-underwriter.php
+++ b/algonquian-real-estate/plugins/algq-mao-engine/includes/class-underwriter.php
@@ -1,0 +1,33 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Underwriter
+{
+    public function analyze(float $arv, float $rehab, float $assignment_fee): array
+    {
+        $mao = max(0, ($arv * 0.70) - $rehab - $assignment_fee);
+        $profit_spread = max(0, $arv - $rehab - $assignment_fee - $mao);
+        $risk_score = $this->risk_score($arv, $rehab, $profit_spread);
+
+        return [
+            'mao' => round($mao, 2),
+            'profit_spread' => round($profit_spread, 2),
+            'risk_score' => $risk_score,
+        ];
+    }
+
+    private function risk_score(float $arv, float $rehab, float $profit_spread): string
+    {
+        if ($arv <= 0 || $rehab / max($arv, 1) > 0.35) {
+            return 'High';
+        }
+
+        if ($profit_spread / max($arv, 1) < 0.15) {
+            return 'Medium';
+        }
+
+        return 'Low';
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/algq-offer-generator.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/algq-offer-generator.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Algonquian Offer Generator
+ * Description: Creative offer, amortization, legacy visualization, and printable offer summary tools.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-amortization-engine.php';
+
+add_action('wp_enqueue_scripts', function (): void {
+    wp_register_style('algq-offer-generator', plugins_url('assets/css/offer-generator.css', __FILE__), [], '0.1.0');
+    wp_register_script('algq-offer-generator', plugins_url('assets/js/offer-generator.js', __FILE__), [], '0.1.0', true);
+});
+
+add_shortcode('algq_offer_generator', function (): string {
+    wp_enqueue_style('algq-offer-generator');
+    wp_enqueue_script('algq-offer-generator');
+    $offer = null;
+    if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_offer_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['algq_offer_nonce'])), 'algq_offer_generate')) {
+        $engine = new ALGQ_Amortization_Engine();
+        $offer = $engine->schedule((float) ($_POST['price'] ?? 0), (float) ($_POST['rate'] ?? 0), (int) ($_POST['term'] ?? 1));
+    }
+    ob_start();
+    include __DIR__ . '/templates/app.php';
+    return (string) ob_get_clean();
+});

--- a/algonquian-real-estate/plugins/algq-offer-generator/assets/css/offer-generator.css
+++ b/algonquian-real-estate/plugins/algq-offer-generator/assets/css/offer-generator.css
@@ -1,0 +1,3 @@
+.algq-offer-generator { border: 1px solid #d7dee8; border-radius: 12px; padding: 1rem; max-width: 760px; }
+.algq-offer-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.algq-offer-card { background: #f8fafc; border-radius: 10px; padding: 1rem; }

--- a/algonquian-real-estate/plugins/algq-offer-generator/assets/js/offer-generator.js
+++ b/algonquian-real-estate/plugins/algq-offer-generator/assets/js/offer-generator.js
@@ -1,0 +1,7 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-algq-print-offer]').forEach(function (button) {
+      button.addEventListener('click', function () { window.print(); });
+    });
+  });
+})();

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-amortization-engine.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-amortization-engine.php
@@ -1,0 +1,34 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Amortization_Engine
+{
+    public function schedule(float $price, float $annual_rate, int $term_months): array
+    {
+        $monthly_rate = ($annual_rate / 100) / 12;
+        $payment = $monthly_rate > 0 ? $price * ($monthly_rate * ((1 + $monthly_rate) ** $term_months)) / (((1 + $monthly_rate) ** $term_months) - 1) : $price / max($term_months, 1);
+        $balance = $price;
+        $schedule = [];
+
+        for ($month = 1; $month <= $term_months; $month++) {
+            $interest = $balance * $monthly_rate;
+            $principal = min($payment - $interest, $balance);
+            $balance = max(0, $balance - $principal);
+            $schedule[] = [
+                'month' => $month,
+                'payment' => round($payment, 2),
+                'principal' => round($principal, 2),
+                'interest' => round($interest, 2),
+                'balance' => round($balance, 2),
+            ];
+        }
+
+        return [
+            'payment' => round($payment, 2),
+            'seller_total_income' => round($payment * $term_months, 2),
+            'schedule' => $schedule,
+        ];
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/templates/app.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/templates/app.php
@@ -1,0 +1,19 @@
+<div class="algq-offer-generator">
+    <h2>Creative Offer Generator</h2>
+    <form method="post">
+        <?php wp_nonce_field('algq_offer_generate', 'algq_offer_nonce'); ?>
+        <div class="algq-offer-grid">
+            <label>Price <input required name="price" type="number" min="0" step="0.01" /></label>
+            <label>Rate <input required name="rate" type="number" min="0" step="0.01" /></label>
+            <label>Term (months) <input required name="term" type="number" min="1" step="1" /></label>
+        </div>
+        <p><button type="submit">Generate Offer</button> <button type="button" data-algq-print-offer>Print / Save PDF</button></p>
+    </form>
+    <?php if (!empty($offer)) : ?>
+        <div class="algq-offer-grid">
+            <div class="algq-offer-card"><strong>Monthly Income</strong><br><?php echo esc_html(number_format($offer['payment'], 2)); ?></div>
+            <div class="algq-offer-card"><strong>Lifetime Income</strong><br><?php echo esc_html(number_format($offer['seller_total_income'], 2)); ?></div>
+            <div class="algq-offer-card"><strong>Timeline</strong><br><?php echo esc_html((string) count($offer['schedule'])); ?> months</div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/algonquian-real-estate/plugins/algq-pdf-signature/README.md
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/README.md
@@ -1,0 +1,3 @@
+# Algonquian PDF & Signature
+
+Planned v1.1+ module for PDF generation, signature requests, audit logs, purchase agreements, LOIs, assignment contracts, and seller-financing agreements.

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/algq-pipeline-crm.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/algq-pipeline-crm.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Plugin Name: Algonquian Pipeline CRM
+ * Description: Deal Kanban board, stage movement foundation, and activity logging.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Pipeline_CRM
+{
+    private const ACTIVITY_TABLE = 'algq_activity_log';
+    private const STAGES = ['Lead Captured', 'Underwriting', 'Offer Sent', 'Under Contract', 'Buyer Assigned', 'Closed'];
+
+    public function __construct()
+    {
+        add_shortcode('algq_pipeline_crm', [$this, 'render_board']);
+        add_action('wp_ajax_algq_move_deal_stage', [$this, 'move_stage']);
+    }
+
+    public static function activate(): void
+    {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta("CREATE TABLE {$wpdb->prefix}" . self::ACTIVITY_TABLE . " (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            deal_id varchar(32) NOT NULL,
+            activity_type varchar(64) NOT NULL,
+            activity_note text NOT NULL,
+            created_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            KEY deal_id (deal_id)
+        ) {$wpdb->get_charset_collate()};");
+    }
+
+    public function render_board(): string
+    {
+        ob_start();
+        echo '<div class="algq-kanban">';
+        foreach (self::STAGES as $stage) {
+            echo '<section class="algq-kanban-stage" data-stage="' . esc_attr($stage) . '"><h3>' . esc_html($stage) . '</h3><p>Drag-and-drop deal cards will appear here.</p></section>';
+        }
+        echo '</div>';
+        return (string) ob_get_clean();
+    }
+
+    public function move_stage(): void
+    {
+        check_ajax_referer('algq_pipeline_move', 'nonce');
+        $deal_id = sanitize_text_field(wp_unslash($_POST['deal_id'] ?? ''));
+        $stage = sanitize_text_field(wp_unslash($_POST['stage'] ?? ''));
+        if (!in_array($stage, self::STAGES, true)) {
+            wp_send_json_error(['message' => 'Invalid stage'], 400);
+        }
+        $this->log_activity($deal_id, 'stage_moved', 'Moved to ' . $stage);
+        wp_send_json_success(['stage' => $stage]);
+    }
+
+    private function log_activity(string $deal_id, string $type, string $note): void
+    {
+        global $wpdb;
+        $wpdb->insert($wpdb->prefix . self::ACTIVITY_TABLE, ['deal_id' => $deal_id, 'activity_type' => $type, 'activity_note' => $note, 'created_at' => current_time('mysql')], ['%s', '%s', '%s', '%s']);
+    }
+}
+
+register_activation_hook(__FILE__, ['ALGQ_Pipeline_CRM', 'activate']);
+new ALGQ_Pipeline_CRM();

--- a/algonquian-real-estate/plugins/algq-revenue-systems/README.md
+++ b/algonquian-real-estate/plugins/algq-revenue-systems/README.md
@@ -1,0 +1,3 @@
+# Algonquian Revenue Systems
+
+Planned v2.0 module for subscription tiers, recurring billing, Stripe integration, WooCommerce Subscriptions, and SaaS license levels.

--- a/algonquian-real-estate/roadmap/backlog.md
+++ b/algonquian-real-estate/roadmap/backlog.md
@@ -1,0 +1,72 @@
+# Algonquian Real Estate Backlog
+
+## Epic 1 — Repository Foundation
+
+- **ARE-001**: Create repository structure: `docs/`, `plugins/`, `templates/`, `roadmap/`, `assets/`, `tests/`, and `scripts/`.
+- **ARE-002**: Create `README.md`, `LICENSE`, `CHANGELOG.md`, and `CONTRIBUTING.md`.
+- **ARE-003**: Create GitHub Actions workflows: `wordpress-lint.yml`, `phpcs.yml`, and `build-plugin-zips.yml`.
+
+## Epic 2 — Deal Intake Plugin
+
+- **ARE-010**: Build seller lead form, property form, deal ID generation, admin dashboard, and `wp_algq_deals`.
+- **ARE-011**: Build `[algq_deal_intake]` with validation, spam protection, and email notifications.
+
+## Epic 3 — MAO Engine
+
+- **ARE-020**: Build `[algq_mao_engine]` with ARV, rehab estimate, assignment fee, and MAO calculator.
+- **ARE-021**: Create `class-underwriter.php` returning MAO, profit spread, and risk score.
+
+## Epic 4 — Creative Offer Generator
+
+- **ARE-030**: Create `algq-offer-generator` UI assets and template.
+- **ARE-031**: Build amortization engine for payment, seller total income, and schedules.
+- **ARE-032**: Build Legacy Visualizer outputs for monthly income, lifetime income, and timeline.
+- **ARE-033**: Generate offer summary, LOI, seller financing sheet, and payment schedule PDFs.
+
+## Epic 5 — Pipeline CRM
+
+- **ARE-040**: Build Kanban board with Lead Captured, Underwriting, Offer Sent, Under Contract, Buyer Assigned, and Closed stages.
+- **ARE-041**: Enable drag-and-drop stage movement.
+- **ARE-042**: Create activity logging in `wp_algq_activity_log`.
+
+## Epic 6 — Buyer Portal
+
+- **ARE-050**: Build registration, login, NDA acceptance, and deal downloads.
+- **ARE-051**: Build buyer profiles for markets, cash available, buy box, and property types.
+- **ARE-052**: Build interest tracking: Interested, Requested Call, Offer Submitted, Assigned.
+
+## Epic 7 — Digital Product Store
+
+- **ARE-060**: Create digital products for contract packs, spreadsheets, calculators, checklists, and training.
+- **ARE-061**: Integrate WooCommerce secure downloads, license tracking, and access control.
+- **ARE-062**: Build `[algq_product_library]` dashboard.
+
+## Epic 8 — Document Library
+
+- **ARE-070**: Build document categories, versioning, search, and tagging.
+- **ARE-071**: Build PDF storage manager.
+
+## Epic 9 — PDF & Signature
+
+- **ARE-080**: Build PDF generation, signature requests, and audit logs.
+- **ARE-081**: Generate Purchase Agreement, LOI, Assignment Contract, and Seller Financing Agreement.
+
+## Epic 10 — Automation Engine
+
+- **ARE-090**: Build workflow builder for lead-to-offer automations.
+- **ARE-091**: Build email automation templates.
+
+## Epic 11 — Funding Tracker
+
+- **ARE-100**: Track lenders, loan requests, commitments, and funding status.
+
+## Epic 12 — Admin Command Center
+
+- **ARE-110**: Create widgets for active deals, pipeline value, offers sent, buyer activity, and funding status.
+- **ARE-111**: Build executive dashboard charts.
+
+## Epic 13 — Revenue Systems
+
+- **ARE-120**: Build subscription tiers: Investor, Buyer, Pro, Enterprise.
+- **ARE-121**: Build recurring billing with WooCommerce Subscriptions and Stripe.
+- **ARE-122**: Create SaaS licensing for Single Site, Agency, and Enterprise.

--- a/algonquian-real-estate/scripts/build-plugin-zips.sh
+++ b/algonquian-real-estate/scripts/build-plugin-zips.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+mkdir -p "$DIST_DIR"
+
+for plugin_dir in "$ROOT_DIR"/plugins/*; do
+  [ -d "$plugin_dir" ] || continue
+  plugin_name="$(basename "$plugin_dir")"
+  (cd "$ROOT_DIR/plugins" && zip -qr "$DIST_DIR/$plugin_name.zip" "$plugin_name" -x '*/node_modules/*' '*/vendor/*' '*/.git/*')
+  echo "Built $DIST_DIR/$plugin_name.zip"
+done

--- a/algonquian-real-estate/templates/README.md
+++ b/algonquian-real-estate/templates/README.md
@@ -1,0 +1,3 @@
+# Shared Templates
+
+Place shared WordPress template partials here when two or more plugins need the same markup pattern.

--- a/algonquian-real-estate/tests/README.md
+++ b/algonquian-real-estate/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Initial validation uses PHP syntax checks for every plugin file. Add WordPress integration tests as plugin behavior matures.


### PR DESCRIPTION
### Motivation
- Establish a structured repository and backlog for a modular WordPress plugin collection so work can be delivered in focused milestones (MVP modules first). 
- Provide minimal, testable plugin scaffolds and CI workflows to speed local validation and continuous integration for future feature development.

### Description
- Add `algonquian-real-estate/` repository foundation including `README.md`, `LICENSE`, `CHANGELOG.md`, `CONTRIBUTING.md`, `docs/architecture.md`, and `roadmap/backlog.md` describing epics ARE-001 through ARE-122. 
- Add plugin scaffolds for MVP modules: `algq-deal-intake` (shortcode, form, `wp_algq_deals` schema via activation, admin page, nonce/spam checks, deal ID generation, email notification), `algq-mao-engine` (underwriter class and shortcode), and `algq-offer-generator` (amortization engine, assets, template, shortcode and print helper). 
- Add additional MVP scaffolds for `algq-pipeline-crm` (Kanban stage scaffold, activity table creation, AJAX stage move handler), `algq-buyer-portal`, `algq-digital-products`, and `algq-command-center`, plus placeholder plugin directories for post-MVP modules. 
- Add automation and CI helpers: `algonquian-real-estate/scripts/build-plugin-zips.sh` and GitHub Actions workflows `wordpress-lint.yml`, `phpcs.yml`, and `build-plugin-zips.yml` for PHP linting, PHPCS, and artifact builds.

### Testing
- Ran PHP syntax checks across plugin files with `find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l`, which completed with no syntax errors. 
- Executed the ZIP build script `bash algonquian-real-estate/scripts/build-plugin-zips.sh` to produce plugin archives, which completed successfully and produced `.zip` artifacts. 
- No automated PHPCS job was run locally; CI workflow `phpcs.yml` was added to run standards checks in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a08f3b6e4832d8407e06102b42d89)