### PR TITLE
feat: add real OneGodian App content pages

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/scripts/smoke-pages.mjs
+++ b/scripts/smoke-pages.mjs
@@ -1,7 +1,13 @@
 import { spawn } from 'node:child_process';
-const server = spawn('node', ['server.js'], { env: { ...process.env, PORT: '4020' } });
-const routes=['/','/omos','/ohi','/models','/tools','/artifacts','/docs','/shop','/latest-news','/dashboard','/legal','/contact','/protocol','/algorithm','/digital-sanctuary'];
-await new Promise(r=>setTimeout(r,1500));
-for (const route of routes){ const res=await fetch(`http://127.0.0.1:4020${route}`); if(res.status!==200) throw new Error(`${route} -> ${res.status}`);}
-server.kill('SIGTERM');
-console.log('smoke pages passed');
+const server = spawn('node', ['server.js'], { env: { ...process.env, PORT: '4020' }, detached: true });
+const routes = ['/', '/ecosystem', '/overview', '/omos', '/algorithm', '/remember', '/time', '/commerce', '/identity', '/institutional', '/status'];
+await new Promise((resolve) => setTimeout(resolve, 1500));
+try {
+  for (const route of routes) {
+    const res = await fetch(`http://127.0.0.1:4020${route}`);
+    if (res.status !== 200) throw new Error(`${route} -> ${res.status}`);
+  }
+  console.log('smoke pages passed');
+} finally {
+  process.kill(-server.pid, 'SIGTERM');
+}

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -3,57 +3,35 @@ import { spawn } from 'node:child_process';
 
 const port = 4010;
 const base = `http://127.0.0.1:${port}`;
-const routes = [
-  '/', '/dashboard', '/sitemap', '/systems-model', '/ecosystem', '/apps', '/plugins', '/api-status', '/system-health',
-  '/omos', '/omos/manifest', '/omos/pages', '/omos/health', '/omos/sync', '/omos/plugins', '/omos/properties',
-  '/architecture', '/architecture/ohi', '/architecture/runtime', '/architecture/interfaces', '/architecture/infrastructure', '/architecture/omos-sync',
-  '/algorithm', '/algorithm/protocol', '/algorithm/experience', '/algorithm/community', '/algorithm/orientation',
-  '/registry', '/time', '/portfolio', '/records', '/tools',
-  '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health', '/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync', '/api/tools', '/api/artifacts', '/api/dashboard'
-];
+const routes = ['/', '/ecosystem', '/overview', '/omos', '/algorithm', '/remember', '/time', '/commerce', '/identity', '/institutional', '/status'];
 
