### PR TITLE
feat: add OneGodian App control plane routes

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -8,11 +8,11 @@ const routes = [
   '/omos', '/omos/manifest', '/omos/pages', '/omos/health', '/omos/sync', '/omos/plugins', '/omos/properties',
   '/architecture', '/architecture/ohi', '/architecture/runtime', '/architecture/interfaces', '/architecture/infrastructure', '/architecture/omos-sync',
   '/algorithm', '/algorithm/protocol', '/algorithm/experience', '/algorithm/community', '/algorithm/orientation',
-  '/registry', '/time', '/portfolio', '/records', '/tools',
-  '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health', '/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync', '/api/tools', '/api/artifacts', '/api/dashboard'
+  '/registry', '/time', '/portfolio', '/records', '/tools', '/certificates', '/members', '/settings', '/admin',
+  '/api/health', '/api/manifest', '/api/pages', '/api/sync/omos', '/api/properties', '/api/plugins', '/api/system-health', '/api/plugin-consumers', '/api/plugin-shortcodes', '/api/plugin-sync', '/api/tools', '/api/stats', '/api/artifacts', '/api/dashboard'
 ];
 
-const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe' });
+const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe', detached: true });
 
 await new Promise((resolve, reject) => {
   const timer = setTimeout(() => reject(new Error('server start timeout')), 30000);
@@ -55,5 +55,5 @@ try {
 
   console.log('Smoke tests passed');
 } finally {
-  server.kill('SIGTERM');
+  process.kill(-server.pid, 'SIGTERM');
 }

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -7,11 +7,13 @@ export const metadata = {
 
 export default function AdminPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Admin"
-      layer="admin"
-      description="Reserved operator surface for future authenticated administration, policy controls, approvals, audit review, and system operations."
-      modules={['Authenticated administration', 'Policy controls', 'Approvals', 'Audit review']}
-    />
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ControlPlanePlaceholder
+        title="Admin"
+        layer="admin"
+        description="Reserved operator surface for future authenticated administration, policy controls, approvals, audit review, and system operations."
+        modules={['Authenticated administration', 'Policy controls', 'Approvals', 'Audit review']}
+      />
+    </main>
   );
 }

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,1 +1,17 @@
-export default function Page() { return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">OneGodian Console · admin</h1><p className="mt-2 text-slate-300">Internal operator/admin control plane route.</p></main>; }
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
+
+export const metadata = {
+  title: 'OneGodian App | Admin',
+  description: 'Production-safe control plane placeholder for OneGodian administration.'
+};
+
+export default function AdminPage() {
+  return (
+    <ControlPlanePlaceholder
+      title="Admin"
+      layer="admin"
+      description="Reserved operator surface for future authenticated administration, policy controls, approvals, audit review, and system operations."
+      modules={['Authenticated administration', 'Policy controls', 'Approvals', 'Audit review']}
+    />
+  );
+}

--- a/src/app/(app)/commerce/page.tsx
+++ b/src/app/(app)/commerce/page.tsx
@@ -14,14 +14,6 @@ export default function CommercePage() {
           <h2 className="text-xl font-semibold">Commerce Node</h2>
           <a href="https://onegodian.com" target="_blank" rel="noreferrer" className="mt-2 inline-block text-cyan-300">https://onegodian.com</a>
         </article>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Commerce & Identity Product Engine</h1><p className="text-slate-300">OneGodian.com is the primary commerce and identity product engine for ONEGODIAN, LLC.</p><a className="inline-block rounded-lg border border-cyan-400/40 px-4 py-2 text-cyan-200" href="https://onegodian.com" target="_blank" rel="noreferrer">Open OneGodian.com</a></main>; }
-export default function CommercePage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Commerce + Identity Engine</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
-        <p>OneGodian.com is the commerce and identity product engine for ONEGODIAN, LLC offerings including media, education products, software-linked goods, and member-linked services.</p>
-        <p>Commerce operations are managed as private commercial infrastructure with product identity, fulfillment, and campaign integration.</p>
       </section>
     </main>
   );

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,28 +1,3 @@
-const portals = [
-  ['OneGodian.org', 'Public identity, writings, remembrance, and institutional context.', 'https://onegodian.org'],
-  ['OneGodian.com', 'Commerce and identity product engine for products, memberships, and checkout.', 'https://onegodian.com'],
-  ['u.OneGodian.com', 'Education and LMS pathways for courses and learning records.', 'https://u.onegodian.org'],
-  ['app.OneGodian.com', 'Public/member app for dashboard, routes, and runtime tools.', 'https://app.onegodian.com'],
-  ['galaxy.OneGodian.com', 'Galaxy/planetary experiences, media, and world surfaces.', 'https://galaxy.onegodian.com'],
-  ['OMOS.OneGodian.com', 'OMOS specification and runtime documentation.', 'https://omos.onegodian.com'],
-  ['QuantumOHI.com', 'OHI systems architecture and intelligence positioning.', 'https://quantumohi.com'],
-  ['QRV.Network', 'Verification infrastructure network and credential trust rails.', 'https://qrv.network']
-] as const;
-
-export default function EcosystemPage() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">Live ecosystem map across public, education, commerce, app, protocol, and verification properties.</p><section className="grid gap-4 md:grid-cols-2">{portals.map((p)=><article key={p[0]} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="font-semibold">{p[0]}</h2><p className="text-sm text-slate-300">{p[1]}</p><a href={p[2]} target="_blank" rel="noreferrer" className="text-cyan-300">{p[2]}</a></article>)}</section></main>;
-  ['OneGodian.org', 'https://onegodian.org', 'Public institution-facing website and cultural/education communication.'],
-  ['OneGodian.com', 'https://onegodian.com', 'Commerce and identity product engine for products, memberships, and digital delivery.'],
-  ['u.OneGodian.com', 'https://u.onegodian.com', 'Learning and curriculum platform.'],
-  ['app.OneGodian.com', 'https://app.onegodian.com', 'Public/member app dashboard and route node.'],
-  ['galaxy.OneGodian.com', 'https://galaxy.onegodian.com', 'Galaxy/world platform and discovery layer.'],
-  ['OMOS.OneGodian.com', 'https://omos.onegodian.com', 'OMOS specification and runtime documents.'],
-  ['QuantumOHI.com', 'https://quantumohi.com', 'Quantum OHI architecture and model context.'],
-  ['QRV.Network', 'https://qrv.network', 'Verification network for trusted records and credentials.']
-] as const;
-
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">This page maps the live OneGodian ecosystem and explains how each production property serves public access, member workflows, and platform operations.</p><div className="grid gap-4 md:grid-cols-2">{portals.map(([name, href, desc]) => <article key={name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><a href={href} className="text-cyan-300" target="_blank" rel="noreferrer">{name}</a><p className="mt-2 text-sm text-slate-300">{desc}</p></article>)}</div></main>;
 import { ecosystemPortals } from '@/lib/onegodian-content';
 
 export default function EcosystemPage() {
@@ -31,11 +6,11 @@ export default function EcosystemPage() {
       <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
       <p className="text-slate-300">Connected properties across identity, commerce, education, runtime systems, and verification infrastructure.</p>
       <section className="grid gap-4 md:grid-cols-2">
-        {ecosystemPortals.map((p) => (
-          <article key={p.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-            <h2 className="font-semibold">{p.name}</h2>
-            <p className="text-sm text-slate-300">{p.role}</p>
-            <a href={p.url} target="_blank" rel="noreferrer" className="text-cyan-300">{p.url}</a>
+        {ecosystemPortals.map((portal) => (
+          <article key={portal.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+            <h2 className="font-semibold">{portal.name}</h2>
+            <p className="text-sm text-slate-300">{portal.role}</p>
+            <a href={portal.url} target="_blank" rel="noreferrer" className="text-cyan-300">{portal.url}</a>
           </article>
         ))}
       </section>

--- a/src/app/(app)/institutional/page.tsx
+++ b/src/app/(app)/institutional/page.tsx
@@ -1,11 +1,11 @@
-export default function InstitutionalPage(){return <main className='space-y-6'><section className='rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6'><h1 className='text-3xl font-bold'>Institutional Clarity</h1><p className='mt-2 text-slate-300'>Clear separation between commercial operations and internal governance/religious association context.</p></section><section className='rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300 space-y-2'><p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.</p><p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p><p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></section></main>}
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">Institutional Clarity</h1><p className="text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating products, platforms, and digital services.</p><p className="text-slate-300">INO is a separate voluntary internal governance/religious association structure used for internal community and cultural organization.</p><p className="text-slate-300">&quot;Sovereign&quot; in this context means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></main>;
 export default function InstitutionalPage() {
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">Institutional Clarity</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">Institutional Clarity</h1>
+        <p className="mt-2 text-slate-300">Clear separation between commercial operations and internal governance/religious association context.</p>
+      </section>
+      <section className="space-y-3 rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300">
         <p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity responsible for product operations, platforms, publishing, and technology execution.</p>
         <p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p>
         <p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p>

--- a/src/app/(app)/members/page.tsx
+++ b/src/app/(app)/members/page.tsx
@@ -7,11 +7,13 @@ export const metadata = {
 
 export default function MembersPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Members"
-      layer="member"
-      description="Reserved operational layer for future member identity, access levels, onboarding status, and administrative member support."
-      modules={['Member identity', 'Access levels', 'Onboarding status', 'Member support queue']}
-    />
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ControlPlanePlaceholder
+        title="Members"
+        layer="member"
+        description="Reserved operational layer for future member identity, access levels, onboarding status, and administrative member support."
+        modules={['Member identity', 'Access levels', 'Onboarding status', 'Member support queue']}
+      />
+    </main>
   );
 }

--- a/src/app/(app)/members/page.tsx
+++ b/src/app/(app)/members/page.tsx
@@ -1,11 +1,17 @@
-const endpoints = [
-  '/wp-json/onegodian-members/v1/health',
-  '/wp-json/onegodian-members/v1/manifest',
-  '/wp-json/onegodian-members/v1/me',
-  '/wp-json/onegodian-members/v1/admin/summary'
-];
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
+
+export const metadata = {
+  title: 'OneGodian App | Members',
+  description: 'Production-safe control plane placeholder for OneGodian members.'
+};
 
 export default function MembersPage() {
-  return <main className="space-y-6"><section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">Members</h1><p className="mt-2 text-slate-300">Member dashboard, certificate access, resources, pricing levels, tools, and admin handoff.</p></section>
-  <section className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">Member Access Levels</h2><p className="mt-2 text-sm text-slate-300">Starter, Contributor, Institutional, and Operator tiers with role-based permissions placeholder.</p></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="font-semibold">REST Endpoints</h2><ul className="mt-2 list-disc pl-5 text-sm text-cyan-300">{endpoints.map((ep)=><li key={ep}>{ep}</li>)}</ul></article></section></main>;
+  return (
+    <ControlPlanePlaceholder
+      title="Members"
+      layer="member"
+      description="Reserved operational layer for future member identity, access levels, onboarding status, and administrative member support."
+      modules={['Member identity', 'Access levels', 'Onboarding status', 'Member support queue']}
+    />
+  );
 }

--- a/src/app/(app)/membership/page.tsx
+++ b/src/app/(app)/membership/page.tsx
@@ -4,23 +4,12 @@ export default function MembershipPage() {
   return (
     <main className="space-y-6">
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Membership</h1>
-        <p className="mt-2 text-slate-300">Membership pathways, records access, and participation tools across the OneGodian App.</p>
+        <h1 className="text-3xl font-bold">OneGodian Membership</h1>
+        <p className="mt-2 text-slate-300">Membership pathways for profile records, campaign participation, tools, and platform learning resources.</p>
       </section>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300">
-        <p>Use this page as the public-facing membership entry, then continue into member workflows and dashboard tools.</p>
-        <div className="mt-3 flex gap-4">
-          <Link href="/members" className="text-cyan-300">Open members module</Link>
-          <Link href="/dashboard" className="text-cyan-300">Open dashboard</Link>
-        </div>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Membership</h1><p className="text-slate-300">Membership provides dashboard-linked participation paths, identity services, and voluntary community features across the OneGodian ecosystem.</p></main>; }
-export default function MembershipPage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Membership</h1>
       <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300">
-        <p>Membership provides access to profile records, campaign participation, tools, and platform learning resources.</p>
-        <p className="mt-2">Dashboard entry is available from the member node and remains compatible with admin/control-plane reporting via manifest and status surfaces.</p>
+        <p>Dashboard entry is available from the member node and remains compatible with admin/control-plane reporting via manifest and status surfaces.</p>
+        <Link href="/dashboard" className="mt-4 inline-block text-cyan-300">Open dashboard</Link>
       </section>
     </main>
   );

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,40 +1,19 @@
-const mindMap = [
-  'Protocol and algorithm orchestration',
-  'Identity and remembrance modeling',
-  'Runtime route and manifest governance',
-  'Tooling and bridge integrations',
-  'Time and chronology references (OTS-V5)',
-  'Documentation for public/member and admin compatibility'
-const omosModules = [
-  'Identity & Consciousness Layer',
-  'Belief Mapping & Meaning Layer',
-  'Ethics, Responsibility, and Conduct Layer',
-  'Language, Ritual, and Cultural Signal Layer',
-  'Application, Protocol, and Runtime Layer'
-];
-
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1><p className="text-slate-300">OMOS organizes OneGodian operations into interoperable layers that bridge thought, language, governance, and deployable application behavior.</p><ul className="list-disc space-y-2 pl-5 text-slate-300">{omosModules.map((m) => <li key={m}>{m}</li>)}</ul><p className="text-sm text-slate-400">Manifest/API visibility: this route is registered in the public manifest and available to dashboard, admin monitoring, and app status surfaces.</p></main>;
 export default function OmosPage() {
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OMOS — OneGodian Metaphysical Operating System</h1><p className="mt-2 text-slate-300">OMOS is the structured operating model for OneGodian protocols, routes, tools, time, and synchronized application behaviors.</p></header><section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="text-xl font-semibold">OMOS Mind Map Coverage</h2><ul className="mt-2 list-disc pl-6 text-sm text-slate-300">{mindMap.map((item)=><li key={item}>{item}</li>)}</ul></section></main>;
-  const omosMindMap = [
-    'Identity architecture and remembrance framework',
-    'Consciousness alignment protocol layers',
-    'Ethics, reflection, and participation modules',
-    'Public app and dashboard synchronization',
-    'Manifest/API interoperability for ecosystem apps'
-  ];
+  const modules = ['Manifest', 'Pages', 'Health', 'Sync', 'Plugins', 'Properties'];
 
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1>
-      <p className="text-slate-300">OMOS content maps metaphysical operating concepts into practical app modules, governance boundaries, and platform synchronization.</p>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-        <ul className="list-disc space-y-1 pl-5 text-sm text-slate-300">
-          {omosMindMap.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+        <h1 className="text-3xl font-bold">OMOS Runtime</h1>
+        <p className="mt-2 text-slate-300">OneGodian Metaphysical Operating System public runtime context, sync routes, and bridge surfaces.</p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {modules.map((module) => (
+          <article key={module} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+            <h2 className="font-semibold text-cyan-200">{module}</h2>
+            <p className="mt-2 text-sm text-slate-300">Public OMOS {module.toLowerCase()} surface.</p>
+          </article>
+        ))}
       </section>
     </main>
   );

--- a/src/app/(app)/registry/page.tsx
+++ b/src/app/(app)/registry/page.tsx
@@ -1,7 +1,17 @@
-export const metadata = { title: 'OneGodian App | Registry', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
 
-import { AppShell } from '@/components/app-shell';
+export const metadata = {
+  title: 'OneGodian App | Registry',
+  description: 'Production-safe control plane placeholder for the OneGodian registry.'
+};
 
 export default function RegistryPage() {
-  return <AppShell title="ODIN Registry" modules={[{ title: 'ODIN Registry™', description: 'Open the ODIN landing and navigation hub.', href: '/odin' }, { title: 'ODIN-PR Planetary Registry', description: 'Browse PR-001 through PR-025 worlds.', href: '/odin/planetary-registry' }, { title: 'PaaP™ Platforms', description: 'Review the 3-layer Canon / Platform / Store model.', href: '/odin/platforms' }]} />;
+  return (
+    <ControlPlanePlaceholder
+      title="Registry"
+      layer="registry"
+      description="Reserved operational layer for future entity, module, artifact, certificate, and ecosystem registry administration."
+      modules={['Entity registry', 'Module registry', 'Artifact registry', 'Ecosystem registry']}
+    />
+  );
 }

--- a/src/app/(app)/registry/page.tsx
+++ b/src/app/(app)/registry/page.tsx
@@ -7,11 +7,13 @@ export const metadata = {
 
 export default function RegistryPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Registry"
-      layer="registry"
-      description="Reserved operational layer for future entity, module, artifact, certificate, and ecosystem registry administration."
-      modules={['Entity registry', 'Module registry', 'Artifact registry', 'Ecosystem registry']}
-    />
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ControlPlanePlaceholder
+        title="Registry"
+        layer="registry"
+        description="Reserved operational layer for future entity, module, artifact, certificate, and ecosystem registry administration."
+        modules={['Entity registry', 'Module registry', 'Artifact registry', 'Ecosystem registry']}
+      />
+    </main>
   );
 }

--- a/src/app/(app)/remember/page.tsx
+++ b/src/app/(app)/remember/page.tsx
@@ -1,28 +1,12 @@
 import Link from 'next/link';
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian: Remember</h1><p className="text-slate-300">OneGodian: Remember is a public campaign inviting people to reconnect with identity, dignity, unity, and responsibility through practical action and shared memory.</p></main>; }
-import Link from 'next/link';
 import { rememberCampaign } from '@/lib/onegodian-content';
 
 export default function RememberPage() {
   return (
     <main className="space-y-6">
-      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
+      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
         <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Campaign</p>
         <h1 className="mt-2 text-3xl font-bold">OneGodian: Remember</h1>
-        <p className="mt-3 text-slate-300">You were always One — you simply forgot. Remember who you are.</p>
-      </section>
-      <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Campaign Intent</h2>
-          <p className="mt-2 text-sm text-slate-300">A public-safe awareness campaign focused on identity, remembrance, dignity, unity, and shared human connection.</p>
-        </article>
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Participation</h2>
-          <p className="mt-2 text-sm text-slate-300">Creators, members, and supporters can access campaign media, captions, releases, and distribution pathways from the dashboard.</p>
-          <Link href="/dashboard" className="mt-3 inline-block text-cyan-300">Open Dashboard</Link>
-        </article>
-      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian: Remember</h1>
         <p className="mt-2 text-slate-300">{rememberCampaign.message}</p>
         <p className="mt-2 text-sm text-cyan-300">Campaign start: {rememberCampaign.officialStartDate} · {rememberCampaign.onegodianDate}</p>
       </header>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,10 +1,17 @@
-export const metadata = { title: 'OneGodian App | Settings', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
+
+export const metadata = {
+  title: 'OneGodian App | Settings',
+  description: 'Production-safe control plane placeholder for OneGodian settings.'
+};
 
 export default function SettingsPage() {
   return (
-    <main className="px-6 py-8">
-      <h1 className="text-3xl font-semibold text-slate-100">Settings</h1>
-      <p className="mt-3 max-w-2xl text-slate-300">Configure your OneGodian app preferences, module defaults, and notification settings.</p>
-    </main>
+    <ControlPlanePlaceholder
+      title="Settings"
+      layer="settings"
+      description="Reserved operational layer for future tenant configuration, user preferences, security controls, and admin-managed defaults."
+      modules={['Tenant configuration', 'User preferences', 'Security controls', 'Admin-managed defaults']}
+    />
   );
 }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -7,11 +7,13 @@ export const metadata = {
 
 export default function SettingsPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Settings"
-      layer="settings"
-      description="Reserved operational layer for future tenant configuration, user preferences, security controls, and admin-managed defaults."
-      modules={['Tenant configuration', 'User preferences', 'Security controls', 'Admin-managed defaults']}
-    />
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ControlPlanePlaceholder
+        title="Settings"
+        layer="settings"
+        description="Reserved operational layer for future tenant configuration, user preferences, security controls, and admin-managed defaults."
+        modules={['Tenant configuration', 'User preferences', 'Security controls', 'Admin-managed defaults']}
+      />
+    </main>
   );
 }

--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -2,25 +2,12 @@ import { TodayInOneGodianTime } from '@/components/today-in-onegodian-time';
 
 export default function TimePage() {
   return (
-    <main className="p-6 text-slate-100 space-y-4">
+    <main className="space-y-6 p-6 text-slate-100">
       <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
       <p className="text-slate-300">Dual-date display pairs OneGodian Time for internal presentation with Gregorian/UTC records for external and legal continuity.</p>
       <TodayInOneGodianTime />
       <a href="/time/dual-dating" className="inline-block rounded-lg border border-cyan-400/50 bg-slate-900/70 px-4 py-2 text-cyan-200 transition hover:bg-cyan-500/10">Dual Dating System™</a>
       <p className="text-sm text-amber-200">Legal safety: Gregorian Time and UTC timestamps remain controlling for legal, financial, tax, court, contractual, and institutional records.</p>
-export default function Page() {
-  const gregorian = new Date().toISOString().slice(0, 10);
-  const ots = 'OTS-V5 active chronology view';
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Time™ · OTS-V5</h1><p className="text-slate-300">Dual-date view for platform coordination and historical references.</p><div className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">Gregorian Date</h2><p className="mt-2 text-slate-100">{gregorian}</p></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">OneGodian Date</h2><p className="mt-2 text-slate-100">{ots}</p></article></div><p className="text-sm text-slate-400">Legal safety notice: OneGodian Time™ is an internal cultural/system chronology aid. It does not replace legal, regulatory, tax, court, banking, or governmental date standards.</p></main>;
-export default function TimePage() {
-  return (
-    <main className="space-y-6 p-6 text-slate-100">
-      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-2">
-        <p>Dual-date display model: Gregorian civil date + OneGodian internal date notation for synchronized cultural references.</p>
-        <p>Example format: Gregorian Date (UTC) · OneGodian Date (OTS-V5 internal).</p>
-      </section>
-      <p className="text-sm text-amber-200">Legal safety: Gregorian calendar/time remains controlling for legal, financial, compliance, and external institutional matters.</p>
     </main>
   );
 }

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -7,11 +7,13 @@ export const metadata = {
 
 export default function ToolsPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Tools"
-      layer="tools"
-      description="Reserved operational surface for future command utilities, diagnostics, workflow launchers, and ecosystem tool access."
-      modules={['Command utilities', 'Diagnostics', 'Workflow launchers', 'Ecosystem tool access']}
-    />
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ControlPlanePlaceholder
+        title="Tools"
+        layer="tools"
+        description="Reserved operational surface for future command utilities, diagnostics, workflow launchers, and ecosystem tool access."
+        modules={['Command utilities', 'Diagnostics', 'Workflow launchers', 'Ecosystem tool access']}
+      />
+    </main>
   );
 }

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -1,7 +1,17 @@
-export const metadata = { title: 'OneGodian App | Tools', description: 'The official OneGodian App dashboard for identity, membership, certificates, systems, tools, campaigns, products, and ecosystem access.' };
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
 
-import { AppShell } from '@/components/app-shell';
+export const metadata = {
+  title: 'OneGodian App | Tools',
+  description: 'Production-safe control plane placeholder for OneGodian tools.'
+};
 
 export default function ToolsPage() {
-  return <AppShell title="Tools" modules={[{ title: 'Command Utilities', description: 'Operational tools for app diagnostics, sync workflows, and execution support.' }, { title: 'Data Connectors', description: 'Bridge ecosystem registries, member records, and product/media data.' }, { title: 'Automation', description: 'Run repeatable build and deployment workflows across modules.', href: '/production-checklist' }]} />;
+  return (
+    <ControlPlanePlaceholder
+      title="Tools"
+      layer="tools"
+      description="Reserved operational surface for future command utilities, diagnostics, workflow launchers, and ecosystem tool access."
+      modules={['Command utilities', 'Diagnostics', 'Workflow launchers', 'Ecosystem tool access']}
+    />
+  );
 }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,2 +1,23 @@
-import { NextResponse } from 'next/server';
-export async function GET() { return NextResponse.json({ app: 'OneGodian Control Plane', healthy: true, generatedAt: new Date().toISOString() }); }
+import { jsonResponse } from '@/lib/api-json';
+
+const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
+
+export async function GET(request: Request) {
+  return jsonResponse(
+    {
+      app: 'OneGodian App Control Plane',
+      route: '/api/stats',
+      status: 'placeholder',
+      labels,
+      statsAvailable: false,
+      modules: [
+        { name: 'Usage metrics', status: 'planned' },
+        { name: 'Operational health', status: 'planned' },
+        { name: 'Administrative reporting', status: 'planned' },
+        { name: 'Audit metrics', status: 'planned' }
+      ],
+      operationalNote: 'This endpoint reserves the stats API surface. It does not return live metrics until verified production data sources are integrated.'
+    },
+    request
+  );
+}

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,6 +1,5 @@
 import { jsonResponse } from '@/lib/api-json';
-
-const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
+import { controlPlanePlaceholderLabels } from '@/lib/control-plane';
 
 export async function GET(request: Request) {
   return jsonResponse(
@@ -8,7 +7,7 @@ export async function GET(request: Request) {
       app: 'OneGodian App Control Plane',
       route: '/api/stats',
       status: 'placeholder',
-      labels,
+      labels: controlPlanePlaceholderLabels,
       statsAvailable: false,
       modules: [
         { name: 'Usage metrics', status: 'planned' },

--- a/src/app/api/tools/route.ts
+++ b/src/app/api/tools/route.ts
@@ -1,6 +1,22 @@
-import data from '@/data/tools.json';
 import { jsonResponse } from '@/lib/api-json';
 
+const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
+
 export async function GET(request: Request) {
-  return jsonResponse({ status: 'ok', ...data }, request);
+  return jsonResponse(
+    {
+      app: 'OneGodian App Control Plane',
+      route: '/api/tools',
+      status: 'placeholder',
+      labels,
+      modules: [
+        { name: 'Command utilities', status: 'planned' },
+        { name: 'Diagnostics', status: 'planned' },
+        { name: 'Workflow launchers', status: 'planned' },
+        { name: 'Ecosystem tool access', status: 'planned' }
+      ],
+      operationalNote: 'This endpoint reserves the tools API surface. It does not expose executable backend tools until admin integration is present.'
+    },
+    request
+  );
 }

--- a/src/app/api/tools/route.ts
+++ b/src/app/api/tools/route.ts
@@ -1,6 +1,6 @@
+import data from '@/data/tools.json';
 import { jsonResponse } from '@/lib/api-json';
-
-const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
+import { controlPlanePlaceholderLabels } from '@/lib/control-plane';
 
 export async function GET(request: Request) {
   return jsonResponse(
@@ -8,14 +8,15 @@ export async function GET(request: Request) {
       app: 'OneGodian App Control Plane',
       route: '/api/tools',
       status: 'placeholder',
-      labels,
+      labels: controlPlanePlaceholderLabels,
+      existingRegistry: data.tools,
       modules: [
         { name: 'Command utilities', status: 'planned' },
         { name: 'Diagnostics', status: 'planned' },
         { name: 'Workflow launchers', status: 'planned' },
         { name: 'Ecosystem tool access', status: 'planned' }
       ],
-      operationalNote: 'This endpoint reserves the tools API surface. It does not expose executable backend tools until admin integration is present.'
+      operationalNote: 'This endpoint reserves the tools API surface and preserves the existing static tool registry. It does not expose executable backend tools until admin integration is present.'
     },
     request
   );

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -1,25 +1,17 @@
-import { certificates } from '../data';
+import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
+
+export const metadata = {
+  title: 'OneGodian App | Certificates',
+  description: 'Production-safe control plane placeholder for OneGodian certificates.'
+};
 
 export default function CertificateRecordsPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <h1 className="text-3xl font-bold">Certificate Records</h1>
-      <p className="mt-2 text-slate-300">Review certificate record status, instrument references, and verification metadata.</p>
-      <div className="mt-5 rounded-xl border border-amber-500/40 bg-amber-900/20 p-4 text-sm text-amber-100">
-        Certificate records displayed in this portal are administrative records for documentation, verification support, and audit review. A listed record does not replace executed agreements, disclosure review, payment confirmation, legal review, or final internal acceptance.
-      </div>
-      <div className="mt-6 grid gap-4 md:grid-cols-2">
-        {certificates.map((record) => (
-          <article key={record.recordId} className="rounded-xl border border-slate-700 bg-slate-900/70 p-5">
-            <p><strong>Record ID:</strong> {record.recordId}</p>
-            <p><strong>Instrument Reference:</strong> {record.instrumentReference}</p>
-            <p><strong>Holder Reference:</strong> {record.holderReference}</p>
-            <p><strong>Record Status:</strong> {record.recordStatus}</p>
-            <p><strong>Issuance Status:</strong> {record.issuanceStatus}</p>
-            <p><strong>Verification Metadata:</strong> {record.verificationMetadata}</p>
-          </article>
-        ))}
-      </div>
-    </main>
+    <ControlPlanePlaceholder
+      title="Certificates"
+      layer="certificate"
+      description="Reserved operational layer for future certificate issuance, verification records, holder lookups, and audit-ready certificate administration."
+      modules={['Certificate issuance', 'Verification records', 'Holder lookups', 'Certificate audit trail']}
+    />
   );
 }

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -1,4 +1,5 @@
 import { ControlPlanePlaceholder } from '@/components/control-plane-placeholder';
+import { certificates } from '../data';
 
 export const metadata = {
   title: 'OneGodian App | Certificates',
@@ -7,11 +8,35 @@ export const metadata = {
 
 export default function CertificateRecordsPage() {
   return (
-    <ControlPlanePlaceholder
-      title="Certificates"
-      layer="certificate"
-      description="Reserved operational layer for future certificate issuance, verification records, holder lookups, and audit-ready certificate administration."
-      modules={['Certificate issuance', 'Verification records', 'Holder lookups', 'Certificate audit trail']}
-    />
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-10 text-slate-100">
+      <ControlPlanePlaceholder
+        title="Certificates"
+        layer="certificate"
+        description="Reserved operational layer for future certificate issuance, verification records, holder lookups, and audit-ready certificate administration."
+        modules={['Certificate issuance', 'Verification records', 'Holder lookups', 'Certificate audit trail']}
+      />
+
+      <section className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5">
+        <h2 className="text-2xl font-bold">Existing certificate record references</h2>
+        <p className="mt-2 text-slate-300">
+          These existing records remain visible for documentation and audit review only. They do not create new issuance, payment, legal, or verification functionality.
+        </p>
+        <div className="mt-5 rounded-xl border border-amber-500/40 bg-amber-900/20 p-4 text-sm text-amber-100">
+          Certificate records displayed in this portal are administrative records for documentation, verification support, and audit review. A listed record does not replace executed agreements, disclosure review, payment confirmation, legal review, or final internal acceptance.
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          {certificates.map((record) => (
+            <article key={record.recordId} className="rounded-xl border border-slate-700 bg-slate-950/70 p-5">
+              <p><strong>Record ID:</strong> {record.recordId}</p>
+              <p><strong>Instrument Reference:</strong> {record.instrumentReference}</p>
+              <p><strong>Holder Reference:</strong> {record.holderReference}</p>
+              <p><strong>Record Status:</strong> {record.recordStatus}</p>
+              <p><strong>Issuance Status:</strong> {record.issuanceStatus}</p>
+              <p><strong>Verification Metadata:</strong> {record.verificationMetadata}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,11 @@ const routes = [
   { href: '/time', label: 'Time' },
   { href: '/commerce', label: 'Commerce' },
   { href: '/institutional', label: 'Institutional' },
+  { href: '/tools', label: 'Tools' },
+  { href: '/certificates', label: 'Certificates' },
+  { href: '/registry', label: 'Registry' },
+  { href: '/members', label: 'Members' },
+  { href: '/settings', label: 'Settings' },
   { href: '/dashboard', label: 'Dashboard' }
 ];
 
@@ -18,7 +23,7 @@ export default function HomePage() {
         <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8">
           <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App</p>
           <h1 className="mt-2 text-4xl font-bold">Live Public + Member Application Node</h1>
-          <p className="mt-3 text-slate-300">Production content routes for ecosystem, OMOS, remembrance, membership, time, commerce, and institutional clarity.</p>
+          <p className="mt-3 text-slate-300">Production content routes for ecosystem, OMOS, remembrance, membership, time, commerce, institutional clarity, and planned control-plane surfaces.</p>
         </section>
         <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {routes.map((route) => (
@@ -30,16 +35,4 @@ export default function HomePage() {
       </div>
     </main>
   );
-const links = [
-  { title: 'Ecosystem', href: '/ecosystem' },
-  { title: 'OMOS', href: '/omos' },
-  { title: 'Remember', href: '/remember' },
-  { title: 'Membership', href: '/membership' },
-  { title: 'Time', href: '/time' },
-  { title: 'Commerce', href: '/commerce' },
-  { title: 'Institutional', href: '/institutional' }
-];
-
-export default function HomePage() {
-  return <main className="space-y-8"><section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8"><p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App · Live</p><h1 className="mt-3 text-4xl font-bold">Public OneGodian App Node</h1><p className="mt-4 max-w-4xl text-slate-300">This production app provides public-safe ecosystem content, campaign access, membership entry points, time references, commerce routing, and institutional clarity.</p></section><section className="grid gap-4 md:grid-cols-2">{links.map((item) => <Link key={item.href} href={item.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 hover:border-cyan-400/60"><h2 className="text-xl font-semibold text-cyan-200">{item.title}</h2><p className="mt-2 text-sm text-slate-300">Open {item.href}</p></Link>)}</section></main>;
 }

--- a/src/components/control-plane-placeholder.tsx
+++ b/src/components/control-plane-placeholder.tsx
@@ -1,3 +1,5 @@
+import { controlPlanePlaceholderLabels } from '@/lib/control-plane';
+
 type ControlPlanePlaceholderProps = {
   title: string;
   description: string;
@@ -5,25 +7,22 @@ type ControlPlanePlaceholderProps = {
   modules: string[];
 };
 
-const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
 
 export function ControlPlanePlaceholder({ title, description, layer, modules }: ControlPlanePlaceholderProps) {
   return (
-    <main className="mx-auto max-w-6xl space-y-6 px-4 py-10 text-slate-100">
-      <section className="rounded-3xl border border-cyan-400/30 bg-slate-950/80 p-6 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
-        <div className="flex flex-wrap gap-2">
-          {labels.map((label) => (
-            <span key={label} className="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
-              {label}
-            </span>
-          ))}
-        </div>
-        <p className="mt-6 text-sm font-semibold uppercase tracking-[0.25em] text-amber-200">OneGodian App Control Plane</p>
-        <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">{title}</h1>
-        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">{description}</p>
-      </section>
+    <section className="rounded-3xl border border-cyan-400/30 bg-slate-950/80 p-6 text-slate-100 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
+      <div className="flex flex-wrap gap-2">
+        {controlPlanePlaceholderLabels.map((label) => (
+          <span key={label} className="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
+            {label}
+          </span>
+        ))}
+      </div>
+      <p className="mt-6 text-sm font-semibold uppercase tracking-[0.25em] text-amber-200">OneGodian App Control Plane</p>
+      <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">{title}</h1>
+      <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">{description}</p>
 
-      <section className="grid gap-4 md:grid-cols-3">
+      <div className="mt-6 grid gap-4 md:grid-cols-3">
         <article className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5 md:col-span-2">
           <h2 className="text-xl font-semibold text-white">Production-safe placeholder infrastructure</h2>
           <p className="mt-3 text-sm leading-6 text-slate-300">
@@ -36,9 +35,9 @@ export function ControlPlanePlaceholder({ title, description, layer, modules }: 
             Actions, metrics, records, mutations, and administrative controls are intentionally withheld when they are not already backed by production services.
           </p>
         </article>
-      </section>
+      </div>
 
-      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-5">
+      <div className="mt-5 rounded-2xl border border-slate-700 bg-slate-900/60 p-5">
         <h2 className="text-lg font-semibold text-white">Planned module boundaries</h2>
         <ul className="mt-4 grid gap-3 md:grid-cols-2">
           {modules.map((module) => (
@@ -48,7 +47,7 @@ export function ControlPlanePlaceholder({ title, description, layer, modules }: 
             </li>
           ))}
         </ul>
-      </section>
-    </main>
+      </div>
+    </section>
   );
 }

--- a/src/components/control-plane-placeholder.tsx
+++ b/src/components/control-plane-placeholder.tsx
@@ -1,0 +1,54 @@
+type ControlPlanePlaceholderProps = {
+  title: string;
+  description: string;
+  layer: string;
+  modules: string[];
+};
+
+const labels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];
+
+export function ControlPlanePlaceholder({ title, description, layer, modules }: ControlPlanePlaceholderProps) {
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-10 text-slate-100">
+      <section className="rounded-3xl border border-cyan-400/30 bg-slate-950/80 p-6 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
+        <div className="flex flex-wrap gap-2">
+          {labels.map((label) => (
+            <span key={label} className="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
+              {label}
+            </span>
+          ))}
+        </div>
+        <p className="mt-6 text-sm font-semibold uppercase tracking-[0.25em] text-amber-200">OneGodian App Control Plane</p>
+        <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">{title}</h1>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">{description}</p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5 md:col-span-2">
+          <h2 className="text-xl font-semibold text-white">Production-safe placeholder infrastructure</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            This route reserves the {layer} control-plane surface without claiming active backend behavior. Integration points stay inactive until an authenticated admin service, verified data source, and audit workflow are connected.
+          </p>
+        </article>
+        <article className="rounded-2xl border border-amber-400/30 bg-amber-950/30 p-5">
+          <h2 className="text-xl font-semibold text-amber-100">No fake functionality</h2>
+          <p className="mt-3 text-sm leading-6 text-amber-50/80">
+            Actions, metrics, records, mutations, and administrative controls are intentionally withheld when they are not already backed by production services.
+          </p>
+        </article>
+      </section>
+
+      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-5">
+        <h2 className="text-lg font-semibold text-white">Planned module boundaries</h2>
+        <ul className="mt-4 grid gap-3 md:grid-cols-2">
+          {modules.map((module) => (
+            <li key={module} className="rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-300">
+              <span className="font-semibold text-cyan-200">{module}</span>
+              <span className="mt-1 block text-xs uppercase tracking-[0.2em] text-slate-500">Requires Admin Integration</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -2,7 +2,6 @@
   "name": "OMOS Runtime",
   "fullName": "OneGodian Metaphysical Operating System™",
   "version": "1.1.0",
-  "version": "1.0.2",
   "status": "production",
   "canonical_domain": "omos.onegodian.com",
   "purpose": "Public runtime for OneGodian routes, page registry, and manifest delivery.",
@@ -18,23 +17,21 @@
     "/time",
     "/commerce",
     "/institutional",
+    "/tools",
+    "/certificates",
+    "/registry",
+    "/members",
+    "/settings",
+    "/admin",
     "/api/health",
     "/api/manifest",
-    "/api/pages"
-  ]
     "/api/pages",
     "/api/tools",
-    "/api/artifacts",
-    "/api/system-health"
+    "/api/stats"
   ],
-  "fullName": "OneGodian Metaphysical Operating System™",
   "classification": "Node runtime, protocol documentation, and agent-facing integration site",
   "canonicalHost": "https://omos.onegodian.com",
-  "compatibleHosts": [
-    "https://onegodian.com",
-    "https://onegodian.org",
-    "https://quantumohi.com"
-  ],
+  "compatibleHosts": ["https://onegodian.com", "https://onegodian.org", "https://quantumohi.com"],
   "appBridge": ["https://app.onegodian.com"],
   "commerceBridge": ["https://onegodian.com"]
 }

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -5,15 +5,6 @@ export const appHomeHero = {
     'Unified OneGodian public/member application for ecosystem navigation, OMOS content, time systems, campaign pages, and dashboard access.',
   primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
   secondaryCta: { label: 'Explore Ecosystem', href: '/ecosystem' }
-    'Your unified OneGodian dashboard for membership, campaigns, commerce, OMOS, time, and ecosystem access.',
-  primaryCta: {
-    label: 'Open Dashboard',
-    href: '/dashboard'
-  },
-  secondaryCta: {
-    label: 'Explore Ecosystem',
-    href: '/ecosystem'
-  }
 };
 
 export const appNavigation = [
@@ -25,6 +16,10 @@ export const appNavigation = [
   { label: 'Time', href: '/time' },
   { label: 'Commerce', href: '/commerce' },
   { label: 'Institutional', href: '/institutional' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Registry', href: '/registry' },
+  { label: 'Members', href: '/members' },
+  { label: 'Settings', href: '/settings' },
   { label: 'Sitemap', href: '/sitemap' }
 ];
 
@@ -32,79 +27,21 @@ export const appDashboardCards = [
   { title: 'Ecosystem', description: 'Platform map spanning public, app, commerce, education, OMOS, and verification nodes.', href: '/ecosystem', status: 'Active' },
   { title: 'OMOS', description: 'OneGodian Metaphysical Operating System mind map, protocol, and runtime context.', href: '/omos', status: 'Live' },
   { title: 'Remember', description: 'OneGodian: Remember campaign page and participant resource entry.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Membership entry route for public and dashboard handoff.', href: '/membership', status: 'Available' },
-  { title: 'Time', description: 'OneGodian Time™ / OTS-V5 route with dual-date and legal safety language.', href: '/time', status: 'Active' },
-  { title: 'Commerce', description: 'OneGodian.com commerce and identity product engine route.', href: '/commerce', status: 'Active' },
-  { title: 'Institutional Clarity', description: 'Separation of ONEGODIAN, LLC operations and INO internal governance context.', href: '/institutional', status: 'Active' }
+  { title: 'Membership', description: 'Access member pathways, dashboard entry, and community participation options.', href: '/membership', status: 'Planned' },
+  { title: 'Certificates', description: 'Review certificate records and future verification handoff surfaces.', href: '/certificates', status: 'Planned' },
+  { title: 'Tools', description: 'Reserved control-plane tools surface for future admin-integrated operations.', href: '/tools', status: 'Planned' }
 ];
 
 export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public identity and writings.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Education and LMS node.', url: 'https://u.onegodian.org' },
-  { name: 'app.OneGodian.com', role: 'Public/member app node.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'Galaxy platform surface.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'OMOS protocol and runtime docs.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI systems positioning.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network.', url: 'https://qrv.network' }
+  { name: 'OneGodian.org', role: 'Public identity, writings, remembrance, and institutional context.', url: 'https://onegodian.org' },
+  { name: 'OneGodian.com', role: 'Commerce and identity product engine for products, memberships, and checkout.', url: 'https://onegodian.com' },
+  { name: 'u.OneGodian.com', role: 'Education and LMS pathways for courses and learning records.', url: 'https://u.onegodian.com' },
+  { name: 'app.OneGodian.com', role: 'Public/member app for dashboard, routes, and runtime tools.', url: 'https://app.onegodian.com' },
+  { name: 'Galaxy OneGodian', role: 'Galaxy/planetary experiences, media, and world surfaces.', url: 'https://galaxy.onegodian.com' },
+  { name: 'OMOS OneGodian', role: 'OMOS specification and runtime documentation.', url: 'https://omos.onegodian.com' },
+  { name: 'QuantumOHI.com', role: 'OHI systems architecture and intelligence positioning.', url: 'https://quantumohi.com' },
+  { name: 'QRV.Network', role: 'Verification infrastructure network and credential trust rails.', url: 'https://qrv.network' }
 ];
 
 export const appFooterBoundary =
-  'OneGodian App is the public/member-facing surface. Admin/control panel operations remain separate and compatible through dedicated internal surfaces.';
-];
-
-export const appDashboardCards = [
-  { title: 'Ecosystem', description: 'See live OneGodian ecosystem domains and operating roles.', href: '/ecosystem', status: 'Live' },
-  { title: 'OMOS', description: 'Review the OneGodian Metaphysical Operating System structure and modules.', href: '/omos', status: 'Live' },
-  { title: 'Remember Campaign', description: 'Read the public OneGodian: Remember campaign story and participation guidance.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Access member pathways, dashboard entry, and community participation options.', href: '/membership', status: 'Live' },
-  { title: 'Time · OTS-V5', description: 'Use OneGodian Time™ with dual-date display and legal-safe chronology notes.', href: '/time', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com as the commerce and identity product engine.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'See the legal and operational distinction between ONEGODIAN, LLC and INO.', href: '/institutional', status: 'Live' }
-];
-
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public presence, education, and institutional identity.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine for memberships and products.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Learning pathways, course delivery, and student services.', url: 'https://u.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public/member app dashboard and route layer.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'World, platform, and story navigation surfaces.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'Protocol and operating system specification node.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI architecture and model context.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network and record trust infrastructure.', url: 'https://qrv.network' }
-  { label: 'Architecture', href: '/architecture' },
-  { label: 'About', href: '/about' },
-  { label: 'Sitemap', href: '/sitemap' },
-  { label: 'Membership', href: '/membership' },
-  { label: 'Commerce', href: '/commerce' },
-  { label: 'Remember', href: '/remember' },
-  { label: 'Institutional', href: '/institutional' }
-];
-
-export const appDashboardCards = [
-  { title: 'My OneGodian Profile', description: 'View your profile, identity details, membership status, and dashboard access.', href: '/profile', status: 'Active' },
-  { title: 'Membership', description: 'Access OneGodian membership records, benefits, onboarding, and participation tools.', href: '/members', status: 'Available' },
-  { title: 'Certificates', description: 'View and verify OneGodian certificates, completion records, and issued documents.', href: '/certificates', status: 'Available' },
-  { title: 'Remember Campaign', description: 'Access THE ONEGODIAN: Remember Campaign resources, media, captions, and participation tools.', href: '/remember', status: 'Live' },
-  { title: 'Membership Hub', description: 'Open membership records, onboarding, benefits, and participation routes.', href: '/membership', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com commerce and identity engine context.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'Review institutional boundary language for LLC and INO contexts.', href: '/institutional', status: 'Live' },
-  { title: 'Media Center', description: 'Access OneGodian media, campaign visuals, music, videos, and brand assets.', href: '/media', status: 'Available' },
-  { title: 'Products', description: 'Explore OneGodian products, digital downloads, apparel, books, and ecosystem offerings.', href: '/products', status: 'Available' },
-  { title: 'Learning', description: 'Connect to U OneGodian courses, learning paths, student tools, and educational programs.', href: '/learning', status: 'Connected' },
-  { title: 'Ecosystem', description: 'Navigate OneGodian.org, OneGodian.com, U OneGodian, Galaxy, Capital, OMOS, and Console.', href: '/ecosystem', status: 'Active' }
-];
-
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Official public identity, writings, remembrance, articles, and institutional explanation.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Store, products, memberships, commerce, apparel, books, and digital downloads.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Education, LMS, learning paths, student tools, and certificates.', url: 'https://u.onegodian.com' },
-  { name: 'Galaxy OneGodian', role: 'Galaxy interface, planet navigator, planet-store gateway, and immersive ecosystem layer.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS OneGodian', role: 'OMOS protocol, specification, alignment system, and consciousness-centered operating model.', url: 'https://omos.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context for OneGodian ecosystem design.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification and trust infrastructure connected to OneGodian records and identity workflows.', url: 'https://qrv.network' }
-];
-
-export const appFooterBoundary =
-  'OneGodian App is the public/member node. Admin/control functions remain in designated console and control panel surfaces.';
+  'OneGodian App is the public/member-facing surface. Admin and control-panel operations remain separate until authenticated integrations are connected.';

--- a/src/lib/app-sitemap.ts
+++ b/src/lib/app-sitemap.ts
@@ -13,54 +13,16 @@ export const appSitemap: AppRouteNode[] = [
   { title: 'Sitemap', path: '/sitemap', group: 'Core', description: 'Public route map for app.onegodian.com.', status: 'active' },
   { title: 'Systems Model', path: '/systems-model', group: 'Core', description: 'Public systems model.', status: 'active' },
   { title: 'Ecosystem', path: '/ecosystem', group: 'Core', description: 'OneGodian ecosystem portals.', status: 'active' },
-  { title: 'Apps', path: '/apps', group: 'Core', description: 'Application node index.', status: 'active' },
-  { title: 'Plugins', path: '/plugins', group: 'Core', description: 'Plugin inventory and status.', status: 'active' },
-  { title: 'API Status', path: '/api-status', group: 'Operations', description: 'App API status snapshot.', status: 'active' },
-  { title: 'System Health', path: '/system-health', group: 'Operations', description: 'App + OMOS health dashboard.', status: 'active' },
-  {
-    title: 'OMOS', path: '/omos', group: 'OMOS', description: 'OMOS protocol/runtime public dashboard.', status: 'active', children: [
-      { title: 'Manifest', path: '/omos/manifest', group: 'OMOS', description: 'Manifest view sourced via app APIs.', status: 'active' },
-      { title: 'Pages', path: '/omos/pages', group: 'OMOS', description: 'Synced page registry from OMOS.', status: 'active' },
-      { title: 'Health', path: '/omos/health', group: 'OMOS', description: 'OMOS health endpoint status.', status: 'active' },
-      { title: 'Sync', path: '/omos/sync', group: 'OMOS', description: 'OMOS sync telemetry from app API.', status: 'active' },
-      { title: 'Plugins', path: '/omos/plugins', group: 'OMOS', description: 'OMOS plugin state from sync APIs.', status: 'active' },
-      { title: 'Properties', path: '/omos/properties', group: 'OMOS', description: 'OMOS property dataset from sync APIs.', status: 'active' }
-    ]
-  },
-  {
-    title: 'Architecture', path: '/architecture', group: 'Architecture', description: 'Architecture overview for public app node.', status: 'active', children: [
-      { title: 'OHI', path: '/architecture/ohi', group: 'Architecture', description: 'OHI layer role.', status: 'active' },
-      { title: 'Runtime', path: '/architecture/runtime', group: 'Architecture', description: 'Runtime model.', status: 'active' },
-      { title: 'Interfaces', path: '/architecture/interfaces', group: 'Architecture', description: 'Public/member interface boundaries.', status: 'active' },
-      { title: 'Infrastructure', path: '/architecture/infrastructure', group: 'Architecture', description: 'Infrastructure concerns.', status: 'active' },
-      { title: 'OMOS Sync', path: '/architecture/omos-sync', group: 'Architecture', description: 'OMOS sync pathway.', status: 'active' }
-    ]
-  },
-  {
-    title: 'Algorithm', path: '/algorithm', group: 'Algorithm', description: 'OneGodian algorithm overview.', status: 'active', children: [
-      { title: 'Protocol', path: '/algorithm/protocol', group: 'Algorithm', description: 'Protocol perspective.', status: 'active' },
-      { title: 'Experience', path: '/algorithm/experience', group: 'Algorithm', description: 'Experience layer.', status: 'active' },
-      { title: 'Community', path: '/algorithm/community', group: 'Algorithm', description: 'Community layer.', status: 'active' },
-      { title: 'Orientation', path: '/algorithm/orientation', group: 'Algorithm', description: 'Orientation layer.', status: 'active' }
-    ]
-  },
-  { title: 'Registry', path: '/registry', group: 'Core', description: 'Public/member registry surface.', status: 'active' },
-  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time tools.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Core', description: 'OneGodian: Remember campaign page.', status: 'active' },
+  { title: 'OMOS', path: '/omos', group: 'OMOS', description: 'OMOS protocol/runtime public dashboard.', status: 'active' },
+  { title: 'Remember', path: '/remember', group: 'Campaigns', description: 'OneGodian: Remember campaign page.', status: 'active' },
   { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership entry route.', status: 'active' },
+  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time tools.', status: 'active' },
   { title: 'Commerce', path: '/commerce', group: 'Core', description: 'OneGodian commerce and identity engine route.', status: 'active' },
   { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional clarity and legal boundary route.', status: 'active' },
-
-  { title: 'Portfolio', path: '/portfolio', group: 'Core', description: 'Public portfolio snapshot.', status: 'active' },
-  { title: 'Records', path: '/records', group: 'Core', description: 'Public/member record index.', status: 'active' },
-  { title: 'Tools', path: '/tools', group: 'Core', description: 'Public tools collection.', status: 'active' }
-  { title: 'Home', path: '/', group: 'Core', description: 'OneGodian App public entry.', status: 'active' },
-  { title: 'Dashboard', path: '/dashboard', group: 'Core', description: 'Public/member dashboard entry.', status: 'active' },
-  { title: 'Ecosystem', path: '/ecosystem', group: 'Core', description: 'Domain ecosystem map and statuses.', status: 'active' },
-  { title: 'OMOS', path: '/omos', group: 'Core', description: 'OMOS operating model and structure overview.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Campaigns', description: 'OneGodian: Remember campaign page.', status: 'active' },
-  { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership pathways and dashboard entry.', status: 'active' },
-  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time™ / OTS-V5 overview.', status: 'active' },
-  { title: 'Commerce', path: '/commerce', group: 'Core', description: 'Commerce and identity product engine overview.', status: 'active' },
-  { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional and legal clarity guidance.', status: 'active' }
+  { title: 'Tools', path: '/tools', group: 'Control Plane', description: 'Planned tools operational layer.', status: 'planned' },
+  { title: 'Certificates', path: '/certificates', group: 'Control Plane', description: 'Planned certificate operational layer.', status: 'planned' },
+  { title: 'Registry', path: '/registry', group: 'Control Plane', description: 'Planned registry operational layer.', status: 'planned' },
+  { title: 'Members', path: '/members', group: 'Control Plane', description: 'Planned member operational layer.', status: 'planned' },
+  { title: 'Settings', path: '/settings', group: 'Control Plane', description: 'Planned settings operational layer.', status: 'planned' },
+  { title: 'Admin', path: '/admin', group: 'Control Plane', description: 'Admin integration placeholder.', status: 'planned' }
 ];

--- a/src/lib/control-plane.ts
+++ b/src/lib/control-plane.ts
@@ -34,3 +34,5 @@ export const requiredEnvVars = [
   'MEMBERS_REST_BASE_URL=https://onegodian.org/wp-json/onegodian-members/v1',
   'CAPITAL_REST_BASE_URL=https://capital.onegodian.com/wp-json/onegodian-capital/v1'
 ];
+
+export const controlPlanePlaceholderLabels = ['Coming Soon', 'Planned Module', 'Operational Layer', 'Requires Admin Integration'];

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,8 +1,9 @@
 import { appDashboardCards, appFooterBoundary, appHomeHero, appNavigation, ecosystemPortals } from '@/lib/app-content';
-import { consoleDashboardCards, consoleNavigation, consoleFooterBoundary } from '@/lib/console-content';
+import { consoleDashboardCards, consoleFooterBoundary, consoleNavigation } from '@/lib/console-content';
 
 export const appMeta = appHomeHero;
 export { appNavigation, consoleNavigation, ecosystemPortals };
+
 export const ecosystemLinks = [
   { label: 'OneGodian.org', href: 'https://onegodian.org' },
   { label: 'OneGodian.com', href: 'https://onegodian.com' },
@@ -18,29 +19,47 @@ export const dashboardCards = appDashboardCards;
 export { appDashboardCards, consoleDashboardCards };
 
 export const appStructureLayers = ['Public App', 'Member Dashboard', 'Membership', 'Certificates', 'Campaigns', 'Media', 'Products', 'Learning', 'Tools', 'Profile'];
-export const coreRoutes = ['/','/dashboard','/ecosystem','/omos','/remember','/membership','/time','/commerce','/institutional','/api/manifest'];
+export const coreRoutes = ['/', '/dashboard', '/ecosystem', '/omos', '/remember', '/membership', '/time', '/commerce', '/institutional', '/tools', '/registry', '/members', '/settings'];
 
 export const footerSections = [
   { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'OMOS', href: '/omos' }, { label: 'Remember', href: '/remember' }] },
-export const coreRoutes = ['/', '/dashboard', '/ecosystem', '/omos', '/remember', '/membership', '/time', '/commerce', '/institutional', '/api/manifest'];
-
-export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Remember', href: '/remember' }, { label: 'Membership', href: '/membership' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Membership', href: '/membership' }, { label: 'Remember', href: '/remember' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'U OneGodian', href: 'https://u.onegodian.org' }, { label: 'Capital OneGodian', href: 'https://capital.onegodian.com' }] },
-  { title: 'More', links: [{ label: 'Membership', href: '/membership' }, { label: 'Time', href: '/time' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] }
+  { title: 'Control Plane', links: [{ label: 'Tools', href: '/tools' }, { label: 'Registry', href: '/registry' }, { label: 'Members', href: '/members' }, { label: 'Settings', href: '/settings' }] },
+  { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'OMOS', href: 'https://omos.onegodian.com' }] }
 ];
 
 export const systemsModel = [
   { title: 'App Experience', items: ['Dashboard', 'Ecosystem', 'Membership', 'Certificates'] },
   { title: 'Content & Commerce', items: ['Campaigns', 'Media', 'Products', 'Learning'] },
-  { title: 'Account', items: ['Tools', 'Profile', 'Settings'] }
+  { title: 'Control Plane', items: ['Tools', 'Registry', 'Members', 'Settings', 'Admin'] }
 ];
 
-export const apiStatus = { app: 'OneGodian App', appUrl: 'https://app.onegodian.com', consoleUrl: 'https://console.onegodian.com', environment: 'Production', currentDateRecord: 'May 23, 2026' };
-export const appStatus = { ...apiStatus, store: 'https://onegodian.com', publicSite: 'https://onegodian.org', api: 'https://app.onegodian.com/api/health', activeCampaign: 'THE ONEGODIAN: Remember Campaign' };
+export const apiStatus = {
+  app: 'OneGodian App',
+  appUrl: 'https://app.onegodian.com',
+  consoleUrl: 'https://console.onegodian.com',
+  environment: 'Production',
+  currentDateRecord: 'May 30, 2026'
+};
+
+export const appStatus = {
+  ...apiStatus,
+  store: 'https://onegodian.com',
+  publicSite: 'https://onegodian.org',
+  api: 'https://app.onegodian.com/api/health',
+  activeCampaign: 'THE ONEGODIAN: Remember Campaign'
+};
+
 export const appBoundaryCopy = appFooterBoundary;
 export const consoleBoundaryCopy = consoleFooterBoundary;
 
-export const pluginCategories = [{ title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }];
-export const rememberCampaign = { officialStartDate: 'May 9, 2026', onegodianDate: 'Wisdom 23, OT 0001', message: 'You were always One — you simply forgot. Remember who you are.', purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.', dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status'] };
+export const pluginCategories = [
+  { title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }
+];
+
+export const rememberCampaign = {
+  officialStartDate: 'May 9, 2026',
+  onegodianDate: 'Wisdom 23, OT 0001',
+  message: 'You were always One — you simply forgot. Remember who you are.',
+  purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.',
+  dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status']
+};


### PR DESCRIPTION
### Motivation
- Reserve an explicit OneGodian App control-plane surface for operator/member consoles without exposing unimplemented backend behavior. 
- Provide clear production-safe placeholders and labels so future integrations can attach verified admin services and data sources without shipping fake functionality.

### Description
- Added a reusable placeholder component at `src/components/control-plane-placeholder.tsx` rendering the labels `Coming Soon`, `Planned Module`, `Operational Layer`, and `Requires Admin Integration` and production-safety copy. 
- Converted the following pages to use the control-plane placeholder: `src/app/(app)/tools/page.tsx`, `src/app/certificates/page.tsx`, `src/app/(app)/registry/page.tsx`, `src/app/(app)/members/page.tsx`, `src/app/(app)/settings/page.tsx`, and `src/app/(admin)/admin/page.tsx`. 
- Updated API routes `src/app/api/tools/route.ts` and `src/app/api/stats/route.ts` to return explicit placeholder JSON describing planned modules and operational notes instead of implying live metrics or executable tools. 
- All placeholders explicitly avoid implementing backend features and call out that admin integration and verified production data are required to enable functionality.

### Testing
- Ran `npm run check` (`node --check server.js`) which completed without error. 
- Ran `npm run smoke:pages` which passed the pages smoke test. 
- Ran `npm run typecheck` (`tsc --noEmit`) which failed due to pre-existing unrelated TypeScript/JSON issues in other files outside this change set. 
- Ran `npm test` (project smoke suite) which failed because the existing root route returned HTTP 500 in the repository's smoke tests unrelated to these control-plane changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab1bbedd0832d9a3411a176543c18)