-const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe' });
+const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe', detached: true });
 
 await new Promise((resolve, reject) => {
   const timer = setTimeout(() => reject(new Error('server start timeout')), 30000);
-  server.stdout.on('data', (d) => {
-    if (d.toString().includes('Ready')) {
+  const onData = (data) => {
+    const text = data.toString();
+    if (text.includes('Ready')) {
       clearTimeout(timer);
       resolve();
     }
-  });
-  server.stderr.on('data', (d) => {
-    if (d.toString().includes('Ready')) {
-      clearTimeout(timer);
-      resolve();
-    }
-  });
+  };
+  server.stdout.on('data', onData);
+  server.stderr.on('data', onData);
 });
 
 try {
   for (const route of routes) {
     const res = await fetch(`${base}${route}`);
-    if (res.status !== 200) throw new Error(`${route} returned ${res.status}`);
+    assert.equal(res.status, 200, `${route} should return 200`);
   }
 
-  const properties = await (await fetch(`${base}/api/properties`)).json();
-  assert.equal(Array.isArray(properties.properties), true);
-  assert.equal(properties.total, 7);
-
-  const plugins = await (await fetch(`${base}/api/plugins`)).json();
-  assert.equal(Array.isArray(plugins.plugins), true);
-  assert.equal(plugins.total, 7);
-
   const apiManifest = await (await fetch(`${base}/api/manifest`)).json();
-  assert.equal(Array.isArray(apiManifest.pluginSync?.endpoints), true);
-
-  const consumers = await (await fetch(`${base}/api/plugin-consumers`)).json();
-  assert.equal(consumers.consumers.length >= 3, true);
-
-  const shortcodes = await (await fetch(`${base}/api/plugin-shortcodes`)).json();
-  assert.equal(shortcodes.shortcodes.includes('[omos_manifest]'), true);
+  assert.deepEqual(apiManifest.routes, routes);
+  assert.equal(apiManifest.commerceEngine, 'https://onegodian.com');
+  assert.equal(apiManifest.interpretationPlatform, 'https://onegodian.org');
 
   console.log('Smoke tests passed');
 } finally {
-  server.kill('SIGTERM');
+  process.kill(-server.pid, 'SIGTERM');
 }

--- a/server.js
+++ b/server.js
@@ -19,24 +19,16 @@ const CANONICAL_HOST = process.env.OMOS_CANONICAL_HOST || 'https://omos.onegodia
 
 const PUBLIC_ROUTES = [
   '/',
+  '/ecosystem',
+  '/overview',
   '/omos',
-  '/ohi',
-  '/models',
-  '/tools',
-  '/artifacts',
-  '/docs',
-  '/shop',
-  '/latest-news',
-  '/dashboard',
-  '/legal',
-  '/contact',
-  '/protocol',
   '/algorithm',
-  '/digital-sanctuary',
-  '/sciences',
-  '/discoveries',
+  '/remember',
   '/time',
-  '/new-year'
+  '/commerce',
+  '/identity',
+  '/institutional',
+  '/status'
 ];
 
 const API_ROUTES = ['/health', '/api/health', '/manifest', '/api/manifest', '/process'];

--- a/src/app/(app)/algorithm/page.tsx
+++ b/src/app/(app)/algorithm/page.tsx
@@ -1,32 +1,26 @@
-import Link from 'next/link';
-
 const layers = [
-  { title: 'Protocol Layer', desc: 'Recognition and classification standards for AI-safe identity handling.' },
-  { title: 'Experience Layer', desc: 'User-facing intelligence and personalization for trusted interactions.' },
-  { title: 'Community Layer', desc: 'Community coherence, governance, and participation pathways.' },
-  { title: 'Orientation Layer', desc: 'Behavioral orientation standards for agents and autonomous systems.' }
+  { title: 'Protocol', detail: 'The rules, route definitions, manifests, vocabulary, safety boundaries, and structured references that make OneGodian systems interoperable.' },
+  { title: 'Experience', detail: 'The user-facing dashboard, content, tools, campaigns, identity flows, and time displays that make the system understandable and usable.' },
+  { title: 'Community', detail: 'The voluntary participation layer for shared memory, membership, cultural context, public education, and human support.' },
+  { title: 'Orientation', detail: 'The alignment layer that keeps language, AI behavior, public claims, legal boundaries, and institutional roles pointed in the correct direction.' }
 ];
 
 export default function AlgorithmPage() {
   return (
     <main className="space-y-6">
       <section className="rounded-2xl border border-cyan-500/30 bg-cyan-500/10 p-6">
-        <h1 className="text-3xl font-black">The OneGodian Algorithm™</h1>
-        <p className="mt-2 text-slate-300">Operational AI architecture for protocol, experience, community, and orientation control layers.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-200">Operating Algorithm</p>
+        <h1 className="mt-2 text-3xl font-black">The OneGodian Algorithm</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">The OneGodian Algorithm is summarized as a four-layer operating model: Protocol, Experience, Community, and Orientation. Together they describe how the ecosystem names things, presents them, invites participation, and keeps claims aligned.</p>
       </section>
-      <section className="grid gap-3 md:grid-cols-2">
+      <section className="grid gap-4 md:grid-cols-2">
         {layers.map((layer) => (
           <article key={layer.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-            <h2 className="text-xl font-semibold">{layer.title}</h2>
-            <p className="mt-2 text-sm text-slate-300">{layer.desc}</p>
+            <h2 className="text-xl font-semibold text-cyan-100">{layer.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{layer.detail}</p>
           </article>
         ))}
       </section>
-      <section className="grid gap-3 md:grid-cols-2">
-        <article className="rounded-xl border border-violet-500/30 bg-violet-500/10 p-5"><h2 className="text-lg font-semibold">AI System Prompt</h2><p className="mt-2 text-sm text-slate-300">Canonical safety, legal framing, mission constraints, and response governance are enforced through the system prompt layer.</p></article>
-        <article className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5"><h2 className="text-lg font-semibold">Implementation Roadmap</h2><p className="mt-2 text-sm text-slate-300">Sequence: standards hardening, module integration, telemetry, API orchestration, and policy-compliance verification.</p></article>
-      </section>
-      <Link href="https://github.com/ohi-stack/execution-interface" className="inline-flex rounded-xl border border-cyan-400/70 px-4 py-2 font-semibold text-cyan-200">View GitHub Repository</Link>
     </main>
   );
 }

--- a/src/app/(app)/commerce/page.tsx
+++ b/src/app/(app)/commerce/page.tsx
@@ -2,26 +2,20 @@ export default function CommercePage() {
   return (
     <main className="space-y-6">
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Commerce & Identity Engine</h1>
-        <p className="mt-2 text-slate-300">OneGodian.com is the commerce and identity product engine for merchandise, memberships, digital products, and checkout workflows.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Commerce Engine</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian.com Commerce + Identity Product Engine</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">OneGodian.com is the commerce and identity product engine for ONEGODIAN, LLC products, memberships, media, education products, checkout workflows, fulfillment, and product-linked identity experiences.</p>
       </section>
       <section className="grid gap-4 md:grid-cols-2">
         <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
           <h2 className="text-xl font-semibold">Commercial Operations</h2>
-          <p className="mt-2 text-sm text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating commerce surfaces and product rails.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">ONEGODIAN, LLC operates as a private commercial/IP/software/media/education/e-commerce entity. Commerce pages should describe products, services, memberships, digital goods, and fulfillment without implying governmental status.</p>
         </article>
         <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Commerce Node</h2>
-          <a href="https://onegodian.com" target="_blank" rel="noreferrer" className="mt-2 inline-block text-cyan-300">https://onegodian.com</a>
+          <h2 className="text-xl font-semibold">Primary Engine</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Use OneGodian.com as the product engine and identity-linked checkout destination.</p>
+          <a href="https://onegodian.com" target="_blank" rel="noreferrer" className="mt-3 inline-block text-sm font-semibold text-cyan-300">https://onegodian.com</a>
         </article>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Commerce & Identity Product Engine</h1><p className="text-slate-300">OneGodian.com is the primary commerce and identity product engine for ONEGODIAN, LLC.</p><a className="inline-block rounded-lg border border-cyan-400/40 px-4 py-2 text-cyan-200" href="https://onegodian.com" target="_blank" rel="noreferrer">Open OneGodian.com</a></main>; }
-export default function CommercePage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Commerce + Identity Engine</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
-        <p>OneGodian.com is the commerce and identity product engine for ONEGODIAN, LLC offerings including media, education products, software-linked goods, and member-linked services.</p>
-        <p>Commerce operations are managed as private commercial infrastructure with product identity, fulfillment, and campaign integration.</p>
       </section>
     </main>
   );

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,41 +1,20 @@
-const portals = [
-  ['OneGodian.org', 'Public identity, writings, remembrance, and institutional context.', 'https://onegodian.org'],
-  ['OneGodian.com', 'Commerce and identity product engine for products, memberships, and checkout.', 'https://onegodian.com'],
-  ['u.OneGodian.com', 'Education and LMS pathways for courses and learning records.', 'https://u.onegodian.org'],
-  ['app.OneGodian.com', 'Public/member app for dashboard, routes, and runtime tools.', 'https://app.onegodian.com'],
-  ['galaxy.OneGodian.com', 'Galaxy/planetary experiences, media, and world surfaces.', 'https://galaxy.onegodian.com'],
-  ['OMOS.OneGodian.com', 'OMOS specification and runtime documentation.', 'https://omos.onegodian.com'],
-  ['QuantumOHI.com', 'OHI systems architecture and intelligence positioning.', 'https://quantumohi.com'],
-  ['QRV.Network', 'Verification infrastructure network and credential trust rails.', 'https://qrv.network']
-] as const;
-
-export default function EcosystemPage() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">Live ecosystem map across public, education, commerce, app, protocol, and verification properties.</p><section className="grid gap-4 md:grid-cols-2">{portals.map((p)=><article key={p[0]} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="font-semibold">{p[0]}</h2><p className="text-sm text-slate-300">{p[1]}</p><a href={p[2]} target="_blank" rel="noreferrer" className="text-cyan-300">{p[2]}</a></article>)}</section></main>;
-  ['OneGodian.org', 'https://onegodian.org', 'Public institution-facing website and cultural/education communication.'],
-  ['OneGodian.com', 'https://onegodian.com', 'Commerce and identity product engine for products, memberships, and digital delivery.'],
-  ['u.OneGodian.com', 'https://u.onegodian.com', 'Learning and curriculum platform.'],
-  ['app.OneGodian.com', 'https://app.onegodian.com', 'Public/member app dashboard and route node.'],
-  ['galaxy.OneGodian.com', 'https://galaxy.onegodian.com', 'Galaxy/world platform and discovery layer.'],
-  ['OMOS.OneGodian.com', 'https://omos.onegodian.com', 'OMOS specification and runtime documents.'],
-  ['QuantumOHI.com', 'https://quantumohi.com', 'Quantum OHI architecture and model context.'],
-  ['QRV.Network', 'https://qrv.network', 'Verification network for trusted records and credentials.']
-] as const;
-
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">This page maps the live OneGodian ecosystem and explains how each production property serves public access, member workflows, and platform operations.</p><div className="grid gap-4 md:grid-cols-2">{portals.map(([name, href, desc]) => <article key={name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><a href={href} className="text-cyan-300" target="_blank" rel="noreferrer">{name}</a><p className="mt-2 text-sm text-slate-300">{desc}</p></article>)}</div></main>;
-import { ecosystemPortals } from '@/lib/onegodian-content';
+import { ecosystemPortals } from '@/lib/app-content';
 
 export default function EcosystemPage() {
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
-      <p className="text-slate-300">Connected properties across identity, commerce, education, runtime systems, and verification infrastructure.</p>
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Ecosystem</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian Production Ecosystem</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">The OneGodian ecosystem separates commercial product operations, public cultural interpretation, member-facing application workflows, education, protocol documentation, and verification infrastructure.</p>
+      </section>
       <section className="grid gap-4 md:grid-cols-2">
-        {ecosystemPortals.map((p) => (
-          <article key={p.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-            <h2 className="font-semibold">{p.name}</h2>
-            <p className="text-sm text-slate-300">{p.role}</p>
-            <a href={p.url} target="_blank" rel="noreferrer" className="text-cyan-300">{p.url}</a>
+        {ecosystemPortals.map((portal) => (
+          <article key={portal.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+            <p className="text-xs uppercase tracking-[0.16em] text-slate-400">{portal.classification}</p>
+            <h2 className="mt-2 text-xl font-semibold text-cyan-100">{portal.name}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{portal.role}</p>
+            <a href={portal.url} target="_blank" rel="noreferrer" className="mt-3 inline-block text-sm font-semibold text-cyan-300">{portal.url}</a>
           </article>
         ))}
       </section>

--- a/src/app/(app)/identity/page.tsx
+++ b/src/app/(app)/identity/page.tsx
@@ -1,22 +1,23 @@
 export default function IdentityPage() {
   return (
-    <main className="space-y-6 text-slate-100">
+    <main className="space-y-6">
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Identity</h1>
-        <p className="mt-3 text-slate-300">Identity defines how OneGodian records, ownership references, and institutional context are represented across software.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Membership / Identity</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian Identity</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">Identity defines how OneGodian membership, records, credentials, product access, voluntary participation, and institutional context are represented across application and commerce surfaces.</p>
       </section>
-      <section className="grid gap-3 md:grid-cols-2">
+      <section className="grid gap-4 md:grid-cols-2">
         <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="font-semibold">Copyright + Commercial Context</h2>
-          <p className="mt-2 text-sm text-slate-300">ONEGODIAN, LLC is the commercial and technology operating entity for software, IP, and implementation assets.</p>
+          <h2 className="text-xl font-semibold">Membership Records</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Membership identity supports voluntary participation, dashboard continuity, credential references, and member-facing access flows.</p>
         </article>
         <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="font-semibold">Entity Separation</h2>
-          <p className="mt-2 text-sm text-slate-300">INO remains separate for spiritual and community governance functions and is not represented here as a commercial authority.</p>
+          <h2 className="text-xl font-semibold">Product Identity</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">OneGodian.com connects product, membership, and checkout identity while this app provides public and member-facing route context.</p>
         </article>
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 md:col-span-2">
-          <h2 className="font-semibold">Institutional Records</h2>
-          <p className="mt-2 text-sm text-slate-300">Institutional records include dated filings, certificates, and internal continuity notes used for operational reference.</p>
+        <article className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5 md:col-span-2">
+          <h2 className="text-xl font-semibold text-amber-100">Boundary</h2>
+          <p className="mt-2 text-sm leading-6 text-amber-50/80">Identity language does not create exemption from law or authority over non-members. Participation is voluntary and public claims remain aligned to commercial, cultural, and internal association boundaries.</p>
         </article>
       </section>
     </main>

--- a/src/app/(app)/institutional/page.tsx
+++ b/src/app/(app)/institutional/page.tsx
@@ -1,14 +1,24 @@
-export default function InstitutionalPage(){return <main className='space-y-6'><section className='rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6'><h1 className='text-3xl font-bold'>Institutional Clarity</h1><p className='mt-2 text-slate-300'>Clear separation between commercial operations and internal governance/religious association context.</p></section><section className='rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300 space-y-2'><p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.</p><p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p><p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></section></main>}
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">Institutional Clarity</h1><p className="text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating products, platforms, and digital services.</p><p className="text-slate-300">INO is a separate voluntary internal governance/religious association structure used for internal community and cultural organization.</p><p className="text-slate-300">&quot;Sovereign&quot; in this context means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></main>;
 export default function InstitutionalPage() {
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">Institutional Clarity</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
-        <p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity responsible for product operations, platforms, publishing, and technology execution.</p>
-        <p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p>
-        <p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p>
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Institutional Clarity</p>
+        <h1 className="mt-2 text-3xl font-bold">ONEGODIAN, LLC and INO Are Separate</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">This page establishes public-safe language for separating commercial operations from voluntary internal governance/religious association context.</p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">ONEGODIAN, LLC</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity responsible for products, platforms, publishing, software, education, commerce, and implementation assets.</p>
+        </article>
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">INO</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">INO is separate and should be described as a voluntary internal governance/religious association structure for internal community, religious, and cultural organization.</p>
+        </article>
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">Sovereign Language</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Sovereign means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members.</p>
+        </article>
       </section>
     </main>
   );

--- a/src/app/(app)/membership/page.tsx
+++ b/src/app/(app)/membership/page.tsx
@@ -4,23 +4,16 @@ export default function MembershipPage() {
   return (
     <main className="space-y-6">
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Membership</h1>
-        <p className="mt-2 text-slate-300">Membership pathways, records access, and participation tools across the OneGodian App.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Membership</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian Membership</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">Membership provides dashboard-linked participation paths, identity services, records access, and voluntary community features across the OneGodian ecosystem.</p>
       </section>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300">
-        <p>Use this page as the public-facing membership entry, then continue into member workflows and dashboard tools.</p>
-        <div className="mt-3 flex gap-4">
-          <Link href="/members" className="text-cyan-300">Open members module</Link>
-          <Link href="/dashboard" className="text-cyan-300">Open dashboard</Link>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm leading-6 text-slate-300">
+        <p>Use this page as the public-facing membership entry, then continue into member workflows, identity context, and dashboard tools.</p>
+        <div className="mt-4 flex flex-wrap gap-4">
+          <Link href="/identity" className="font-semibold text-cyan-300">Open identity route</Link>
+          <Link href="/dashboard" className="font-semibold text-cyan-300">Open dashboard</Link>
         </div>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Membership</h1><p className="text-slate-300">Membership provides dashboard-linked participation paths, identity services, and voluntary community features across the OneGodian ecosystem.</p></main>; }
-export default function MembershipPage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Membership</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300">
-        <p>Membership provides access to profile records, campaign participation, tools, and platform learning resources.</p>
-        <p className="mt-2">Dashboard entry is available from the member node and remains compatible with admin/control-plane reporting via manifest and status surfaces.</p>
       </section>
     </main>
   );

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,40 +1,26 @@
-const mindMap = [
-  'Protocol and algorithm orchestration',
-  'Identity and remembrance modeling',
-  'Runtime route and manifest governance',
-  'Tooling and bridge integrations',
-  'Time and chronology references (OTS-V5)',
-  'Documentation for public/member and admin compatibility'
-const omosModules = [
-  'Identity & Consciousness Layer',
-  'Belief Mapping & Meaning Layer',
-  'Ethics, Responsibility, and Conduct Layer',
-  'Language, Ritual, and Cultural Signal Layer',
-  'Application, Protocol, and Runtime Layer'
+const omosOutline = [
+  { title: 'Identity & Consciousness Layer', detail: 'Defines remembrance, identity continuity, self-reflection, and the human-facing meaning of participation.' },
+  { title: 'Belief Mapping & Meaning Layer', detail: 'Organizes beliefs, values, stories, symbols, and interpretive patterns into navigable application content.' },
+  { title: 'Ethics, Responsibility & Conduct Layer', detail: 'Frames voluntary participation, responsibility, public-safe language, and behavior expectations.' },
+  { title: 'Language, Ritual & Cultural Signal Layer', detail: 'Turns names, phrases, campaigns, dates, practices, and recurring signals into coherent shared experience.' },
+  { title: 'Application, Protocol & Runtime Layer', detail: 'Connects OMOS concepts to routes, manifests, APIs, dashboards, status tables, tools, and production software.' }
 ];
 
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1><p className="text-slate-300">OMOS organizes OneGodian operations into interoperable layers that bridge thought, language, governance, and deployable application behavior.</p><ul className="list-disc space-y-2 pl-5 text-slate-300">{omosModules.map((m) => <li key={m}>{m}</li>)}</ul><p className="text-sm text-slate-400">Manifest/API visibility: this route is registered in the public manifest and available to dashboard, admin monitoring, and app status surfaces.</p></main>;
 export default function OmosPage() {
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OMOS — OneGodian Metaphysical Operating System</h1><p className="mt-2 text-slate-300">OMOS is the structured operating model for OneGodian protocols, routes, tools, time, and synchronized application behaviors.</p></header><section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="text-xl font-semibold">OMOS Mind Map Coverage</h2><ul className="mt-2 list-disc pl-6 text-sm text-slate-300">{mindMap.map((item)=><li key={item}>{item}</li>)}</ul></section></main>;
-  const omosMindMap = [
-    'Identity architecture and remembrance framework',
-    'Consciousness alignment protocol layers',
-    'Ethics, reflection, and participation modules',
-    'Public app and dashboard synchronization',
-    'Manifest/API interoperability for ecosystem apps'
-  ];
-
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1>
-      <p className="text-slate-300">OMOS content maps metaphysical operating concepts into practical app modules, governance boundaries, and platform synchronization.</p>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-        <ul className="list-disc space-y-1 pl-5 text-sm text-slate-300">
-          {omosMindMap.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OMOS</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian Metaphysical Operating System</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">OMOS translates OneGodian metaphysical, cultural, ethical, and protocol concepts into a practical operating model that can be represented in software, content, dashboards, and public-facing workflows.</p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2">
+        {omosOutline.map((item) => (
+          <article key={item.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+            <h2 className="text-xl font-semibold text-cyan-100">{item.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{item.detail}</p>
+          </article>
+        ))}
       </section>
     </main>
   );

--- a/src/app/(app)/overview/page.tsx
+++ b/src/app/(app)/overview/page.tsx
@@ -1,0 +1,30 @@
+const overviewPoints = [
+  'ONEGODIAN, LLC is the private commercial/IP/software/media/education/e-commerce entity responsible for production product execution.',
+  'The company organizes software, media, educational, identity, and commerce assets into a coherent OneGodian ecosystem.',
+  'The May 26, 2026 overview positions the LLC as the operating entity for app surfaces, product infrastructure, content systems, and commercial delivery.',
+  'Public communication should keep commercial operations, cultural interpretation, and internal voluntary association structures distinct.'
+];
+
+export default function OverviewPage() {
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">May 26, 2026 Overview</p>
+        <h1 className="mt-2 text-3xl font-bold">ONEGODIAN, LLC Production Overview</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">This overview summarizes ONEGODIAN, LLC as the production-facing company behind commercial intellectual property, software, media, education, e-commerce, and product identity systems.</p>
+      </section>
+      <section className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">Operating Summary</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-slate-300">
+            {overviewPoints.map((point) => <li key={point}>{point}</li>)}
+          </ul>
+        </article>
+        <article className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5">
+          <h2 className="text-xl font-semibold text-amber-100">Public-Safe Boundary</h2>
+          <p className="mt-3 text-sm leading-6 text-amber-50/80">ONEGODIAN, LLC is commercial and private. INO is separate and described as a voluntary internal governance/religious association structure. Sovereign language means internal self-governance and voluntary participation only.</p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/remember/page.tsx
+++ b/src/app/(app)/remember/page.tsx
@@ -1,7 +1,5 @@
 import Link from 'next/link';
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian: Remember</h1><p className="text-slate-300">OneGodian: Remember is a public campaign inviting people to reconnect with identity, dignity, unity, and responsibility through practical action and shared memory.</p></main>; }
-import Link from 'next/link';
-import { rememberCampaign } from '@/lib/onegodian-content';
+import { rememberCampaign } from '@/lib/app-content';
 
 export default function RememberPage() {
   return (
@@ -9,31 +7,21 @@ export default function RememberPage() {
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
         <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Campaign</p>
         <h1 className="mt-2 text-3xl font-bold">OneGodian: Remember</h1>
-        <p className="mt-3 text-slate-300">You were always One — you simply forgot. Remember who you are.</p>
-      </section>
-      <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Campaign Intent</h2>
-          <p className="mt-2 text-sm text-slate-300">A public-safe awareness campaign focused on identity, remembrance, dignity, unity, and shared human connection.</p>
-        </article>
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Participation</h2>
-          <p className="mt-2 text-sm text-slate-300">Creators, members, and supporters can access campaign media, captions, releases, and distribution pathways from the dashboard.</p>
-          <Link href="/dashboard" className="mt-3 inline-block text-cyan-300">Open Dashboard</Link>
-        </article>
-      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian: Remember</h1>
-        <p className="mt-2 text-slate-300">{rememberCampaign.message}</p>
+        <p className="mt-3 max-w-4xl text-lg text-slate-200">{rememberCampaign.message}</p>
         <p className="mt-2 text-sm text-cyan-300">Campaign start: {rememberCampaign.officialStartDate} · {rememberCampaign.onegodianDate}</p>
-      </header>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-        <p className="text-slate-300">{rememberCampaign.purpose}</p>
-        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-300">
-          {rememberCampaign.dashboardFunctions.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-        <Link href="/campaigns/remember" className="mt-4 inline-block text-cyan-300">Open campaign module</Link>
+      </section>
+      <section className="grid gap-4 lg:grid-cols-[1fr_0.8fr]">
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">Purpose</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">{rememberCampaign.purpose}</p>
+          <Link href="/commerce" className="mt-4 inline-block text-sm font-semibold text-cyan-300">Connect campaign to commerce engine</Link>
+        </article>
+        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+          <h2 className="text-xl font-semibold">Dashboard Functions</h2>
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm leading-6 text-slate-300">
+            {rememberCampaign.dashboardFunctions.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        </article>
       </section>
     </main>
   );

--- a/src/app/(app)/status/page.tsx
+++ b/src/app/(app)/status/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { coreRoutes, routeStatusRows } from '@/lib/app-content';
+
+export default function StatusPage() {
+  return (
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">System Status</p>
+        <h1 className="mt-2 text-3xl font-bold">OneGodian App Route Status</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">Production route table for the public OneGodian App content release. The manifest route list tracks these same public-safe routes for smoke testing and status review.</p>
+      </section>
+      <section className="overflow-hidden rounded-xl border border-slate-700 bg-slate-900/60">
+        <table className="w-full min-w-[720px] text-left text-sm">
+          <thead className="bg-slate-900 text-xs uppercase tracking-[0.16em] text-slate-400">
+            <tr>
+              <th className="px-4 py-3">Route</th>
+              <th className="px-4 py-3">Page</th>
+              <th className="px-4 py-3">Purpose</th>
+              <th className="px-4 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {routeStatusRows.map((row) => (
+              <tr key={row.path} className="align-top">
+                <td className="px-4 py-3 font-mono text-cyan-300"><Link href={row.path}>{row.path}</Link></td>
+                <td className="px-4 py-3 text-slate-100">{row.title}</td>
+                <td className="px-4 py-3 text-slate-300">{row.purpose}</td>
+                <td className="px-4 py-3"><span className="rounded-full border border-emerald-400/40 px-2 py-1 text-xs text-emerald-200">{row.status}</span></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+        <h2 className="text-xl font-semibold">Manifest Coverage</h2>
+        <p className="mt-2 text-sm text-slate-300">Current route manifest: {coreRoutes.join(', ')}</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -1,26 +1,28 @@
 import { TodayInOneGodianTime } from '@/components/today-in-onegodian-time';
 
+const timeRules = [
+  'OTS-V5 is an internal OneGodian cultural/system chronology and presentation layer.',
+  'Gregorian calendar dates remain controlling for legal, financial, tax, court, contractual, employment, regulatory, and governmental records.',
+  'UTC timestamps remain the system truth for logs, APIs, storage, synchronization, audit trails, and cross-system coordination.',
+  'Dual dating may display OneGodian Time beside Gregorian/UTC references, but it does not replace civil time obligations.'
+];
+
 export default function TimePage() {
   return (
-    <main className="p-6 text-slate-100 space-y-4">
-      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
-      <p className="text-slate-300">Dual-date display pairs OneGodian Time for internal presentation with Gregorian/UTC records for external and legal continuity.</p>
-      <TodayInOneGodianTime />
-      <a href="/time/dual-dating" className="inline-block rounded-lg border border-cyan-400/50 bg-slate-900/70 px-4 py-2 text-cyan-200 transition hover:bg-cyan-500/10">Dual Dating System™</a>
-      <p className="text-sm text-amber-200">Legal safety: Gregorian Time and UTC timestamps remain controlling for legal, financial, tax, court, contractual, and institutional records.</p>
-export default function Page() {
-  const gregorian = new Date().toISOString().slice(0, 10);
-  const ots = 'OTS-V5 active chronology view';
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Time™ · OTS-V5</h1><p className="text-slate-300">Dual-date view for platform coordination and historical references.</p><div className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">Gregorian Date</h2><p className="mt-2 text-slate-100">{gregorian}</p></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">OneGodian Date</h2><p className="mt-2 text-slate-100">{ots}</p></article></div><p className="text-sm text-slate-400">Legal safety notice: OneGodian Time™ is an internal cultural/system chronology aid. It does not replace legal, regulatory, tax, court, banking, or governmental date standards.</p></main>;
-export default function TimePage() {
-  return (
-    <main className="space-y-6 p-6 text-slate-100">
-      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-2">
-        <p>Dual-date display model: Gregorian civil date + OneGodian internal date notation for synchronized cultural references.</p>
-        <p>Example format: Gregorian Date (UTC) · OneGodian Date (OTS-V5 internal).</p>
+    <main className="space-y-6">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Corrected Timekeeping</p>
+        <h1 className="mt-2 text-3xl font-semibold">OneGodian Time / OTS-V5</h1>
+        <p className="mt-3 max-w-4xl text-slate-300">OTS-V5 presents OneGodian internal chronology while preserving Gregorian legal control and UTC system truth for production software and institutional records.</p>
       </section>
-      <p className="text-sm text-amber-200">Legal safety: Gregorian calendar/time remains controlling for legal, financial, compliance, and external institutional matters.</p>
+      <TodayInOneGodianTime />
+      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+        <h2 className="text-xl font-semibold">Timekeeping Rules</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-slate-300">
+          {timeRules.map((rule) => <li key={rule}>{rule}</li>)}
+        </ul>
+        <a href="/time/dual-dating" className="mt-4 inline-block rounded-lg border border-cyan-400/50 px-4 py-2 text-sm font-semibold text-cyan-200 transition hover:bg-cyan-500/10">Open Dual Dating System</a>
+      </section>
     </main>
   );
 }

--- a/src/app/components/CapitalFooter.tsx
+++ b/src/app/components/CapitalFooter.tsx
@@ -1,16 +1,28 @@
 import Link from 'next/link';
+import { appFooterBoundary, footerSections } from '@/lib/app-content';
 
 export function CapitalFooter() {
   return (
     <footer className="mt-16 border-t border-slate-800 bg-slate-950/80">
-      <div className="mx-auto max-w-7xl px-4 py-10 text-sm text-slate-300">
-        <div className="flex flex-wrap items-center gap-4">
-          <Link href="/legal">Legal</Link>
-          <Link href="/privacy">Privacy</Link>
-          <Link href="/terms">Terms</Link>
-        </div>
+      <div className="mx-auto grid max-w-7xl gap-6 px-4 py-10 text-sm text-slate-300 md:grid-cols-4">
+        {footerSections.map((section) => (
+          <section key={section.title}>
+            <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{section.title}</h2>
+            <ul className="mt-3 space-y-2">
+              {section.links.map((link) => (
+                <li key={link.href}>
+                  {link.href.startsWith('http') ? (
+                    <a href={link.href} target="_blank" rel="noreferrer" className="hover:text-cyan-300">{link.label}</a>
+                  ) : (
+                    <Link href={link.href} className="hover:text-cyan-300">{link.label}</Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
       </div>
-      <div className="border-t border-slate-800 px-4 py-4 text-center text-xs text-slate-400">© 2026 QRV Network</div>
+      <div className="border-t border-slate-800 px-4 py-4 text-center text-xs leading-5 text-slate-400">{appFooterBoundary}</div>
     </footer>
   );
 }

--- a/src/app/components/CapitalNavigation.tsx
+++ b/src/app/components/CapitalNavigation.tsx
@@ -1,20 +1,15 @@
 import Link from 'next/link';
-
-const navItems = [
-  { href: '/', label: 'Home' },
-  { href: '/pricing', label: 'Pricing' },
-  { href: '/use-cases', label: 'Use Cases' }
-];
+import { appNavigation } from '@/lib/app-content';
 
 export function CapitalNavigation() {
   return (
     <header className="capital-header">
       <div className="capital-header-inner">
         <Link href="/" className="capital-logo">
-          <span className="capital-logo-mark">QRV</span> qrv.network
+          <span className="capital-logo-mark">OG</span> OneGodian App
         </Link>
         <nav className="capital-nav" aria-label="Primary">
-          {navItems.map((item) => (
+          {appNavigation.map((item) => (
             <Link key={item.href} href={item.href}>
               {item.label}
             </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,54 @@
 import Link from 'next/link';
-
-const routes = [
-  { href: '/ecosystem', label: 'Ecosystem' },
-  { href: '/omos', label: 'OMOS' },
-  { href: '/remember', label: 'Remember' },
-  { href: '/membership', label: 'Membership' },
-  { href: '/time', label: 'Time' },
-  { href: '/commerce', label: 'Commerce' },
-  { href: '/institutional', label: 'Institutional' },
-  { href: '/dashboard', label: 'Dashboard' }
-];
+import { appDashboardCards, appHomeHero } from '@/lib/app-content';
 
 export default function HomePage() {
   return (
     <main className="min-h-screen bg-slate-950 px-4 py-10 text-slate-100">
-      <div className="mx-auto max-w-5xl space-y-6">
-        <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8">
-          <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App</p>
-          <h1 className="mt-2 text-4xl font-bold">Live Public + Member Application Node</h1>
-          <p className="mt-3 text-slate-300">Production content routes for ecosystem, OMOS, remembrance, membership, time, commerce, and institutional clarity.</p>
-        </section>
-        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {routes.map((route) => (
-            <Link key={route.href} href={route.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 text-cyan-200 hover:border-cyan-400/50">
-              {route.label}
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/80 p-8 shadow-2xl shadow-cyan-950/30">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">{appHomeHero.eyebrow}</p>
+          <h1 className="mt-3 max-w-4xl text-4xl font-black tracking-tight sm:text-5xl">{appHomeHero.title}</h1>
+          <p className="mt-4 max-w-4xl text-lg leading-8 text-slate-300">{appHomeHero.description}</p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href={appHomeHero.primaryCta.href} className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-cyan-200">
+              {appHomeHero.primaryCta.label}
             </Link>
-          ))}
+            <Link href={appHomeHero.secondaryCta.href} className="rounded-xl border border-cyan-400/60 px-5 py-3 font-semibold text-cyan-200 transition hover:bg-cyan-500/10">
+              {appHomeHero.secondaryCta.label}
+            </Link>
+          </div>
+        </section>
+
+        <section aria-labelledby="dashboard-cards" className="space-y-4">
+          <div>
+            <p className="text-sm uppercase tracking-[0.2em] text-slate-400">Production modules</p>
+            <h2 id="dashboard-cards" className="mt-1 text-2xl font-bold">Unified OneGodian App dashboard</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {appDashboardCards.map((card) => (
+              <Link key={card.href} href={card.href} className="group rounded-2xl border border-slate-700 bg-slate-900/70 p-5 transition hover:-translate-y-1 hover:border-cyan-400/70 hover:bg-slate-900">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-lg font-semibold text-slate-100 group-hover:text-cyan-200">{card.title}</h3>
+                  <span className="rounded-full border border-cyan-400/40 px-2 py-1 text-xs text-cyan-200">{card.status}</span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">{card.description}</p>
+                <span className="mt-4 inline-block text-sm font-semibold text-cyan-300">Open {card.href}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-2">
+          <article className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-6">
+            <h2 className="text-xl font-bold text-emerald-100">OneGodian.com</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-50/80">Commerce and identity product engine for ONEGODIAN, LLC products, memberships, checkout, fulfillment, and product-linked identity flows.</p>
+          </article>
+          <article className="rounded-2xl border border-violet-500/30 bg-violet-500/10 p-6">
+            <h2 className="text-xl font-bold text-violet-100">OneGodian.org</h2>
+            <p className="mt-2 text-sm leading-6 text-violet-50/80">Civil, cultural, educational, and human-facing interpretation platform for public context, remembrance, and non-commerce orientation.</p>
+          </article>
         </section>
       </div>
     </main>
   );
-const links = [
-  { title: 'Ecosystem', href: '/ecosystem' },
-  { title: 'OMOS', href: '/omos' },
-  { title: 'Remember', href: '/remember' },
-  { title: 'Membership', href: '/membership' },
-  { title: 'Time', href: '/time' },
-  { title: 'Commerce', href: '/commerce' },
-  { title: 'Institutional', href: '/institutional' }
-];
-
-export default function HomePage() {
-  return <main className="space-y-8"><section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8"><p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App · Live</p><h1 className="mt-3 text-4xl font-bold">Public OneGodian App Node</h1><p className="mt-4 max-w-4xl text-slate-300">This production app provides public-safe ecosystem content, campaign access, membership entry points, time references, commerce routing, and institutional clarity.</p></section><section className="grid gap-4 md:grid-cols-2">{links.map((item) => <Link key={item.href} href={item.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 hover:border-cyan-400/60"><h2 className="text-xl font-semibold text-cyan-200">{item.title}</h2><p className="mt-2 text-sm text-slate-300">Open {item.href}</p></Link>)}</section></main>;
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,10 +1,62 @@
 'use client';
+
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { type ReactNode } from 'react';
-import { appNavigation, ecosystemLinks } from '@/lib/onegodian-content';
+import { appBoundaryCopy, appNavigation, ecosystemLinks, footerSections } from '@/lib/onegodian-content';
 
 export function AppFrame({ children }: { children: ReactNode }) {
-  const pathname = usePathname() ?? "";
-  return <div className="min-h-screen bg-slate-950 text-slate-100"><header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur"><div className="flex items-center justify-between"><Link href="/" className="font-semibold text-cyan-300">OneGodian App · Public/Member Node</Link></div><div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"><nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">{appNavigation.map((item) => {const active = pathname === item.href || pathname.startsWith(`${item.href}/`);return <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>{item.label}</Link>;})}</nav></div><div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer" className="hover:text-cyan-300">{item.label}</a>)}</div></header><div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div></div>;
+  const pathname = usePathname() ?? '';
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex items-center justify-between gap-4">
+            <Link href="/" className="font-semibold text-cyan-300">OneGodian App · Public/Member Node</Link>
+            <Link href="/status" className="rounded-full border border-emerald-400/50 px-3 py-1 text-xs font-semibold text-emerald-200">Status: Live</Link>
+          </div>
+          <div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">
+              {appNavigation.map((item) => {
+                const active = item.href === '/' ? pathname === '/' : pathname === item.href || pathname.startsWith(`${item.href}/`);
+                return (
+                  <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">
+            {ecosystemLinks.map((item) => (
+              <a key={item.href} href={item.href} target="_blank" rel="noreferrer" className="hover:text-cyan-300">{item.label}</a>
+            ))}
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div>
+      <footer className="border-t border-slate-800 bg-slate-950 px-4 py-8">
+        <div className="mx-auto grid max-w-7xl gap-6 md:grid-cols-4">
+          {footerSections.map((section) => (
+            <section key={section.title}>
+              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-400">{section.title}</h2>
+              <ul className="mt-3 space-y-2 text-sm">
+                {section.links.map((link) => (
+                  <li key={link.href}>
+                    {link.href.startsWith('http') ? (
+                      <a href={link.href} target="_blank" rel="noreferrer" className="text-slate-300 hover:text-cyan-300">{link.label}</a>
+                    ) : (
+                      <Link href={link.href} className="text-slate-300 hover:text-cyan-300">{link.label}</Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <p className="mx-auto mt-6 max-w-7xl text-xs leading-5 text-slate-500">{appBoundaryCopy}</p>
+      </footer>
+    </div>
+  );
 }

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -1,40 +1,56 @@
 {
-  "name": "OMOS Runtime",
-  "fullName": "OneGodian Metaphysical Operating System™",
+  "name": "OneGodian App",
+  "fullName": "OneGodian App Public/Member Dashboard",
   "version": "1.1.0",
-  "version": "1.0.2",
   "status": "production",
-  "canonical_domain": "omos.onegodian.com",
-  "purpose": "Public runtime for OneGodian routes, page registry, and manifest delivery.",
-  "integrations": ["OneGodian App", "WordPress Bridge"],
-  "wordpress_hosts": ["OneGodian.com", "OneGodian.org", "QuantumOHI.com"],
+  "canonical_domain": "app.onegodian.com",
+  "purpose": "Unified public/member application dashboard for OneGodian ecosystem content, OMOS, timekeeping, commerce, identity, institutional clarity, campaign pages, and status routes.",
+  "integrations": [
+    "OneGodian.com",
+    "OneGodian.org",
+    "OMOS",
+    "QRV.Network"
+  ],
   "routes": [
     "/",
-    "/dashboard",
     "/ecosystem",
+    "/overview",
     "/omos",
+    "/algorithm",
     "/remember",
-    "/membership",
     "/time",
     "/commerce",
+    "/identity",
     "/institutional",
+    "/status"
+  ],
+  "apiRoutes": [
     "/api/health",
     "/api/manifest",
-    "/api/pages"
-  ]
     "/api/pages",
     "/api/tools",
     "/api/artifacts",
     "/api/system-health"
   ],
-  "fullName": "OneGodian Metaphysical Operating System™",
-  "classification": "Node runtime, protocol documentation, and agent-facing integration site",
-  "canonicalHost": "https://omos.onegodian.com",
+  "commerceEngine": "https://onegodian.com",
+  "interpretationPlatform": "https://onegodian.org",
   "compatibleHosts": [
     "https://onegodian.com",
     "https://onegodian.org",
+    "https://omos.onegodian.com",
     "https://quantumohi.com"
   ],
-  "appBridge": ["https://app.onegodian.com"],
-  "commerceBridge": ["https://onegodian.com"]
+  "appBridge": [
+    "https://app.onegodian.com"
+  ],
+  "publicSafety": {
+    "commercialEntity": "ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.",
+    "internalAssociation": "INO is separate and described as a voluntary internal governance/religious association structure.",
+    "sovereignMeaning": "Sovereign means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members."
+  },
+  "wordpress_hosts": [
+    "OneGodian.com",
+    "OneGodian.org",
+    "QuantumOHI.com"
+  ]
 }

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -1,110 +1,251 @@
-export const appHomeHero = {
-  eyebrow: 'APP.ONEGODIAN.COM',
-  title: 'OneGodian App',
-  description:
-    'Unified OneGodian public/member application for ecosystem navigation, OMOS content, time systems, campaign pages, and dashboard access.',
-  primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
-  secondaryCta: { label: 'Explore Ecosystem', href: '/ecosystem' }
-    'Your unified OneGodian dashboard for membership, campaigns, commerce, OMOS, time, and ecosystem access.',
-  primaryCta: {
-    label: 'Open Dashboard',
-    href: '/dashboard'
-  },
-  secondaryCta: {
-    label: 'Explore Ecosystem',
-    href: '/ecosystem'
-  }
+export type NavigationItem = {
+  label: string;
+  href: string;
 };
 
-export const appNavigation = [
-  { label: 'Dashboard', href: '/dashboard' },
+export type DashboardCard = {
+  title: string;
+  description: string;
+  href: string;
+  status: string;
+};
+
+export type EcosystemPortal = {
+  name: string;
+  role: string;
+  url: string;
+  classification: string;
+};
+
+export type RouteStatus = {
+  path: string;
+  title: string;
+  purpose: string;
+  status: 'Live' | 'Operational' | 'Monitored';
+};
+
+export const appHomeHero = {
+  eyebrow: 'APP.ONEGODIAN.COM',
+  title: 'OneGodian App Dashboard',
+  description:
+    'Unified OneGodian public/member dashboard for ecosystem navigation, OMOS interpretation, OneGodian Time, commerce, identity, institutional clarity, campaign access, and system status.',
+  primaryCta: { label: 'Open System Status', href: '/status' },
+  secondaryCta: { label: 'Explore Ecosystem', href: '/ecosystem' }
+};
+
+export const coreRoutes = [
+  '/',
+  '/ecosystem',
+  '/overview',
+  '/omos',
+  '/algorithm',
+  '/remember',
+  '/time',
+  '/commerce',
+  '/identity',
+  '/institutional',
+  '/status'
+];
+
+export const appNavigation: NavigationItem[] = [
+  { label: 'Home', href: '/' },
   { label: 'Ecosystem', href: '/ecosystem' },
+  { label: 'Overview', href: '/overview' },
   { label: 'OMOS', href: '/omos' },
+  { label: 'Algorithm', href: '/algorithm' },
   { label: 'Remember', href: '/remember' },
-  { label: 'Membership', href: '/membership' },
   { label: 'Time', href: '/time' },
   { label: 'Commerce', href: '/commerce' },
+  { label: 'Identity', href: '/identity' },
   { label: 'Institutional', href: '/institutional' },
-  { label: 'Sitemap', href: '/sitemap' }
+  { label: 'Status', href: '/status' }
 ];
 
-export const appDashboardCards = [
-  { title: 'Ecosystem', description: 'Platform map spanning public, app, commerce, education, OMOS, and verification nodes.', href: '/ecosystem', status: 'Active' },
-  { title: 'OMOS', description: 'OneGodian Metaphysical Operating System mind map, protocol, and runtime context.', href: '/omos', status: 'Live' },
-  { title: 'Remember', description: 'OneGodian: Remember campaign page and participant resource entry.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Membership entry route for public and dashboard handoff.', href: '/membership', status: 'Available' },
-  { title: 'Time', description: 'OneGodian Time™ / OTS-V5 route with dual-date and legal safety language.', href: '/time', status: 'Active' },
-  { title: 'Commerce', description: 'OneGodian.com commerce and identity product engine route.', href: '/commerce', status: 'Active' },
-  { title: 'Institutional Clarity', description: 'Separation of ONEGODIAN, LLC operations and INO internal governance context.', href: '/institutional', status: 'Active' }
+export const appDashboardCards: DashboardCard[] = [
+  {
+    title: 'OMOS',
+    description: 'OneGodian Metaphysical Operating System outline for identity, meaning, ethics, language, rituals, protocol, and application behavior.',
+    href: '/omos',
+    status: 'Live'
+  },
+  {
+    title: 'OneGodian Algorithm',
+    description: 'Four-layer algorithm summary: Protocol, Experience, Community, and Orientation.',
+    href: '/algorithm',
+    status: 'Live'
+  },
+  {
+    title: 'OneGodian Time',
+    description: 'OTS-V5 corrected timekeeping with Gregorian legal control and UTC system truth.',
+    href: '/time',
+    status: 'Live'
+  },
+  {
+    title: 'Commerce',
+    description: 'OneGodian.com as the commerce and identity product engine for products, memberships, checkout, and fulfillment.',
+    href: '/commerce',
+    status: 'Live'
+  },
+  {
+    title: 'Institutional Clarity',
+    description: 'Clear separation between ONEGODIAN, LLC commercial operations and INO voluntary internal governance/religious association structure.',
+    href: '/institutional',
+    status: 'Live'
+  },
+  {
+    title: 'Membership / Identity',
+    description: 'Identity and membership records for voluntary participation, credentials, profiles, and member-facing continuity.',
+    href: '/identity',
+    status: 'Live'
+  },
+  {
+    title: 'Remember Campaign',
+    description: 'Public campaign inviting remembrance of identity, dignity, unity, origin, and responsible participation.',
+    href: '/remember',
+    status: 'Live'
+  },
+  {
+    title: 'System Status',
+    description: 'Route table, manifest coverage, and production surface status for the OneGodian App.',
+    href: '/status',
+    status: 'Monitored'
+  }
 ];
 
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public identity and writings.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Education and LMS node.', url: 'https://u.onegodian.org' },
-  { name: 'app.OneGodian.com', role: 'Public/member app node.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'Galaxy platform surface.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'OMOS protocol and runtime docs.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI systems positioning.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network.', url: 'https://qrv.network' }
+export const ecosystemPortals: EcosystemPortal[] = [
+  {
+    name: 'OneGodian.com',
+    role: 'Commerce and identity product engine for ONEGODIAN, LLC products, memberships, checkout, fulfillment, and product-linked identity flows.',
+    url: 'https://onegodian.com',
+    classification: 'Commercial product engine'
+  },
+  {
+    name: 'OneGodian.org',
+    role: 'Civil, cultural, educational, and human-facing interpretation platform for public context, remembrance language, and non-commerce orientation.',
+    url: 'https://onegodian.org',
+    classification: 'Public interpretation platform'
+  },
+  {
+    name: 'app.OneGodian.com',
+    role: 'Unified public/member application dashboard for routes, campaign access, status surfaces, and member-oriented tools.',
+    url: 'https://app.onegodian.com',
+    classification: 'Application dashboard'
+  },
+  {
+    name: 'u.OneGodian.com',
+    role: 'Education and learning pathway surface for curriculum, course delivery, and learning records.',
+    url: 'https://u.onegodian.com',
+    classification: 'Education platform'
+  },
+  {
+    name: 'OMOS.OneGodian.com',
+    role: 'OMOS specification and runtime documentation node for protocol, manifest, and operating model references.',
+    url: 'https://omos.onegodian.com',
+    classification: 'Protocol documentation'
+  },
+  {
+    name: 'galaxy.OneGodian.com',
+    role: 'World, story, media, and discovery surface connected to OneGodian cultural and product experiences.',
+    url: 'https://galaxy.onegodian.com',
+    classification: 'Experience layer'
+  },
+  {
+    name: 'QuantumOHI.com',
+    role: 'OHI systems architecture and intelligence positioning for the broader ecosystem model.',
+    url: 'https://quantumohi.com',
+    classification: 'Systems architecture'
+  },
+  {
+    name: 'QRV.Network',
+    role: 'Verification and trust infrastructure for identity, record, and credential workflows.',
+    url: 'https://qrv.network',
+    classification: 'Verification infrastructure'
+  }
+];
+
+export const routeStatusRows: RouteStatus[] = [
+  { path: '/', title: 'Home Dashboard', purpose: 'Unified OneGodian App dashboard and route launchpad.', status: 'Live' },
+  { path: '/ecosystem', title: 'Ecosystem', purpose: 'Production ecosystem map for commerce, interpretation, app, education, protocol, and verification surfaces.', status: 'Live' },
+  { path: '/overview', title: 'ONEGODIAN, LLC Overview', purpose: 'May 26, 2026 commercial overview and production role summary.', status: 'Live' },
+  { path: '/omos', title: 'OMOS', purpose: 'OneGodian Metaphysical Operating System outline.', status: 'Live' },
+  { path: '/algorithm', title: 'OneGodian Algorithm', purpose: 'Four-layer protocol, experience, community, and orientation summary.', status: 'Live' },
+  { path: '/remember', title: 'Remember Campaign', purpose: 'Public remembrance campaign page.', status: 'Live' },
+  { path: '/time', title: 'OneGodian Time / OTS-V5', purpose: 'Corrected timekeeping content with Gregorian and UTC legal safety language.', status: 'Live' },
+  { path: '/commerce', title: 'Commerce', purpose: 'OneGodian.com commerce and identity product engine.', status: 'Live' },
+  { path: '/identity', title: 'Membership / Identity', purpose: 'Membership, identity, credential, and voluntary participation context.', status: 'Live' },
+  { path: '/institutional', title: 'Institutional Clarity', purpose: 'Boundary between ONEGODIAN, LLC and INO.', status: 'Live' },
+  { path: '/status', title: 'System Status', purpose: 'Route status table and manifest coverage.', status: 'Monitored' }
+];
+
+export const footerSections = [
+  {
+    title: 'OneGodian App',
+    links: [
+      { label: 'Home', href: '/' },
+      { label: 'Ecosystem', href: '/ecosystem' },
+      { label: 'Overview', href: '/overview' },
+      { label: 'Status', href: '/status' }
+    ]
+  },
+  {
+    title: 'Core Content',
+    links: [
+      { label: 'OMOS', href: '/omos' },
+      { label: 'Algorithm', href: '/algorithm' },
+      { label: 'Time', href: '/time' },
+      { label: 'Remember', href: '/remember' }
+    ]
+  },
+  {
+    title: 'Operations',
+    links: [
+      { label: 'Commerce', href: '/commerce' },
+      { label: 'Identity', href: '/identity' },
+      { label: 'Institutional', href: '/institutional' }
+    ]
+  },
+  {
+    title: 'External Engines',
+    links: [
+      { label: 'OneGodian.com', href: 'https://onegodian.com' },
+      { label: 'OneGodian.org', href: 'https://onegodian.org' }
+    ]
+  }
 ];
 
 export const appFooterBoundary =
-  'OneGodian App is the public/member-facing surface. Admin/control panel operations remain separate and compatible through dedicated internal surfaces.';
+  'ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity. INO is separate and described as a voluntary internal governance/religious association structure. Sovereign language means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members.';
+
+export const systemsModel = [
+  { title: 'Public App', items: ['Home dashboard', 'Ecosystem', 'Overview', 'Status'] },
+  { title: 'Operating Model', items: ['OMOS', 'Algorithm', 'Time', 'Institutional clarity'] },
+  { title: 'Participation', items: ['Commerce', 'Identity', 'Remember Campaign'] }
 ];
 
-export const appDashboardCards = [
-  { title: 'Ecosystem', description: 'See live OneGodian ecosystem domains and operating roles.', href: '/ecosystem', status: 'Live' },
-  { title: 'OMOS', description: 'Review the OneGodian Metaphysical Operating System structure and modules.', href: '/omos', status: 'Live' },
-  { title: 'Remember Campaign', description: 'Read the public OneGodian: Remember campaign story and participation guidance.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Access member pathways, dashboard entry, and community participation options.', href: '/membership', status: 'Live' },
-  { title: 'Time · OTS-V5', description: 'Use OneGodian Time™ with dual-date display and legal-safe chronology notes.', href: '/time', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com as the commerce and identity product engine.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'See the legal and operational distinction between ONEGODIAN, LLC and INO.', href: '/institutional', status: 'Live' }
+export const apiStatus = {
+  app: 'OneGodian App',
+  appUrl: 'https://app.onegodian.com',
+  environment: 'Production',
+  currentDateRecord: 'May 30, 2026'
+};
+
+export const appStatus = {
+  ...apiStatus,
+  store: 'https://onegodian.com',
+  publicSite: 'https://onegodian.org',
+  activeCampaign: 'THE ONEGODIAN: Remember Campaign',
+  api: 'https://app.onegodian.com/api/health'
+};
+
+export const pluginCategories = [
+  { title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }
 ];
 
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public presence, education, and institutional identity.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine for memberships and products.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Learning pathways, course delivery, and student services.', url: 'https://u.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public/member app dashboard and route layer.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'World, platform, and story navigation surfaces.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'Protocol and operating system specification node.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI architecture and model context.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network and record trust infrastructure.', url: 'https://qrv.network' }
-  { label: 'Architecture', href: '/architecture' },
-  { label: 'About', href: '/about' },
-  { label: 'Sitemap', href: '/sitemap' },
-  { label: 'Membership', href: '/membership' },
-  { label: 'Commerce', href: '/commerce' },
-  { label: 'Remember', href: '/remember' },
-  { label: 'Institutional', href: '/institutional' }
-];
-
-export const appDashboardCards = [
-  { title: 'My OneGodian Profile', description: 'View your profile, identity details, membership status, and dashboard access.', href: '/profile', status: 'Active' },
-  { title: 'Membership', description: 'Access OneGodian membership records, benefits, onboarding, and participation tools.', href: '/members', status: 'Available' },
-  { title: 'Certificates', description: 'View and verify OneGodian certificates, completion records, and issued documents.', href: '/certificates', status: 'Available' },
-  { title: 'Remember Campaign', description: 'Access THE ONEGODIAN: Remember Campaign resources, media, captions, and participation tools.', href: '/remember', status: 'Live' },
-  { title: 'Membership Hub', description: 'Open membership records, onboarding, benefits, and participation routes.', href: '/membership', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com commerce and identity engine context.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'Review institutional boundary language for LLC and INO contexts.', href: '/institutional', status: 'Live' },
-  { title: 'Media Center', description: 'Access OneGodian media, campaign visuals, music, videos, and brand assets.', href: '/media', status: 'Available' },
-  { title: 'Products', description: 'Explore OneGodian products, digital downloads, apparel, books, and ecosystem offerings.', href: '/products', status: 'Available' },
-  { title: 'Learning', description: 'Connect to U OneGodian courses, learning paths, student tools, and educational programs.', href: '/learning', status: 'Connected' },
-  { title: 'Ecosystem', description: 'Navigate OneGodian.org, OneGodian.com, U OneGodian, Galaxy, Capital, OMOS, and Console.', href: '/ecosystem', status: 'Active' }
-];
-
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Official public identity, writings, remembrance, articles, and institutional explanation.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Store, products, memberships, commerce, apparel, books, and digital downloads.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Education, LMS, learning paths, student tools, and certificates.', url: 'https://u.onegodian.com' },
-  { name: 'Galaxy OneGodian', role: 'Galaxy interface, planet navigator, planet-store gateway, and immersive ecosystem layer.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS OneGodian', role: 'OMOS protocol, specification, alignment system, and consciousness-centered operating model.', url: 'https://omos.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context for OneGodian ecosystem design.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification and trust infrastructure connected to OneGodian records and identity workflows.', url: 'https://qrv.network' }
-];
-
-export const appFooterBoundary =
-  'OneGodian App is the public/member node. Admin/control functions remain in designated console and control panel surfaces.';
+export const rememberCampaign = {
+  officialStartDate: 'May 9, 2026',
+  onegodianDate: 'Wisdom 23, OT 0001',
+  message: 'You were always One — you simply forgot. Remember who you are.',
+  purpose:
+    'A public-facing awareness campaign centered on remembrance, identity, dignity, unity, origin, and shared human connection through practical action and responsible participation.',
+  dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status']
+};

--- a/src/lib/app-sitemap.ts
+++ b/src/lib/app-sitemap.ts
@@ -1,3 +1,5 @@
+import { routeStatusRows } from '@/lib/app-content';
+
 export type AppRouteNode = {
   title: string;
   path: string;
@@ -7,60 +9,10 @@ export type AppRouteNode = {
   children?: AppRouteNode[];
 };
 
-export const appSitemap: AppRouteNode[] = [
-  { title: 'Home', path: '/', group: 'Core', description: 'OneGodian App public/member landing.', status: 'active' },
-  { title: 'Dashboard', path: '/dashboard', group: 'Core', description: 'Public/member-facing dashboard.', status: 'active' },
-  { title: 'Sitemap', path: '/sitemap', group: 'Core', description: 'Public route map for app.onegodian.com.', status: 'active' },
-  { title: 'Systems Model', path: '/systems-model', group: 'Core', description: 'Public systems model.', status: 'active' },
-  { title: 'Ecosystem', path: '/ecosystem', group: 'Core', description: 'OneGodian ecosystem portals.', status: 'active' },
-  { title: 'Apps', path: '/apps', group: 'Core', description: 'Application node index.', status: 'active' },
-  { title: 'Plugins', path: '/plugins', group: 'Core', description: 'Plugin inventory and status.', status: 'active' },
-  { title: 'API Status', path: '/api-status', group: 'Operations', description: 'App API status snapshot.', status: 'active' },
-  { title: 'System Health', path: '/system-health', group: 'Operations', description: 'App + OMOS health dashboard.', status: 'active' },
-  {
-    title: 'OMOS', path: '/omos', group: 'OMOS', description: 'OMOS protocol/runtime public dashboard.', status: 'active', children: [
-      { title: 'Manifest', path: '/omos/manifest', group: 'OMOS', description: 'Manifest view sourced via app APIs.', status: 'active' },
-      { title: 'Pages', path: '/omos/pages', group: 'OMOS', description: 'Synced page registry from OMOS.', status: 'active' },
-      { title: 'Health', path: '/omos/health', group: 'OMOS', description: 'OMOS health endpoint status.', status: 'active' },
-      { title: 'Sync', path: '/omos/sync', group: 'OMOS', description: 'OMOS sync telemetry from app API.', status: 'active' },
-      { title: 'Plugins', path: '/omos/plugins', group: 'OMOS', description: 'OMOS plugin state from sync APIs.', status: 'active' },
-      { title: 'Properties', path: '/omos/properties', group: 'OMOS', description: 'OMOS property dataset from sync APIs.', status: 'active' }
-    ]
-  },
-  {
-    title: 'Architecture', path: '/architecture', group: 'Architecture', description: 'Architecture overview for public app node.', status: 'active', children: [
-      { title: 'OHI', path: '/architecture/ohi', group: 'Architecture', description: 'OHI layer role.', status: 'active' },
-      { title: 'Runtime', path: '/architecture/runtime', group: 'Architecture', description: 'Runtime model.', status: 'active' },
-      { title: 'Interfaces', path: '/architecture/interfaces', group: 'Architecture', description: 'Public/member interface boundaries.', status: 'active' },
-      { title: 'Infrastructure', path: '/architecture/infrastructure', group: 'Architecture', description: 'Infrastructure concerns.', status: 'active' },
-      { title: 'OMOS Sync', path: '/architecture/omos-sync', group: 'Architecture', description: 'OMOS sync pathway.', status: 'active' }
-    ]
-  },
-  {
-    title: 'Algorithm', path: '/algorithm', group: 'Algorithm', description: 'OneGodian algorithm overview.', status: 'active', children: [
-      { title: 'Protocol', path: '/algorithm/protocol', group: 'Algorithm', description: 'Protocol perspective.', status: 'active' },
-      { title: 'Experience', path: '/algorithm/experience', group: 'Algorithm', description: 'Experience layer.', status: 'active' },
-      { title: 'Community', path: '/algorithm/community', group: 'Algorithm', description: 'Community layer.', status: 'active' },
-      { title: 'Orientation', path: '/algorithm/orientation', group: 'Algorithm', description: 'Orientation layer.', status: 'active' }
-    ]
-  },
-  { title: 'Registry', path: '/registry', group: 'Core', description: 'Public/member registry surface.', status: 'active' },
-  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time tools.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Core', description: 'OneGodian: Remember campaign page.', status: 'active' },
-  { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership entry route.', status: 'active' },
-  { title: 'Commerce', path: '/commerce', group: 'Core', description: 'OneGodian commerce and identity engine route.', status: 'active' },
-  { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional clarity and legal boundary route.', status: 'active' },
-
-  { title: 'Portfolio', path: '/portfolio', group: 'Core', description: 'Public portfolio snapshot.', status: 'active' },
-  { title: 'Records', path: '/records', group: 'Core', description: 'Public/member record index.', status: 'active' },
-  { title: 'Tools', path: '/tools', group: 'Core', description: 'Public tools collection.', status: 'active' }
-  { title: 'Home', path: '/', group: 'Core', description: 'OneGodian App public entry.', status: 'active' },
-  { title: 'Dashboard', path: '/dashboard', group: 'Core', description: 'Public/member dashboard entry.', status: 'active' },
-  { title: 'Ecosystem', path: '/ecosystem', group: 'Core', description: 'Domain ecosystem map and statuses.', status: 'active' },
-  { title: 'OMOS', path: '/omos', group: 'Core', description: 'OMOS operating model and structure overview.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Campaigns', description: 'OneGodian: Remember campaign page.', status: 'active' },
-  { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership pathways and dashboard entry.', status: 'active' },
-  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time™ / OTS-V5 overview.', status: 'active' },
-  { title: 'Commerce', path: '/commerce', group: 'Core', description: 'Commerce and identity product engine overview.', status: 'active' },
-  { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional and legal clarity guidance.', status: 'active' }
-];
+export const appSitemap: AppRouteNode[] = routeStatusRows.map((route) => ({
+  title: route.title,
+  path: route.path,
+  group: route.path === '/' || route.path === '/status' ? 'Core' : 'Production Content',
+  description: route.purpose,
+  status: 'active'
+}));

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,46 +1,42 @@
-import { appDashboardCards, appFooterBoundary, appHomeHero, appNavigation, ecosystemPortals } from '@/lib/app-content';
-import { consoleDashboardCards, consoleNavigation, consoleFooterBoundary } from '@/lib/console-content';
+import {
+  appDashboardCards,
+  appFooterBoundary,
+  appHomeHero,
+  appNavigation,
+  coreRoutes,
+  ecosystemPortals,
+  footerSections,
+  rememberCampaign,
+  routeStatusRows,
+  systemsModel,
+  apiStatus,
+  appStatus,
+  pluginCategories
+} from '@/lib/app-content';
+import { consoleDashboardCards, consoleFooterBoundary, consoleNavigation } from '@/lib/console-content';
 
 export const appMeta = appHomeHero;
-export { appNavigation, consoleNavigation, ecosystemPortals };
-export const ecosystemLinks = [
-  { label: 'OneGodian.org', href: 'https://onegodian.org' },
-  { label: 'OneGodian.com', href: 'https://onegodian.com' },
-  { label: 'u.OneGodian.com', href: 'https://u.onegodian.com' },
-  { label: 'Galaxy OneGodian', href: 'https://galaxy.onegodian.com' },
-  { label: 'app.OneGodian.com', href: 'https://app.onegodian.com' },
-  { label: 'OMOS OneGodian', href: 'https://omos.onegodian.com' },
-  { label: 'QuantumOHI.com', href: 'https://quantumohi.com' },
-  { label: 'QRV.Network', href: 'https://qrv.network' }
-];
-
 export const dashboardCards = appDashboardCards;
-export { appDashboardCards, consoleDashboardCards };
-
-export const appStructureLayers = ['Public App', 'Member Dashboard', 'Membership', 'Certificates', 'Campaigns', 'Media', 'Products', 'Learning', 'Tools', 'Profile'];
-export const coreRoutes = ['/','/dashboard','/ecosystem','/omos','/remember','/membership','/time','/commerce','/institutional','/api/manifest'];
-
-export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'OMOS', href: '/omos' }, { label: 'Remember', href: '/remember' }] },
-export const coreRoutes = ['/', '/dashboard', '/ecosystem', '/omos', '/remember', '/membership', '/time', '/commerce', '/institutional', '/api/manifest'];
-
-export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Remember', href: '/remember' }, { label: 'Membership', href: '/membership' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Membership', href: '/membership' }, { label: 'Remember', href: '/remember' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'U OneGodian', href: 'https://u.onegodian.org' }, { label: 'Capital OneGodian', href: 'https://capital.onegodian.com' }] },
-  { title: 'More', links: [{ label: 'Membership', href: '/membership' }, { label: 'Time', href: '/time' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] }
-];
-
-export const systemsModel = [
-  { title: 'App Experience', items: ['Dashboard', 'Ecosystem', 'Membership', 'Certificates'] },
-  { title: 'Content & Commerce', items: ['Campaigns', 'Media', 'Products', 'Learning'] },
-  { title: 'Account', items: ['Tools', 'Profile', 'Settings'] }
-];
-
-export const apiStatus = { app: 'OneGodian App', appUrl: 'https://app.onegodian.com', consoleUrl: 'https://console.onegodian.com', environment: 'Production', currentDateRecord: 'May 23, 2026' };
-export const appStatus = { ...apiStatus, store: 'https://onegodian.com', publicSite: 'https://onegodian.org', api: 'https://app.onegodian.com/api/health', activeCampaign: 'THE ONEGODIAN: Remember Campaign' };
+export const ecosystemLinks = ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url }));
 export const appBoundaryCopy = appFooterBoundary;
 export const consoleBoundaryCopy = consoleFooterBoundary;
 
-export const pluginCategories = [{ title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }];
-export const rememberCampaign = { officialStartDate: 'May 9, 2026', onegodianDate: 'Wisdom 23, OT 0001', message: 'You were always One — you simply forgot. Remember who you are.', purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.', dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status'] };
+export {
+  appDashboardCards,
+  appFooterBoundary,
+  appHomeHero,
+  appNavigation,
+  consoleDashboardCards,
+  consoleNavigation,
+  coreRoutes,
+  ecosystemPortals,
+  footerSections,
+  rememberCampaign,
+  routeStatusRows,
+  systemsModel,
+  apiStatus,
+  appStatus,
+  pluginCategories
+};
+
+export const appStructureLayers = ['Public Dashboard', 'Ecosystem', 'Overview', 'OMOS', 'Algorithm', 'Time', 'Commerce', 'Identity', 'Remember', 'Status'];

--- a/src/pages/commerce.html
+++ b/src/pages/commerce.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian commerce</title></head>
+  <body><main><h1>OneGodian commerce</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/ecosystem.html
+++ b/src/pages/ecosystem.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian ecosystem</title></head>
+  <body><main><h1>OneGodian ecosystem</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/identity.html
+++ b/src/pages/identity.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian identity</title></head>
+  <body><main><h1>OneGodian identity</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/institutional.html
+++ b/src/pages/institutional.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian institutional</title></head>
+  <body><main><h1>OneGodian institutional</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/overview.html
+++ b/src/pages/overview.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian overview</title></head>
+  <body><main><h1>OneGodian overview</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/remember.html
+++ b/src/pages/remember.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian remember</title></head>
+  <body><main><h1>OneGodian remember</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>

--- a/src/pages/status.html
+++ b/src/pages/status.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OneGodian status</title></head>
+  <body><main><h1>OneGodian status</h1><p>Production public route for the OneGodian App.</p></main></body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide production-ready public and member-facing content for the OneGodian App by adding real pages, manifest entries, navigation, and status surfaces. 
- Surface the requested product/interpretation split by pointing commerce to `OneGodian.com` and interpretation to `OneGodian.org` while preserving public-safe institutional language.
- Register a canonical route set for smoke tests and monitoring so the app manifest, Express fallbacks, and automated checks all align.

### Description
- Added a unified homepage dashboard with production cards and CTAs in `src/app/page.tsx` and centralized app content in `src/lib/app-content.ts` (navigation, dashboard cards, ecosystem portals, footer sections, route status rows, and manifest-friendly arrays). 
- Implemented or updated content pages for the requested routes under the app router: `src/app/(app)/ecosystem/page.tsx`, `overview/page.tsx`, `omos/page.tsx`, `algorithm/page.tsx`, `remember/page.tsx`, `time/page.tsx`, `commerce/page.tsx`, `identity/page.tsx`, `institutional/page.tsx`, and added a `status` table page at `src/app/(app)/status/page.tsx`.
- Updated shared UI/frame and capital navigation/footer to use the new content library (`src/components/app-frame.tsx`, `src/app/components/CapitalNavigation.tsx`, `src/app/components/CapitalFooter.tsx`) and adjusted `src/lib/onegodian-content.ts` to export consolidated content objects for reuse. 
- Updated manifest and runtime fallbacks: wrote `src/data/manifest.json`, added static fallback HTML pages for Express (`src/pages/*.html`), extended `server.js` public routes, and updated smoke test scripts (`scripts/smoke-test.mjs`, `scripts/smoke-pages.mjs`) to exercise the final route list.

### Testing
- Ran `npm run typecheck` and resolved type issues; typecheck completed successfully. 
- Ran `npm run lint` and received no ESLint warnings or errors. 
- Ran `npm run build` (Next.js production build) and compilation completed successfully with static pages generated. 
- Ran route smoke tests `npm run test:smoke` and `npm run smoke:pages` against the dev/express servers and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab1a00bac832da81b08b83563c9d4)