### PR TITLE
Revamp UI theme and components; restyle pages and update app content/manifest

### DIFF
--- a/src/app/(app)/commerce/page.tsx
+++ b/src/app/(app)/commerce/page.tsx
@@ -1,27 +1,21 @@
 export default function CommercePage() {
   return (
     <main className="space-y-6">
-      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Commerce & Identity Engine</h1>
-        <p className="mt-2 text-slate-300">OneGodian.com is the commerce and identity product engine for merchandise, memberships, digital products, and checkout workflows.</p>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Commerce Node</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">Commerce & Identity Engine</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">OneGodian.com is the commerce and identity product engine for merchandise, memberships, digital products, and checkout workflows.</p>
       </section>
       <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Commercial Operations</h2>
-          <p className="mt-2 text-sm text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating commerce surfaces and product rails.</p>
+        <article className="mobile-card">
+          <h2 className="text-xl font-semibold text-white">Commercial Operations</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating commerce surfaces and product rails.</p>
         </article>
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Commerce Node</h2>
-          <a href="https://onegodian.com" target="_blank" rel="noreferrer" className="mt-2 inline-block text-cyan-300">https://onegodian.com</a>
+        <article className="mobile-card">
+          <h2 className="text-xl font-semibold text-white">Commerce Node</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Product identity, fulfillment, checkout, and campaign integration route through the production commerce property.</p>
+          <a href="https://onegodian.com" target="_blank" rel="noreferrer" className="mt-4 inline-flex text-sm font-semibold text-gold-300 hover:text-gold-100">https://onegodian.com</a>
         </article>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Commerce & Identity Product Engine</h1><p className="text-slate-300">OneGodian.com is the primary commerce and identity product engine for ONEGODIAN, LLC.</p><a className="inline-block rounded-lg border border-cyan-400/40 px-4 py-2 text-cyan-200" href="https://onegodian.com" target="_blank" rel="noreferrer">Open OneGodian.com</a></main>; }
-export default function CommercePage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Commerce + Identity Engine</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
-        <p>OneGodian.com is the commerce and identity product engine for ONEGODIAN, LLC offerings including media, education products, software-linked goods, and member-linked services.</p>
-        <p>Commerce operations are managed as private commercial infrastructure with product identity, fulfillment, and campaign integration.</p>
       </section>
     </main>
   );

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -15,5 +15,32 @@ export default function DashboardPage() {
     { label: 'Failing services', value: sync.errors.length ? sync.errors.join('; ') : 'none' }
   ];
 
-  return <main className="space-y-8"><header className="rounded-2xl border border-cyan-400/30 bg-slate-950 p-6"><h1 className="text-3xl font-bold text-cyan-200">ONEGODIAN MEMBER DASHBOARD</h1></header><section className="grid gap-4 md:grid-cols-2">{dashboardCards.map((card) => <article key={card.title} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><div className="flex items-center justify-between"><h2 className="text-xl font-semibold">{card.title}</h2><span className="text-xs text-cyan-300">{card.status}</span></div><p className="mt-2 text-sm text-slate-300">{card.description}</p><Link href={card.href} className="mt-3 inline-block text-cyan-300">Open</Link></article>)}</section><section className="grid gap-4 md:grid-cols-3">{widgets.map((widget) => <article key={widget.label} className="rounded-xl border border-cyan-700/40 bg-slate-900/40 p-4"><h3 className="text-sm text-cyan-200">{widget.label}</h3><p className="mt-2 break-all text-lg font-semibold text-slate-100">{widget.value}</p></article>)}</section></main>;
+  return (
+    <main className="space-y-8">
+      <header className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Member Command Surface</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">ONEGODIAN MEMBER DASHBOARD</h1>
+      </header>
+      <section className="grid gap-4 md:grid-cols-2">
+        {dashboardCards.map((card) => (
+          <article key={card.title} className="mobile-card">
+            <div className="flex items-start justify-between gap-4">
+              <h2 className="text-xl font-bold text-white">{card.title}</h2>
+              <span className="rounded-full border border-gold-300/40 bg-gold-300/10 px-2.5 py-1 text-xs font-bold text-gold-100">{card.status}</span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{card.description}</p>
+            <Link href={card.href} className="mt-5 inline-block text-xs font-black uppercase tracking-[0.22em] text-gold-300">Open →</Link>
+          </article>
+        ))}
+      </section>
+      <section className="grid gap-4 md:grid-cols-3">
+        {widgets.map((widget) => (
+          <article key={widget.label} className="rounded-3xl border border-purple-300/15 bg-white/[0.045] p-4 shadow-sovereign backdrop-blur-xl">
+            <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-purple-100/80">{widget.label}</h3>
+            <p className="mt-3 break-all text-lg font-bold text-white">{widget.value}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
 }

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,41 +1,19 @@
-const portals = [
-  ['OneGodian.org', 'Public identity, writings, remembrance, and institutional context.', 'https://onegodian.org'],
-  ['OneGodian.com', 'Commerce and identity product engine for products, memberships, and checkout.', 'https://onegodian.com'],
-  ['u.OneGodian.com', 'Education and LMS pathways for courses and learning records.', 'https://u.onegodian.org'],
-  ['app.OneGodian.com', 'Public/member app for dashboard, routes, and runtime tools.', 'https://app.onegodian.com'],
-  ['galaxy.OneGodian.com', 'Galaxy/planetary experiences, media, and world surfaces.', 'https://galaxy.onegodian.com'],
-  ['OMOS.OneGodian.com', 'OMOS specification and runtime documentation.', 'https://omos.onegodian.com'],
-  ['QuantumOHI.com', 'OHI systems architecture and intelligence positioning.', 'https://quantumohi.com'],
-  ['QRV.Network', 'Verification infrastructure network and credential trust rails.', 'https://qrv.network']
-] as const;
-
-export default function EcosystemPage() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">Live ecosystem map across public, education, commerce, app, protocol, and verification properties.</p><section className="grid gap-4 md:grid-cols-2">{portals.map((p)=><article key={p[0]} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="font-semibold">{p[0]}</h2><p className="text-sm text-slate-300">{p[1]}</p><a href={p[2]} target="_blank" rel="noreferrer" className="text-cyan-300">{p[2]}</a></article>)}</section></main>;
-  ['OneGodian.org', 'https://onegodian.org', 'Public institution-facing website and cultural/education communication.'],
-  ['OneGodian.com', 'https://onegodian.com', 'Commerce and identity product engine for products, memberships, and digital delivery.'],
-  ['u.OneGodian.com', 'https://u.onegodian.com', 'Learning and curriculum platform.'],
-  ['app.OneGodian.com', 'https://app.onegodian.com', 'Public/member app dashboard and route node.'],
-  ['galaxy.OneGodian.com', 'https://galaxy.onegodian.com', 'Galaxy/world platform and discovery layer.'],
-  ['OMOS.OneGodian.com', 'https://omos.onegodian.com', 'OMOS specification and runtime documents.'],
-  ['QuantumOHI.com', 'https://quantumohi.com', 'Quantum OHI architecture and model context.'],
-  ['QRV.Network', 'https://qrv.network', 'Verification network for trusted records and credentials.']
-] as const;
-
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Ecosystem</h1><p className="text-slate-300">This page maps the live OneGodian ecosystem and explains how each production property serves public access, member workflows, and platform operations.</p><div className="grid gap-4 md:grid-cols-2">{portals.map(([name, href, desc]) => <article key={name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><a href={href} className="text-cyan-300" target="_blank" rel="noreferrer">{name}</a><p className="mt-2 text-sm text-slate-300">{desc}</p></article>)}</div></main>;
 import { ecosystemPortals } from '@/lib/onegodian-content';
 
 export default function EcosystemPage() {
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
-      <p className="text-slate-300">Connected properties across identity, commerce, education, runtime systems, and verification infrastructure.</p>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Ecosystem Registry</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">OneGodian Ecosystem</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Connected properties across identity, commerce, education, runtime systems, galaxy surfaces, and verification infrastructure.</p>
+      </section>
       <section className="grid gap-4 md:grid-cols-2">
-        {ecosystemPortals.map((p) => (
-          <article key={p.name} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-            <h2 className="font-semibold">{p.name}</h2>
-            <p className="text-sm text-slate-300">{p.role}</p>
-            <a href={p.url} target="_blank" rel="noreferrer" className="text-cyan-300">{p.url}</a>
+        {ecosystemPortals.map((portal) => (
+          <article key={portal.name} className="mobile-card">
+            <h2 className="text-xl font-semibold text-white">{portal.name}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{portal.role}</p>
+            <a href={portal.url} target="_blank" rel="noreferrer" className="mt-4 inline-flex text-sm font-semibold text-gold-300 hover:text-gold-100">{portal.url}</a>
           </article>
         ))}
       </section>

--- a/src/app/(app)/institutional/page.tsx
+++ b/src/app/(app)/institutional/page.tsx
@@ -1,14 +1,20 @@
-export default function InstitutionalPage(){return <main className='space-y-6'><section className='rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6'><h1 className='text-3xl font-bold'>Institutional Clarity</h1><p className='mt-2 text-slate-300'>Clear separation between commercial operations and internal governance/religious association context.</p></section><section className='rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300 space-y-2'><p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.</p><p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p><p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></section></main>}
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">Institutional Clarity</h1><p className="text-slate-300">ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity operating products, platforms, and digital services.</p><p className="text-slate-300">INO is a separate voluntary internal governance/religious association structure used for internal community and cultural organization.</p><p className="text-slate-300">&quot;Sovereign&quot; in this context means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p></main>;
 export default function InstitutionalPage() {
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">Institutional Clarity</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-3">
-        <p>ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity responsible for product operations, platforms, publishing, and technology execution.</p>
-        <p>INO is separate and should be described as a voluntary internal governance/religious association structure.</p>
-        <p>“Sovereign” means internal self-governance and voluntary participation, not exemption from U.S. law or governmental authority over non-members.</p>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Institutional Clarity</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">OneGodian Institutional Boundaries</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Clear public-facing language for commercial operations, educational/media activity, community participation, and verification infrastructure.</p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="mobile-card">
+          <h2 className="text-xl font-semibold text-white">ONEGODIAN, LLC</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Private commercial/IP/software/media/education/e-commerce operations, products, and platform services.</p>
+        </article>
+        <article className="mobile-card">
+          <h2 className="text-xl font-semibold text-white">Public + Member App</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Public-safe routes, member entry points, campaign resources, content context, and status surfaces remain separate from admin/control tools.</p>
+        </article>
       </section>
     </main>
   );

--- a/src/app/(app)/membership/page.tsx
+++ b/src/app/(app)/membership/page.tsx
@@ -3,24 +3,18 @@ import Link from 'next/link';
 export default function MembershipPage() {
   return (
     <main className="space-y-6">
-      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Membership</h1>
-        <p className="mt-2 text-slate-300">Membership pathways, records access, and participation tools across the OneGodian App.</p>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Member Access</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">OneGodian Membership</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Membership pathways, records access, identity services, and voluntary community features across the OneGodian ecosystem.</p>
       </section>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-sm text-slate-300">
+      <section className="mobile-card text-sm leading-6 text-slate-300">
         <p>Use this page as the public-facing membership entry, then continue into member workflows and dashboard tools.</p>
-        <div className="mt-3 flex gap-4">
-          <Link href="/members" className="text-cyan-300">Open members module</Link>
-          <Link href="/dashboard" className="text-cyan-300">Open dashboard</Link>
+        <p className="mt-3">Dashboard entry remains compatible with public/member reporting via manifest and status surfaces.</p>
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <Link href="/members" className="premium-button-secondary">Open members module</Link>
+          <Link href="/dashboard" className="premium-button">Open dashboard</Link>
         </div>
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">Membership</h1><p className="text-slate-300">Membership provides dashboard-linked participation paths, identity services, and voluntary community features across the OneGodian ecosystem.</p></main>; }
-export default function MembershipPage() {
-  return (
-    <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OneGodian Membership</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300">
-        <p>Membership provides access to profile records, campaign participation, tools, and platform learning resources.</p>
-        <p className="mt-2">Dashboard entry is available from the member node and remains compatible with admin/control-plane reporting via manifest and status surfaces.</p>
       </section>
     </main>
   );

--- a/src/app/(app)/omos/page.tsx
+++ b/src/app/(app)/omos/page.tsx
@@ -1,40 +1,23 @@
-const mindMap = [
-  'Protocol and algorithm orchestration',
-  'Identity and remembrance modeling',
-  'Runtime route and manifest governance',
-  'Tooling and bridge integrations',
-  'Time and chronology references (OTS-V5)',
-  'Documentation for public/member and admin compatibility'
-const omosModules = [
-  'Identity & Consciousness Layer',
-  'Belief Mapping & Meaning Layer',
-  'Ethics, Responsibility, and Conduct Layer',
-  'Language, Ritual, and Cultural Signal Layer',
-  'Application, Protocol, and Runtime Layer'
-];
-
-export default function Page() {
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1><p className="text-slate-300">OMOS organizes OneGodian operations into interoperable layers that bridge thought, language, governance, and deployable application behavior.</p><ul className="list-disc space-y-2 pl-5 text-slate-300">{omosModules.map((m) => <li key={m}>{m}</li>)}</ul><p className="text-sm text-slate-400">Manifest/API visibility: this route is registered in the public manifest and available to dashboard, admin monitoring, and app status surfaces.</p></main>;
 export default function OmosPage() {
-  return <main className="space-y-6"><header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6"><h1 className="text-3xl font-bold">OMOS — OneGodian Metaphysical Operating System</h1><p className="mt-2 text-slate-300">OMOS is the structured operating model for OneGodian protocols, routes, tools, time, and synchronized application behaviors.</p></header><section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5"><h2 className="text-xl font-semibold">OMOS Mind Map Coverage</h2><ul className="mt-2 list-disc pl-6 text-sm text-slate-300">{mindMap.map((item)=><li key={item}>{item}</li>)}</ul></section></main>;
-  const omosMindMap = [
-    'Identity architecture and remembrance framework',
-    'Consciousness alignment protocol layers',
-    'Ethics, reflection, and participation modules',
-    'Public app and dashboard synchronization',
-    'Manifest/API interoperability for ecosystem apps'
-  ];
-
   return (
     <main className="space-y-6">
-      <h1 className="text-3xl font-bold">OMOS · OneGodian Metaphysical Operating System</h1>
-      <p className="text-slate-300">OMOS content maps metaphysical operating concepts into practical app modules, governance boundaries, and platform synchronization.</p>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-        <ul className="list-disc space-y-1 pl-5 text-sm text-slate-300">
-          {omosMindMap.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Operating System</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">OMOS · OneGodian Metaphysical Operating System™</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Protocol, runtime documentation, page registry, and app bridge context for the OneGodian ecosystem.</p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-3">
+        {[
+          ['Manifest', '/omos/manifest', 'Runtime manifest and compatibility context.'],
+          ['Pages', '/omos/pages', 'Synced page registry for public routes.'],
+          ['Health', '/omos/health', 'Operational status and sync visibility.']
+        ].map(([title, href, description]) => (
+          <a key={href} href={href} className="mobile-card group">
+            <h2 className="text-xl font-semibold text-white group-hover:text-gold-200">{title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{description}</p>
+            <span className="mt-4 inline-flex text-xs font-semibold uppercase tracking-[0.22em] text-gold-300">Open →</span>
+          </a>
+        ))}
       </section>
     </main>
   );

--- a/src/app/(app)/remember/page.tsx
+++ b/src/app/(app)/remember/page.tsx
@@ -1,39 +1,23 @@
-import Link from 'next/link';
-export default function Page() { return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian: Remember</h1><p className="text-slate-300">OneGodian: Remember is a public campaign inviting people to reconnect with identity, dignity, unity, and responsibility through practical action and shared memory.</p></main>; }
-import Link from 'next/link';
 import { rememberCampaign } from '@/lib/onegodian-content';
 
 export default function RememberPage() {
   return (
     <main className="space-y-6">
-      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Campaign</p>
-        <h1 className="mt-2 text-3xl font-bold">OneGodian: Remember</h1>
-        <p className="mt-3 text-slate-300">You were always One — you simply forgot. Remember who you are.</p>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Campaign</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">THE ONEGODIAN: Remember Campaign</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">{rememberCampaign.message}</p>
+        <p className="mt-3 text-sm font-semibold text-purple-200">Campaign start: {rememberCampaign.officialStartDate} · {rememberCampaign.onegodianDate}</p>
       </section>
-      <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Campaign Intent</h2>
-          <p className="mt-2 text-sm text-slate-300">A public-safe awareness campaign focused on identity, remembrance, dignity, unity, and shared human connection.</p>
-        </article>
-        <article className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
-          <h2 className="text-xl font-semibold">Participation</h2>
-          <p className="mt-2 text-sm text-slate-300">Creators, members, and supporters can access campaign media, captions, releases, and distribution pathways from the dashboard.</p>
-          <Link href="/dashboard" className="mt-3 inline-block text-cyan-300">Open Dashboard</Link>
-        </article>
-      <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">OneGodian: Remember</h1>
-        <p className="mt-2 text-slate-300">{rememberCampaign.message}</p>
-        <p className="mt-2 text-sm text-cyan-300">Campaign start: {rememberCampaign.officialStartDate} · {rememberCampaign.onegodianDate}</p>
-      </header>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5">
+      <section className="mobile-card">
         <p className="text-slate-300">{rememberCampaign.purpose}</p>
-        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-300">
+        <ul className="mt-5 grid gap-3 sm:grid-cols-2">
           {rememberCampaign.dashboardFunctions.map((item) => (
-            <li key={item}>{item}</li>
+            <li key={item} className="rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-slate-200">
+              <span className="mr-2 text-gold-300">✦</span>{item}
+            </li>
           ))}
         </ul>
-        <Link href="/campaigns/remember" className="mt-4 inline-block text-cyan-300">Open campaign module</Link>
       </section>
     </main>
   );

--- a/src/app/(app)/time/page.tsx
+++ b/src/app/(app)/time/page.tsx
@@ -2,25 +2,17 @@ import { TodayInOneGodianTime } from '@/components/today-in-onegodian-time';
 
 export default function TimePage() {
   return (
-    <main className="p-6 text-slate-100 space-y-4">
-      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
-      <p className="text-slate-300">Dual-date display pairs OneGodian Time for internal presentation with Gregorian/UTC records for external and legal continuity.</p>
-      <TodayInOneGodianTime />
-      <a href="/time/dual-dating" className="inline-block rounded-lg border border-cyan-400/50 bg-slate-900/70 px-4 py-2 text-cyan-200 transition hover:bg-cyan-500/10">Dual Dating System™</a>
-      <p className="text-sm text-amber-200">Legal safety: Gregorian Time and UTC timestamps remain controlling for legal, financial, tax, court, contractual, and institutional records.</p>
-export default function Page() {
-  const gregorian = new Date().toISOString().slice(0, 10);
-  const ots = 'OTS-V5 active chronology view';
-  return <main className="space-y-6"><h1 className="text-3xl font-bold">OneGodian Time™ · OTS-V5</h1><p className="text-slate-300">Dual-date view for platform coordination and historical references.</p><div className="grid gap-4 md:grid-cols-2"><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">Gregorian Date</h2><p className="mt-2 text-slate-100">{gregorian}</p></article><article className="rounded-xl border border-slate-700 bg-slate-900/60 p-4"><h2 className="text-cyan-200">OneGodian Date</h2><p className="mt-2 text-slate-100">{ots}</p></article></div><p className="text-sm text-slate-400">Legal safety notice: OneGodian Time™ is an internal cultural/system chronology aid. It does not replace legal, regulatory, tax, court, banking, or governmental date standards.</p></main>;
-export default function TimePage() {
-  return (
-    <main className="space-y-6 p-6 text-slate-100">
-      <h1 className="text-3xl font-semibold">OneGodian Time™ / OTS-V5</h1>
-      <section className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 text-slate-300 space-y-2">
-        <p>Dual-date display model: Gregorian civil date + OneGodian internal date notation for synchronized cultural references.</p>
-        <p>Example format: Gregorian Date (UTC) · OneGodian Date (OTS-V5 internal).</p>
+    <main className="space-y-6">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Chronology</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">OneGodian Time™ / OTS-V5</h1>
+        <p className="mt-3 max-w-3xl text-slate-300">Dual-date display pairs OneGodian Time for internal presentation with Gregorian/UTC records for external and legal continuity.</p>
       </section>
-      <p className="text-sm text-amber-200">Legal safety: Gregorian calendar/time remains controlling for legal, financial, compliance, and external institutional matters.</p>
+      <section className="mobile-card">
+        <TodayInOneGodianTime />
+        <a href="/time/dual-dating" className="premium-button-secondary mt-5 inline-flex">Dual Dating System™</a>
+      </section>
+      <p className="rounded-2xl border border-gold-300/25 bg-gold-300/10 p-4 text-sm leading-6 text-gold-100">Legal safety: Gregorian Time and UTC timestamps remain controlling for legal, financial, tax, court, contractual, and institutional records.</p>
     </main>
   );
 }

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -2,21 +2,24 @@ import { certificates } from '../data';
 
 export default function CertificateRecordsPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <h1 className="text-3xl font-bold">Certificate Records</h1>
-      <p className="mt-2 text-slate-300">Review certificate record status, instrument references, and verification metadata.</p>
-      <div className="mt-5 rounded-xl border border-amber-500/40 bg-amber-900/20 p-4 text-sm text-amber-100">
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Verification Records</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Certificate Records</h1>
+        <p className="mt-3 leading-7 text-slate-300">Review certificate record status, instrument references, and verification metadata.</p>
+      </section>
+      <div className="mt-5 rounded-3xl border border-gold-300/30 bg-gold-300/10 p-4 text-sm leading-6 text-gold-100 backdrop-blur-xl">
         Certificate records displayed in this portal are administrative records for documentation, verification support, and audit review. A listed record does not replace executed agreements, disclosure review, payment confirmation, legal review, or final internal acceptance.
       </div>
       <div className="mt-6 grid gap-4 md:grid-cols-2">
         {certificates.map((record) => (
-          <article key={record.recordId} className="rounded-xl border border-slate-700 bg-slate-900/70 p-5">
-            <p><strong>Record ID:</strong> {record.recordId}</p>
-            <p><strong>Instrument Reference:</strong> {record.instrumentReference}</p>
-            <p><strong>Holder Reference:</strong> {record.holderReference}</p>
-            <p><strong>Record Status:</strong> {record.recordStatus}</p>
-            <p><strong>Issuance Status:</strong> {record.issuanceStatus}</p>
-            <p><strong>Verification Metadata:</strong> {record.verificationMetadata}</p>
+          <article key={record.recordId} className="mobile-card space-y-2 text-sm leading-6 text-slate-200">
+            <p><strong className="text-gold-200">Record ID:</strong> {record.recordId}</p>
+            <p><strong className="text-gold-200">Instrument Reference:</strong> {record.instrumentReference}</p>
+            <p><strong className="text-gold-200">Holder Reference:</strong> {record.holderReference}</p>
+            <p><strong className="text-gold-200">Record Status:</strong> {record.recordStatus}</p>
+            <p><strong className="text-gold-200">Issuance Status:</strong> {record.issuanceStatus}</p>
+            <p><strong className="text-gold-200">Verification Metadata:</strong> {record.verificationMetadata}</p>
           </article>
         ))}
       </div>

--- a/src/app/components/CapitalFooter.tsx
+++ b/src/app/components/CapitalFooter.tsx
@@ -2,15 +2,21 @@ import Link from 'next/link';
 
 export function CapitalFooter() {
   return (
-    <footer className="mt-16 border-t border-slate-800 bg-slate-950/80">
+    <footer className="border-t border-gold-300/15 bg-abyss/86 backdrop-blur-xl">
       <div className="mx-auto max-w-7xl px-4 py-10 text-sm text-slate-300">
-        <div className="flex flex-wrap items-center gap-4">
-          <Link href="/legal">Legal</Link>
-          <Link href="/privacy">Privacy</Link>
-          <Link href="/terms">Terms</Link>
+        <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+          <div>
+            <p className="font-black tracking-[-0.03em] text-white">OneGodian Production Surface</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.2em] text-gold-300">Institutional clarity · member access · ecosystem routes</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <Link href="/legal" className="hover:text-gold-300">Legal</Link>
+            <Link href="/privacy" className="hover:text-gold-300">Privacy</Link>
+            <Link href="/terms" className="hover:text-gold-300">Terms</Link>
+          </div>
         </div>
       </div>
-      <div className="border-t border-slate-800 px-4 py-4 text-center text-xs text-slate-400">© 2026 QRV Network</div>
+      <div className="border-t border-white/10 px-4 py-4 text-center text-xs text-slate-400">© 2026 OneGodian</div>
     </footer>
   );
 }

--- a/src/app/components/CapitalNavigation.tsx
+++ b/src/app/components/CapitalNavigation.tsx
@@ -11,13 +11,11 @@ export function CapitalNavigation() {
     <header className="capital-header">
       <div className="capital-header-inner">
         <Link href="/" className="capital-logo">
-          <span className="capital-logo-mark">QRV</span> qrv.network
+          <span className="capital-logo-mark">OG</span> OneGodian
         </Link>
         <nav className="capital-nav" aria-label="Primary">
           {navItems.map((item) => (
-            <Link key={item.href} href={item.href}>
-              {item.label}
-            </Link>
+            <Link key={item.href} href={item.href}>{item.label}</Link>
           ))}
         </nav>
       </div>

--- a/src/app/components/CapitalReadinessTable.tsx
+++ b/src/app/components/CapitalReadinessTable.tsx
@@ -1,5 +1,22 @@
 import { ReadinessItem } from '../data';
 
 export function CapitalReadinessTable({ items }: { items: ReadinessItem[] }) {
-  return <div className="overflow-x-auto rounded-xl border border-slate-700"><table className="min-w-full text-left text-sm"><thead className="bg-slate-800/60"><tr><th className="p-3">Layer</th><th className="p-3">Status</th><th className="p-3">Notes</th></tr></thead><tbody>{items.map((item) => <tr key={item.layer} className="border-t border-slate-700"><td className="p-3 font-medium">{item.layer}</td><td className="p-3">{item.status}</td><td className="p-3 text-slate-300">{item.detail}</td></tr>)}</tbody></table></div>;
+  return (
+    <div className="overflow-x-auto rounded-3xl border border-white/10 bg-white/[0.045] shadow-sovereign backdrop-blur-xl">
+      <table className="min-w-full text-left text-sm">
+        <thead className="border-b border-gold-300/20 bg-gold-300/10 text-gold-100">
+          <tr><th className="p-3">Layer</th><th className="p-3">Status</th><th className="p-3">Notes</th></tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.layer} className="border-t border-white/10">
+              <td className="p-3 font-semibold text-white">{item.layer}</td>
+              <td className="p-3 text-gold-200">{item.status}</td>
+              <td className="p-3 text-slate-300">{item.detail}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/src/app/components/LiveVerifyForm.tsx
+++ b/src/app/components/LiveVerifyForm.tsx
@@ -18,13 +18,13 @@ export function LiveVerifyForm({ demoRecordId }: { demoRecordId: string }) {
     <form className="mt-5 flex flex-col gap-3 sm:flex-row" onSubmit={onSubmit}>
       <input
         aria-label="Enter QRVID"
-        className="w-full rounded-xl border border-slate-600 bg-slate-950 px-4 py-3 text-slate-100 outline-none ring-cyan-300/40 placeholder:text-slate-500 focus:ring"
+        className="w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-slate-100 outline-none ring-gold-300/30 placeholder:text-slate-500 focus:border-gold-300/50 focus:ring"
         onChange={(event) => setQrvid(event.target.value)}
         placeholder="Enter QRVID"
         value={qrvid}
       />
-      <button className="rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-5 py-3 text-sm font-semibold text-cyan-100" type="submit">Verify</button>
-      <a className="rounded-xl border border-slate-500/60 px-5 py-3 text-center text-sm font-semibold text-slate-100" href={`${VERIFY_BASE_URL}/${demoRecordId}`}>Try Demo Record</a>
+      <button className="premium-button" type="submit">Verify</button>
+      <a className="premium-button-secondary text-center" href={`${VERIFY_BASE_URL}/${demoRecordId}`}>Try Demo Record</a>
     </form>
   );
 }

--- a/src/app/disclosures/page.tsx
+++ b/src/app/disclosures/page.tsx
@@ -1,1 +1,11 @@
-export default function Page(){return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">disclosures </h1><p className="mt-2 text-slate-300">Administrative record workspace for disclosures with disclosure review and acknowledgement workflow support.</p></main>}
+export default function Page() {
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Disclosures</h1>
+        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for disclosures with disclosure review and acknowledgement workflow support.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,14 +2,174 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  @apply bg-abyss text-slate-100;
+:root {
+  color-scheme: dark;
+  --og-abyss: #030712;
+  --og-navy: #07111f;
+  --og-panel: rgba(10, 18, 34, 0.72);
+  --og-gold: #eac85a;
+  --og-purple: #a78bfa;
 }
 
-.capital-header { position: sticky; top: 0; z-index: 50; border-bottom: 1px solid rgb(51 65 85); background: rgba(2,6,23,0.95); backdrop-filter: blur(10px); }
-.capital-header-inner { max-width: 80rem; margin: 0 auto; padding: 0.75rem 1rem; display: flex; flex-wrap: wrap; gap: 0.75rem 1.25rem; align-items: center; }
-.capital-logo { font-weight: 700; color: #e2e8f0; display: inline-flex; align-items: center; gap: .5rem; white-space: nowrap; }
-.capital-logo-mark { display: inline-grid; place-items: center; width: 1.75rem; height: 1.75rem; border-radius: 9999px; background: #06b6d4; color: #082f49; font-size: .75rem; }
-.capital-nav, .capital-ecosystem-nav { display: flex; flex-wrap: wrap; gap: .5rem .9rem; min-width: 0; }
-.capital-nav a, .capital-ecosystem-nav a { font-size: .9rem; color: #cbd5e1; }
-@media (min-width: 1024px) { .capital-nav { margin-left: auto; } .capital-ecosystem-nav { margin-left: 1rem; border-left:1px solid rgb(71 85 105); padding-left: 1rem; } }
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--og-abyss);
+}
+
+body {
+  @apply min-h-screen bg-abyss font-sans text-slate-100 antialiased;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(124, 58, 237, 0.24), transparent 34rem),
+    radial-gradient(circle at 88% 8%, rgba(234, 200, 90, 0.16), transparent 30rem),
+    linear-gradient(135deg, #030712 0%, #07111f 46%, #05050a 100%);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(234, 200, 90, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(167, 139, 250, 0.06) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.78), transparent 78%);
+}
+
+a {
+  text-underline-offset: 4px;
+}
+
+::selection {
+  background: rgba(234, 200, 90, 0.28);
+  color: #fff8d7;
+}
+
+@layer components {
+  .onegodian-surface {
+    background:
+      radial-gradient(circle at 15% 10%, rgba(124, 58, 237, 0.22), transparent 28rem),
+      radial-gradient(circle at 82% 0%, rgba(234, 200, 90, 0.16), transparent 26rem),
+      linear-gradient(180deg, rgba(3, 7, 18, 0.28), rgba(3, 7, 18, 0.88));
+  }
+
+  .glass-panel {
+    @apply rounded-[2rem] border border-white/10 bg-white/[0.06] shadow-sovereign backdrop-blur-2xl;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .mobile-card {
+    @apply relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.055] p-5 shadow-sovereign backdrop-blur-xl transition duration-300 hover:-translate-y-1 hover:border-gold-300/40 hover:bg-white/[0.08] hover:shadow-gold active:translate-y-0;
+  }
+
+  .mobile-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 18% 0%, rgba(234, 200, 90, 0.14), transparent 42%),
+      radial-gradient(circle at 100% 0%, rgba(167, 139, 250, 0.14), transparent 38%);
+    opacity: 0.85;
+  }
+
+  .mobile-card > * {
+    position: relative;
+  }
+
+  .premium-button {
+    @apply inline-flex items-center justify-center rounded-full border border-gold-300/60 bg-gold-300 px-5 py-3 text-sm font-black uppercase tracking-[0.18em] text-slate-950 shadow-gold transition hover:-translate-y-0.5 hover:bg-gold-200 active:translate-y-0;
+  }
+
+  .premium-button-secondary {
+    @apply inline-flex items-center justify-center rounded-full border border-purple-300/30 bg-purple-300/10 px-5 py-3 text-sm font-bold uppercase tracking-[0.16em] text-purple-100 transition hover:-translate-y-0.5 hover:border-gold-300/50 hover:text-gold-100 active:translate-y-0;
+  }
+}
+
+.capital-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid rgba(234, 200, 90, 0.18);
+  background: rgba(3, 7, 18, 0.82);
+  backdrop-filter: blur(18px);
+}
+.capital-header-inner {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  align-items: center;
+}
+.capital-logo {
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  color: #fff7d6;
+  display: inline-flex;
+  align-items: center;
+  gap: .65rem;
+  white-space: nowrap;
+}
+.capital-logo-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(234, 200, 90, 0.5);
+  background: linear-gradient(135deg, rgba(234, 200, 90, 0.95), rgba(167, 139, 250, 0.35));
+  color: #05050a;
+  font-size: .7rem;
+  box-shadow: 0 0 28px rgba(234, 200, 90, 0.2);
+}
+.capital-nav, .capital-ecosystem-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem .9rem;
+  min-width: 0;
+}
+.capital-nav a, .capital-ecosystem-nav a {
+  border-radius: 9999px;
+  padding: .45rem .8rem;
+  font-size: .86rem;
+  color: #d8d2e8;
+  transition: color .2s ease, background .2s ease, border-color .2s ease;
+}
+.capital-nav a:hover, .capital-ecosystem-nav a:hover {
+  background: rgba(234, 200, 90, 0.08);
+  color: #fff4bf;
+}
+@media (min-width: 1024px) {
+  .capital-nav { margin-left: auto; }
+  .capital-ecosystem-nav { margin-left: 1rem; border-left:1px solid rgba(234, 200, 90, 0.18); padding-left: 1rem; }
+}
+
+/* Legacy utility bridge: keep older route markup visually aligned with the OneGodian production system. */
+:where(.bg-slate-950, .bg-slate-900, .bg-slate-800) {
+  background-color: rgba(5, 5, 10, 0.9);
+}
+:where(.bg-slate-900\/70, .bg-slate-900\/60, .bg-slate-900\/50, .bg-slate-900\/40, .bg-slate-950\/70, .bg-slate-950\/80) {
+  background: linear-gradient(135deg, rgba(10, 18, 34, 0.76), rgba(5, 5, 10, 0.82));
+  backdrop-filter: blur(18px);
+}
+:where(.border-slate-800, .border-slate-700, .border-slate-600, .border-cyan-500\/30, .border-cyan-400\/30, .border-cyan-700\/40) {
+  border-color: rgba(234, 200, 90, 0.18);
+}
+:where(.text-cyan-100, .text-cyan-200, .text-cyan-300, .text-cyan-400) {
+  color: #eac85a;
+}
+:where(.bg-cyan-500\/20, .bg-cyan-500\/10) {
+  background-color: rgba(234, 200, 90, 0.1);
+}
+:where(.border-cyan-400\/40, .border-cyan-400\/50, .border-cyan-400\/60, .border-cyan-400\/70, .border-cyan-400\/80) {
+  border-color: rgba(234, 200, 90, 0.42);
+}
+:where(.ring-cyan-300\/40) {
+  --tw-ring-color: rgba(234, 200, 90, 0.35);
+}

--- a/src/app/investor-portal/page.tsx
+++ b/src/app/investor-portal/page.tsx
@@ -1,1 +1,11 @@
-export default function Page(){return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">investor portal </h1><p className="mt-2 text-slate-300">Administrative record workspace for investor portal with disclosure review and acknowledgement workflow support.</p></main>}
+export default function Page() {
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Investor Portal</h1>
+        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for investor portal with disclosure review and acknowledgement workflow support.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,3 +1,11 @@
 export default function LegalPage() {
-  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Legal</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network legal content.</p></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-4xl px-4 py-10">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Institutional Surface</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Legal</h1>
+        <p className="mt-4 leading-7 text-slate-300">This page is reserved for OneGodian legal content, institutional notices, and public boundary language.</p>
+      </section>
+    </main>
+  );
 }

--- a/src/app/offerings/page.tsx
+++ b/src/app/offerings/page.tsx
@@ -1,1 +1,11 @@
-export default function Page(){return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">offerings </h1><p className="mt-2 text-slate-300">Administrative record workspace for offerings with disclosure review and acknowledgement workflow support.</p></main>}
+export default function Page() {
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Offerings</h1>
+        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for offerings with disclosure review and acknowledgement workflow support.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,43 @@
 import Link from 'next/link';
+import { appMeta } from '@/lib/onegodian-content';
 
 const routes = [
-  { href: '/ecosystem', label: 'Ecosystem' },
-  { href: '/omos', label: 'OMOS' },
-  { href: '/remember', label: 'Remember' },
-  { href: '/membership', label: 'Membership' },
-  { href: '/time', label: 'Time' },
-  { href: '/commerce', label: 'Commerce' },
-  { href: '/institutional', label: 'Institutional' },
-  { href: '/dashboard', label: 'Dashboard' }
+  { href: '/ecosystem', label: 'Ecosystem', detail: 'Connected domain and platform map' },
+  { href: '/omos', label: 'OMOS', detail: 'Operating model and runtime context' },
+  { href: '/remember', label: 'Remember', detail: 'Campaign access and participation' },
+  { href: '/membership', label: 'Membership', detail: 'Member pathways and records entry' },
+  { href: '/time', label: 'Time', detail: 'OneGodian Time and UTC clarity' },
+  { href: '/commerce', label: 'Commerce', detail: 'Products, memberships, and checkout routing' },
+  { href: '/institutional', label: 'Institutional', detail: 'Public boundary and clarity language' },
+  { href: '/dashboard', label: 'Dashboard', detail: 'Member node overview and module status' }
 ];
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-slate-950 px-4 py-10 text-slate-100">
-      <div className="mx-auto max-w-5xl space-y-6">
-        <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8">
-          <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App</p>
-          <h1 className="mt-2 text-4xl font-bold">Live Public + Member Application Node</h1>
-          <p className="mt-3 text-slate-300">Production content routes for ecosystem, OMOS, remembrance, membership, time, commerce, and institutional clarity.</p>
+    <main className="onegodian-surface min-h-screen px-4 py-10 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="glass-panel relative overflow-hidden p-6 sm:p-8 lg:p-10">
+          <div className="absolute right-6 top-6 hidden h-28 w-28 rounded-full border border-gold-300/30 bg-gold-300/10 blur-sm sm:block" />
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-gold-300">{appMeta.eyebrow}</p>
+          <h1 className="mt-4 max-w-4xl text-4xl font-black tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">{appMeta.title}</h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-slate-300 sm:text-lg">{appMeta.description}</p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link href={appMeta.primaryCta.href} className="premium-button">{appMeta.primaryCta.label}</Link>
+            <Link href={appMeta.secondaryCta.href} className="premium-button-secondary">{appMeta.secondaryCta.label}</Link>
+          </div>
         </section>
+
         <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {routes.map((route) => (
-            <Link key={route.href} href={route.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-4 text-cyan-200 hover:border-cyan-400/50">
-              {route.label}
+            <Link key={route.href} href={route.href} className="mobile-card group">
+              <span className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200/80">Node</span>
+              <h2 className="mt-3 text-xl font-bold text-white group-hover:text-gold-200">{route.label}</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{route.detail}</p>
+              <span className="mt-5 inline-flex text-xs font-semibold uppercase tracking-[0.22em] text-gold-300">Open →</span>
             </Link>
           ))}
         </section>
       </div>
     </main>
   );
-const links = [
-  { title: 'Ecosystem', href: '/ecosystem' },
-  { title: 'OMOS', href: '/omos' },
-  { title: 'Remember', href: '/remember' },
-  { title: 'Membership', href: '/membership' },
-  { title: 'Time', href: '/time' },
-  { title: 'Commerce', href: '/commerce' },
-  { title: 'Institutional', href: '/institutional' }
-];
-
-export default function HomePage() {
-  return <main className="space-y-8"><section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8"><p className="text-xs uppercase tracking-[0.2em] text-cyan-300">OneGodian App · Live</p><h1 className="mt-3 text-4xl font-bold">Public OneGodian App Node</h1><p className="mt-4 max-w-4xl text-slate-300">This production app provides public-safe ecosystem content, campaign access, membership entry points, time references, commerce routing, and institutional clarity.</p></section><section className="grid gap-4 md:grid-cols-2">{links.map((item) => <Link key={item.href} href={item.href} className="rounded-xl border border-slate-700 bg-slate-900/60 p-5 hover:border-cyan-400/60"><h2 className="text-xl font-semibold text-cyan-200">{item.title}</h2><p className="mt-2 text-sm text-slate-300">Open {item.href}</p></Link>)}</section></main>;
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -5,5 +5,23 @@ const plans = [
 ];
 
 export default function PricingPage() {
-  return <main className="mx-auto max-w-6xl px-4 py-10"><h1 className="text-3xl font-bold">Issuer Pricing</h1><div className="mt-6 grid gap-4 md:grid-cols-3">{plans.map((plan)=><section key={plan.name} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5"><h2 className="text-xl font-semibold text-cyan-200">{plan.name}</h2><p className="mt-2 text-lg font-bold">{plan.price}</p><ul className="mt-3 space-y-2 text-sm text-slate-300">{plan.features.map((feature)=><li key={feature}>• {feature}</li>)}</ul></section>)}</div></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Verification Network</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Issuer Pricing</h1>
+      </section>
+      <div className="mt-6 grid gap-4 md:grid-cols-3">
+        {plans.map((plan) => (
+          <section key={plan.name} className="mobile-card">
+            <h2 className="text-xl font-bold text-white">{plan.name}</h2>
+            <p className="mt-2 text-2xl font-black text-gold-300">{plan.price}</p>
+            <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-300">
+              {plan.features.map((feature) => <li key={feature}><span className="mr-2 text-gold-300">✦</span>{feature}</li>)}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,3 +1,11 @@
 export default function PrivacyPage() {
-  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Privacy</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network privacy content.</p></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-4xl px-4 py-10">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Policy Surface</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Privacy</h1>
+        <p className="mt-4 leading-7 text-slate-300">This page is reserved for OneGodian privacy content and public/member data handling guidance.</p>
+      </section>
+    </main>
+  );
 }

--- a/src/app/production-readiness/page.tsx
+++ b/src/app/production-readiness/page.tsx
@@ -2,5 +2,26 @@ import { CapitalReadinessTable } from '../components/CapitalReadinessTable';
 import { readinessItems } from '../data';
 
 export default function ProductionReadinessPage() {
-  return <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100"><h1 className="text-3xl font-bold">Production Readiness</h1><p className="mt-2 text-slate-300">Current operating maturity for the capital.onegodian.com Hostinger Node application.</p><section className="mt-6"><CapitalReadinessTable items={readinessItems} /></section><section className="mt-8"><h2 className="text-xl font-semibold">Next Actions</h2><div className="mt-3 grid gap-3 md:grid-cols-2">{readinessItems.map((item) => <article key={item.layer} className="rounded-lg border border-slate-700 bg-slate-900/70 p-4"><h3 className="font-medium">{item.layer}</h3><p className="text-sm text-cyan-200">Status: {item.status}</p><p className="text-sm text-slate-300">{item.detail}</p></article>)}</div></section></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Production Operations</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Production Readiness</h1>
+        <p className="mt-3 leading-7 text-slate-300">Current operating maturity for the OneGodian Hostinger Node application.</p>
+      </section>
+      <section className="mt-6"><CapitalReadinessTable items={readinessItems} /></section>
+      <section className="mt-8">
+        <h2 className="text-xl font-bold text-white">Next Actions</h2>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          {readinessItems.map((item) => (
+            <article key={item.layer} className="mobile-card">
+              <h3 className="font-bold text-white">{item.layer}</h3>
+              <p className="mt-2 text-sm font-semibold text-gold-300">Status: {item.status}</p>
+              <p className="mt-1 text-sm leading-6 text-slate-300">{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,3 +1,11 @@
 export default function TermsPage() {
-  return <main className="mx-auto max-w-4xl px-4 py-10"><h1 className="text-3xl font-bold">Terms</h1><p className="mt-4 text-slate-300">This page is reserved for QRV Network terms content.</p></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-4xl px-4 py-10">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Terms Surface</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Terms</h1>
+        <p className="mt-4 leading-7 text-slate-300">This page is reserved for OneGodian terms content and public/member usage guidance.</p>
+      </section>
+    </main>
+  );
 }

--- a/src/app/use-cases/page.tsx
+++ b/src/app/use-cases/page.tsx
@@ -6,5 +6,20 @@ const useCases = [
 ];
 
 export default function UseCasesPage() {
-  return <main className="mx-auto max-w-6xl px-4 py-10"><h1 className="text-3xl font-bold">Verification Use Cases</h1><div className="mt-6 grid gap-4 md:grid-cols-2">{useCases.map((item)=><section key={item.title} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5"><h2 className="text-xl font-semibold text-cyan-200">{item.title}</h2><p className="mt-2 text-sm text-slate-300">{item.body}</p></section>)}</div></main>;
+  return (
+    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10">
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Trust Rails</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Verification Use Cases</h1>
+      </section>
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
+        {useCases.map((item) => (
+          <section key={item.title} className="mobile-card">
+            <h2 className="text-xl font-bold text-white">{item.title}</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{item.body}</p>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
 }

--- a/src/components/AppStatusPanel.tsx
+++ b/src/components/AppStatusPanel.tsx
@@ -2,17 +2,18 @@ import { appStatus } from '@/lib/onegodian-content';
 
 export function AppStatusPanel() {
   return (
-    <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-6">
-      <h2 className="text-xl font-semibold">App Status</h2>
-      <dl className="mt-4 grid gap-3 sm:grid-cols-2">
-        <div><dt className="text-xs text-slate-400">App URL</dt><dd>{appStatus.appUrl}</dd></div>
-        <div><dt className="text-xs text-slate-400">Store URL</dt><dd>{appStatus.store}</dd></div>
-        <div><dt className="text-xs text-slate-400">Public site URL</dt><dd>{appStatus.publicSite}</dd></div>
-        <div><dt className="text-xs text-slate-400">API URL</dt><dd>{appStatus.api}</dd></div>
-        <div><dt className="text-xs text-slate-400">Active campaign</dt><dd>{appStatus.activeCampaign}</dd></div>
-        <div><dt className="text-xs text-slate-400">System status</dt><dd>{appStatus.environment}</dd></div>
+    <section className="mobile-card p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gold-300">Runtime Status</p>
+      <h2 className="mt-2 text-xl font-black text-white">App Status</h2>
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">App URL</dt><dd className="break-all text-white">{appStatus.appUrl}</dd></div>
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">Store URL</dt><dd className="break-all text-white">{appStatus.store}</dd></div>
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">Public site URL</dt><dd className="break-all text-white">{appStatus.publicSite}</dd></div>
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">API URL</dt><dd className="break-all text-white">{appStatus.api}</dd></div>
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">Active campaign</dt><dd className="text-white">{appStatus.activeCampaign}</dd></div>
+        <div><dt className="text-xs uppercase tracking-[0.16em] text-purple-100/70">System status</dt><dd className="text-white">{appStatus.environment}</dd></div>
       </dl>
-      <p className="mt-4 text-xs text-slate-400">Last updated: {appStatus.currentDateRecord}</p>
+      <p className="mt-5 text-xs text-slate-400">Last updated: {appStatus.currentDateRecord}</p>
     </section>
   );
 }

--- a/src/components/app-frame.tsx
+++ b/src/components/app-frame.tsx
@@ -1,10 +1,59 @@
 'use client';
+
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { type ReactNode } from 'react';
 import { appNavigation, ecosystemLinks } from '@/lib/onegodian-content';
 
 export function AppFrame({ children }: { children: ReactNode }) {
-  const pathname = usePathname() ?? "";
-  return <div className="min-h-screen bg-slate-950 text-slate-100"><header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-4 py-4 backdrop-blur"><div className="flex items-center justify-between"><Link href="/" className="font-semibold text-cyan-300">OneGodian App · Public/Member Node</Link></div><div className="mt-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"><nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">{appNavigation.map((item) => {const active = pathname === item.href || pathname.startsWith(`${item.href}/`);return <Link key={item.href} href={item.href} className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${active ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-200' : 'border-slate-700 text-slate-300 hover:border-cyan-400/50 hover:text-cyan-200'}`}>{item.label}</Link>;})}</nav></div><div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">{ecosystemLinks.map((item) => <a key={item.href} href={item.href} target="_blank" rel="noreferrer" className="hover:text-cyan-300">{item.label}</a>)}</div></header><div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6">{children}</div></div>;
+  const pathname = usePathname() ?? '';
+
+  return (
+    <div className="onegodian-surface min-h-screen text-slate-100">
+      <header className="sticky top-0 z-30 border-b border-gold-300/15 bg-abyss/82 px-4 py-4 shadow-sovereign backdrop-blur-2xl">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Link href="/" className="inline-flex items-center gap-3 font-black tracking-[-0.03em] text-white">
+              <span className="grid h-9 w-9 place-items-center rounded-full border border-gold-300/40 bg-gold-300 text-xs font-black text-abyss shadow-gold">OG</span>
+              <span>
+                OneGodian App
+                <span className="ml-2 hidden text-xs font-semibold uppercase tracking-[0.22em] text-gold-300 sm:inline">Public / Member Node</span>
+              </span>
+            </Link>
+            <div className="rounded-full border border-purple-300/20 bg-purple-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-purple-100">Production Dashboard</div>
+          </div>
+
+          <div className="mt-4 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <nav className="flex min-w-max flex-nowrap gap-2" aria-label="Main navigation">
+              {appNavigation.map((item) => {
+                const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm font-semibold transition ${
+                      active
+                        ? 'border-gold-300/70 bg-gold-300/18 text-gold-100 shadow-gold'
+                        : 'border-white/10 bg-white/[0.03] text-slate-300 hover:border-purple-300/40 hover:text-gold-100'
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+
+          <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">
+            {ecosystemLinks.map((item) => (
+              <a key={item.href} href={item.href} target="_blank" rel="noreferrer" className="hover:text-gold-300">
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:py-10">{children}</div>
+    </div>
+  );
 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -12,12 +12,14 @@ type Module = {
 
 export function AppShell({ title, modules }: { title: string; modules: Module[] }) {
   return (
-    <main className="relative min-h-screen overflow-hidden px-6 py-10">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(99,102,241,0.22),transparent_28%),radial-gradient(circle_at_85%_5%,rgba(34,211,238,0.2),transparent_30%),linear-gradient(to_bottom,rgba(2,6,23,1),rgba(2,6,23,.88))]" />
-      <div className="pointer-events-none absolute inset-0 opacity-30 [background-image:linear-gradient(rgba(148,163,184,.14)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,.1)_1px,transparent_1px)] [background-size:36px_36px]" />
-      <div className="mx-auto max-w-6xl">
-        <h1 className="relative text-3xl font-bold tracking-wide text-slate-100">{title}</h1>
-        <div className="relative mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <main className="onegodian-surface relative min-h-screen overflow-hidden px-4 py-8 sm:px-6 lg:px-8 lg:py-10">
+      <div className="pointer-events-none absolute inset-0 opacity-35 [background-image:linear-gradient(rgba(234,200,90,.12)_1px,transparent_1px),linear-gradient(90deg,rgba(167,139,250,.12)_1px,transparent_1px)] [background-size:40px_40px]" />
+      <div className="relative mx-auto max-w-6xl">
+        <section className="glass-panel p-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Production Dashboard</p>
+          <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white sm:text-4xl">{title}</h1>
+        </section>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {modules.map((module) => (
             <ModuleCard key={module.title} {...module} />
           ))}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -11,48 +11,40 @@ type ModuleCardProps = {
 };
 
 const accentStyles = {
-  cyan: 'from-cyan-400/80 to-cyan-500/30 border-cyan-400/35',
-  gold: 'from-amber-300/80 to-amber-500/20 border-amber-300/35',
-  violet: 'from-violet-400/80 to-violet-600/20 border-violet-400/35',
-  emerald: 'from-emerald-400/80 to-emerald-600/20 border-emerald-400/35',
-  magenta: 'from-fuchsia-400/80 to-fuchsia-600/20 border-fuchsia-400/35',
-  orange: 'from-orange-400/80 to-orange-600/20 border-orange-400/35',
-  red: 'from-red-400/80 to-red-600/20 border-red-400/35',
-  silver: 'from-slate-300/70 to-slate-400/20 border-slate-300/35'
+  cyan: 'from-cyan-300/70 to-purple-400/20 border-cyan-300/30 text-cyan-100',
+  gold: 'from-gold-300/85 to-gold-500/25 border-gold-300/45 text-gold-100',
+  violet: 'from-purple-300/75 to-royal/25 border-purple-300/40 text-purple-100',
+  emerald: 'from-emerald-300/75 to-emerald-600/20 border-emerald-300/35 text-emerald-100',
+  magenta: 'from-fuchsia-300/75 to-purple-600/25 border-fuchsia-300/35 text-fuchsia-100',
+  orange: 'from-orange-300/80 to-gold-500/25 border-orange-300/35 text-orange-100',
+  red: 'from-red-300/75 to-red-600/20 border-red-300/35 text-red-100',
+  silver: 'from-slate-200/70 to-slate-500/20 border-slate-200/30 text-slate-100'
 };
 
 function Glyph({ glyph = 'dashboard' }: { glyph?: ModuleCardProps['glyph'] }) {
-  const common = 'h-14 w-14 stroke-[1.5] text-cyan-200/80 transition-transform duration-300 group-hover:scale-105 group-hover:rotate-3';
+  const common = 'h-14 w-14 stroke-[1.35] text-gold-200/75 transition-transform duration-300 group-hover:scale-105 group-hover:rotate-3';
   if (glyph === 'planet') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="12" cy="12" r="4.5" /><ellipse cx="12" cy="12" rx="9" ry="3.2" /><path d="M3 14c1.8 1.2 4.2 2 9 2s7.2-.8 9-2" /></svg>;
   if (glyph === 'moons') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="12" cy="12" r="2.8" /><circle cx="6.5" cy="8" r="1.6" /><circle cx="18" cy="15.5" r="1.8" /><path d="M4 12a8 8 0 0 1 8-8" /><path d="M20 12a8 8 0 0 1-8 8" /></svg>;
   if (glyph === 'ecosystem') return <svg viewBox="0 0 24 24" fill="none" className={common}><circle cx="6" cy="7" r="2" /><circle cx="18" cy="6" r="2" /><circle cx="12" cy="17" r="2" /><path d="M7.8 8.1 10.2 15" /><path d="M16.2 7.1 13.8 15" /><path d="M8 7h8" /></svg>;
   return <svg viewBox="0 0 24 24" fill="none" className={common}><rect x="4" y="4" width="16" height="16" rx="3" /><path d="M8 9h8M8 13h8M8 17h5" /></svg>;
 }
 
-export function ModuleCard({ title, description, href = '#', accent = 'cyan', stats = [], glyph = 'dashboard', featured = false }: ModuleCardProps) {
+export function ModuleCard({ title, description, href = '#', accent = 'gold', stats = [], glyph = 'dashboard', featured = false }: ModuleCardProps) {
   return (
-    <Link
-      href={href}
-      className={`group relative overflow-hidden rounded-2xl border bg-slate-900/70 p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(34,211,238,0.18)] active:translate-y-0.5 ${accentStyles[accent]} ${
-        featured ? 'sm:col-span-2 lg:col-span-1 lg:min-h-64' : ''
-      }`}
-    >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(103,232,249,0.13),transparent_50%),linear-gradient(135deg,rgba(15,23,42,0.85),rgba(2,6,23,0.95))]" />
-      <div className="absolute right-2 top-2 opacity-90">
-        <Glyph glyph={glyph} />
-      </div>
+    <Link href={href} className={`mobile-card group ${featured ? 'sm:col-span-2 lg:col-span-1 lg:min-h-64' : ''}`}>
+      <div className="absolute right-3 top-3 opacity-90"><Glyph glyph={glyph} /></div>
       <div className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${accentStyles[accent].split(' ').slice(0, 2).join(' ')}`} />
       <div className="relative">
-        <h3 className="text-lg font-semibold text-slate-100">{title}</h3>
-        <p className="mt-2 max-w-[85%] text-sm text-slate-300">{description}</p>
+        <h3 className="max-w-[82%] text-lg font-bold text-white">{title}</h3>
+        <p className="mt-2 max-w-[88%] text-sm leading-6 text-slate-300">{description}</p>
         {stats.length > 0 && (
-          <ul className="mt-4 space-y-1 text-xs text-slate-300/90">
+          <ul className="mt-4 space-y-2 text-xs text-slate-300/95">
             {stats.slice(0, 3).map((item) => (
-              <li key={item} className="flex items-center gap-2"><span className="h-1.5 w-1.5 rounded-full bg-cyan-300" />{item}</li>
+              <li key={item} className="flex items-center gap-2"><span className="h-1.5 w-1.5 rounded-full bg-gold-300" />{item}</li>
             ))}
           </ul>
         )}
-        <span className="mt-4 inline-block text-xs font-medium uppercase tracking-[0.2em] text-cyan-200/80">Open Module →</span>
+        <span className="mt-5 inline-block text-xs font-black uppercase tracking-[0.22em] text-gold-300">Open Module →</span>
       </div>
     </Link>
   );

--- a/src/components/module-shell-page.tsx
+++ b/src/components/module-shell-page.tsx
@@ -17,17 +17,17 @@ export function ModuleShellPage({ slug, pageTitle }: ModuleShellPageProps) {
 
   return (
     <main className="space-y-6 text-slate-100">
-      <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">{appModule.category} Module</p>
-        <h1 className="mt-2 text-3xl font-bold text-white sm:text-4xl">{pageTitle ?? appModule.title}</h1>
+      <section className="glass-panel p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">{appModule.category} Module</p>
+        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white sm:text-4xl">{pageTitle ?? appModule.title}</h1>
       </section>
-      <section className="rounded-2xl border border-slate-700 bg-slate-900/60 p-5">
-        <h2 className="text-lg font-semibold text-cyan-200">Connected Systems</h2>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <section className="mobile-card">
+        <h2 className="text-lg font-bold text-white">Connected Systems</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {connectedSystems.map((connected) => (
-            <Link key={connected.slug} href={connected.route} className="rounded-xl border border-slate-700 bg-slate-950/70 p-4 transition hover:border-cyan-400/70">
-              <p className="text-sm font-semibold text-slate-100">{connected.title}</p>
-              <p className="mt-1 text-xs text-slate-400">{connected.route}</p>
+            <Link key={connected.slug} href={connected.route} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 transition hover:border-gold-300/40 hover:bg-gold-300/10">
+              <p className="text-sm font-semibold text-white">{connected.title}</p>
+              <p className="mt-1 text-xs text-purple-100/75">{connected.route}</p>
             </Link>
           ))}
         </div>

--- a/src/components/module-ui.tsx
+++ b/src/components/module-ui.tsx
@@ -2,31 +2,32 @@ import type { ReactNode } from 'react';
 
 export function ModuleHeader({ title, description, cta }: { title: string; description: string; cta?: ReactNode }) {
   return (
-    <header className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
-      <h1 className="text-3xl font-bold text-slate-100">{title}</h1>
-      <p className="mt-3 max-w-4xl text-slate-300">{description}</p>
-      {cta ? <div className="mt-4">{cta}</div> : null}
+    <header className="glass-panel p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">OneGodian Module</p>
+      <h1 className="mt-3 text-3xl font-black tracking-[-0.03em] text-white">{title}</h1>
+      <p className="mt-3 max-w-4xl leading-7 text-slate-300">{description}</p>
+      {cta ? <div className="mt-5">{cta}</div> : null}
     </header>
   );
 }
 
 export function StatusBadge({ status }: { status: string }) {
-  return <span className="rounded-full border border-cyan-400/60 bg-cyan-500/10 px-2 py-1 text-xs font-medium text-cyan-200">{status}</span>;
+  return <span className="rounded-full border border-gold-300/50 bg-gold-300/10 px-2.5 py-1 text-xs font-bold text-gold-100">{status}</span>;
 }
 
 export function PriorityBadge({ priority }: { priority: string }) {
-  const tone = priority === 'Critical' ? 'border-red-400/60 bg-red-500/10 text-red-200' : priority === 'High' ? 'border-amber-400/60 bg-amber-500/10 text-amber-200' : 'border-slate-500/70 bg-slate-800 text-slate-200';
-  return <span className={`rounded-full border px-2 py-1 text-xs font-medium ${tone}`}>{priority}</span>;
+  const tone = priority === 'Critical' ? 'border-red-300/60 bg-red-500/10 text-red-100' : priority === 'High' ? 'border-gold-300/60 bg-gold-300/10 text-gold-100' : 'border-purple-300/40 bg-purple-300/10 text-purple-100';
+  return <span className={`rounded-full border px-2.5 py-1 text-xs font-bold ${tone}`}>{priority}</span>;
 }
 
 export function ChecklistCard({ title = 'Production Checklist', items }: { title?: string; items: string[] }) {
   return (
-    <section className="rounded-xl border border-slate-700 bg-slate-900/50 p-5">
-      <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
-      <ul className="mt-3 space-y-2 text-sm text-slate-300">
+    <section className="mobile-card">
+      <h2 className="text-lg font-bold text-white">{title}</h2>
+      <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-300">
         {items.map((item) => (
           <li key={item} className="flex gap-2">
-            <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-300" />
+            <span className="mt-2 h-1.5 w-1.5 rounded-full bg-gold-300" />
             <span>{item}</span>
           </li>
         ))}

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -2,12 +2,16 @@
   "name": "OMOS Runtime",
   "fullName": "OneGodian Metaphysical Operating System™",
   "version": "1.1.0",
-  "version": "1.0.2",
   "status": "production",
   "canonical_domain": "omos.onegodian.com",
+  "canonicalHost": "https://omos.onegodian.com",
+  "classification": "Node runtime, protocol documentation, and agent-facing integration site",
   "purpose": "Public runtime for OneGodian routes, page registry, and manifest delivery.",
   "integrations": ["OneGodian App", "WordPress Bridge"],
   "wordpress_hosts": ["OneGodian.com", "OneGodian.org", "QuantumOHI.com"],
+  "compatibleHosts": ["https://onegodian.com", "https://onegodian.org", "https://quantumohi.com"],
+  "appBridge": ["https://app.onegodian.com"],
+  "commerceBridge": ["https://onegodian.com"],
   "routes": [
     "/",
     "/dashboard",
@@ -20,21 +24,9 @@
     "/institutional",
     "/api/health",
     "/api/manifest",
-    "/api/pages"
-  ]
     "/api/pages",
     "/api/tools",
     "/api/artifacts",
     "/api/system-health"
-  ],
-  "fullName": "OneGodian Metaphysical Operating System™",
-  "classification": "Node runtime, protocol documentation, and agent-facing integration site",
-  "canonicalHost": "https://omos.onegodian.com",
-  "compatibleHosts": [
-    "https://onegodian.com",
-    "https://onegodian.org",
-    "https://quantumohi.com"
-  ],
-  "appBridge": ["https://app.onegodian.com"],
-  "commerceBridge": ["https://onegodian.com"]
+  ]
 }

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -2,10 +2,7 @@ export const appHomeHero = {
   eyebrow: 'APP.ONEGODIAN.COM',
   title: 'OneGodian App',
   description:
-    'Unified OneGodian public/member application for ecosystem navigation, OMOS content, time systems, campaign pages, and dashboard access.',
-  primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
-  secondaryCta: { label: 'Explore Ecosystem', href: '/ecosystem' }
-    'Your unified OneGodian dashboard for membership, campaigns, commerce, OMOS, time, and ecosystem access.',
+    'Unified OneGodian public/member application for ecosystem navigation, OMOS content, time systems, campaign pages, commerce routing, and dashboard access.',
   primaryCta: {
     label: 'Open Dashboard',
     href: '/dashboard'
@@ -29,79 +26,24 @@ export const appNavigation = [
 ];
 
 export const appDashboardCards = [
-  { title: 'Ecosystem', description: 'Platform map spanning public, app, commerce, education, OMOS, and verification nodes.', href: '/ecosystem', status: 'Active' },
-  { title: 'OMOS', description: 'OneGodian Metaphysical Operating System mind map, protocol, and runtime context.', href: '/omos', status: 'Live' },
-  { title: 'Remember', description: 'OneGodian: Remember campaign page and participant resource entry.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Membership entry route for public and dashboard handoff.', href: '/membership', status: 'Available' },
-  { title: 'Time', description: 'OneGodian Time™ / OTS-V5 route with dual-date and legal safety language.', href: '/time', status: 'Active' },
-  { title: 'Commerce', description: 'OneGodian.com commerce and identity product engine route.', href: '/commerce', status: 'Active' },
-  { title: 'Institutional Clarity', description: 'Separation of ONEGODIAN, LLC operations and INO internal governance context.', href: '/institutional', status: 'Active' }
-];
-
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public identity and writings.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Education and LMS node.', url: 'https://u.onegodian.org' },
-  { name: 'app.OneGodian.com', role: 'Public/member app node.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'Galaxy platform surface.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'OMOS protocol and runtime docs.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI systems positioning.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network.', url: 'https://qrv.network' }
-];
-
-export const appFooterBoundary =
-  'OneGodian App is the public/member-facing surface. Admin/control panel operations remain separate and compatible through dedicated internal surfaces.';
-];
-
-export const appDashboardCards = [
-  { title: 'Ecosystem', description: 'See live OneGodian ecosystem domains and operating roles.', href: '/ecosystem', status: 'Live' },
-  { title: 'OMOS', description: 'Review the OneGodian Metaphysical Operating System structure and modules.', href: '/omos', status: 'Live' },
-  { title: 'Remember Campaign', description: 'Read the public OneGodian: Remember campaign story and participation guidance.', href: '/remember', status: 'Live' },
-  { title: 'Membership', description: 'Access member pathways, dashboard entry, and community participation options.', href: '/membership', status: 'Live' },
-  { title: 'Time · OTS-V5', description: 'Use OneGodian Time™ with dual-date display and legal-safe chronology notes.', href: '/time', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com as the commerce and identity product engine.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'See the legal and operational distinction between ONEGODIAN, LLC and INO.', href: '/institutional', status: 'Live' }
-];
-
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public presence, education, and institutional identity.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine for memberships and products.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Learning pathways, course delivery, and student services.', url: 'https://u.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public/member app dashboard and route layer.', url: 'https://app.onegodian.com' },
-  { name: 'galaxy.OneGodian.com', role: 'World, platform, and story navigation surfaces.', url: 'https://galaxy.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'Protocol and operating system specification node.', url: 'https://omos.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'OHI architecture and model context.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification network and record trust infrastructure.', url: 'https://qrv.network' }
-  { label: 'Architecture', href: '/architecture' },
-  { label: 'About', href: '/about' },
-  { label: 'Sitemap', href: '/sitemap' },
-  { label: 'Membership', href: '/membership' },
-  { label: 'Commerce', href: '/commerce' },
-  { label: 'Remember', href: '/remember' },
-  { label: 'Institutional', href: '/institutional' }
-];
-
-export const appDashboardCards = [
-  { title: 'My OneGodian Profile', description: 'View your profile, identity details, membership status, and dashboard access.', href: '/profile', status: 'Active' },
-  { title: 'Membership', description: 'Access OneGodian membership records, benefits, onboarding, and participation tools.', href: '/members', status: 'Available' },
-  { title: 'Certificates', description: 'View and verify OneGodian certificates, completion records, and issued documents.', href: '/certificates', status: 'Available' },
-  { title: 'Remember Campaign', description: 'Access THE ONEGODIAN: Remember Campaign resources, media, captions, and participation tools.', href: '/remember', status: 'Live' },
-  { title: 'Membership Hub', description: 'Open membership records, onboarding, benefits, and participation routes.', href: '/membership', status: 'Live' },
-  { title: 'Commerce Engine', description: 'Open OneGodian.com commerce and identity engine context.', href: '/commerce', status: 'Live' },
-  { title: 'Institutional Clarity', description: 'Review institutional boundary language for LLC and INO contexts.', href: '/institutional', status: 'Live' },
-  { title: 'Media Center', description: 'Access OneGodian media, campaign visuals, music, videos, and brand assets.', href: '/media', status: 'Available' },
-  { title: 'Products', description: 'Explore OneGodian products, digital downloads, apparel, books, and ecosystem offerings.', href: '/products', status: 'Available' },
-  { title: 'Learning', description: 'Connect to U OneGodian courses, learning paths, student tools, and educational programs.', href: '/learning', status: 'Connected' },
-  { title: 'Ecosystem', description: 'Navigate OneGodian.org, OneGodian.com, U OneGodian, Galaxy, Capital, OMOS, and Console.', href: '/ecosystem', status: 'Active' }
+  { title: 'Ecosystem', description: 'Platform map spanning public, app, commerce, education, OMOS, galaxy, and verification nodes.', href: '/ecosystem', status: 'Active' },
+  { title: 'OMOS', description: 'OneGodian Metaphysical Operating System protocol, runtime context, and manifest surfaces.', href: '/omos', status: 'Live' },
+  { title: 'Remember', description: 'THE ONEGODIAN: Remember campaign page and participant resource entry.', href: '/remember', status: 'Live' },
+  { title: 'Membership', description: 'Membership entry route for profile records, participation tools, and dashboard workflows.', href: '/membership', status: 'Available' },
+  { title: 'Commerce Engine', description: 'OneGodian.com commerce and identity product engine context for offerings and checkout.', href: '/commerce', status: 'Live' },
+  { title: 'Institutional Clarity', description: 'Institutional boundary language for public, private, and operational contexts.', href: '/institutional', status: 'Live' },
+  { title: 'Media Center', description: 'Campaign visuals, brand assets, music, video, and publishing surfaces.', href: '/media', status: 'Available' },
+  { title: 'Products', description: 'Products, digital downloads, apparel, books, and ecosystem offerings.', href: '/products', status: 'Available' },
+  { title: 'Learning', description: 'Connect to U OneGodian courses, learning paths, student tools, and certificates.', href: '/learning', status: 'Connected' }
 ];
 
 export const ecosystemPortals = [
   { name: 'OneGodian.org', role: 'Official public identity, writings, remembrance, articles, and institutional explanation.', url: 'https://onegodian.org' },
   { name: 'OneGodian.com', role: 'Store, products, memberships, commerce, apparel, books, and digital downloads.', url: 'https://onegodian.com' },
   { name: 'u.OneGodian.com', role: 'Education, LMS, learning paths, student tools, and certificates.', url: 'https://u.onegodian.com' },
+  { name: 'app.OneGodian.com', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' },
   { name: 'Galaxy OneGodian', role: 'Galaxy interface, planet navigator, planet-store gateway, and immersive ecosystem layer.', url: 'https://galaxy.onegodian.com' },
   { name: 'OMOS OneGodian', role: 'OMOS protocol, specification, alignment system, and consciousness-centered operating model.', url: 'https://omos.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Public and member-facing dashboard for membership, certificates, campaigns, media, tools, and ecosystem access.', url: 'https://app.onegodian.com' },
   { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context for OneGodian ecosystem design.', url: 'https://quantumohi.com' },
   { name: 'QRV.Network', role: 'Verification and trust infrastructure connected to OneGodian records and identity workflows.', url: 'https://qrv.network' }
 ];

--- a/src/lib/app-sitemap.ts
+++ b/src/lib/app-sitemap.ts
@@ -3,7 +3,7 @@ export type AppRouteNode = {
   path: string;
   group: string;
   description: string;
-  status: 'active' | 'planned';
+  status: 'active' | 'planned' | 'internal';
   children?: AppRouteNode[];
 };
 
@@ -18,7 +18,12 @@ export const appSitemap: AppRouteNode[] = [
   { title: 'API Status', path: '/api-status', group: 'Operations', description: 'App API status snapshot.', status: 'active' },
   { title: 'System Health', path: '/system-health', group: 'Operations', description: 'App + OMOS health dashboard.', status: 'active' },
   {
-    title: 'OMOS', path: '/omos', group: 'OMOS', description: 'OMOS protocol/runtime public dashboard.', status: 'active', children: [
+    title: 'OMOS',
+    path: '/omos',
+    group: 'OMOS',
+    description: 'OMOS protocol/runtime public dashboard.',
+    status: 'active',
+    children: [
       { title: 'Manifest', path: '/omos/manifest', group: 'OMOS', description: 'Manifest view sourced via app APIs.', status: 'active' },
       { title: 'Pages', path: '/omos/pages', group: 'OMOS', description: 'Synced page registry from OMOS.', status: 'active' },
       { title: 'Health', path: '/omos/health', group: 'OMOS', description: 'OMOS health endpoint status.', status: 'active' },
@@ -28,16 +33,12 @@ export const appSitemap: AppRouteNode[] = [
     ]
   },
   {
-    title: 'Architecture', path: '/architecture', group: 'Architecture', description: 'Architecture overview for public app node.', status: 'active', children: [
-      { title: 'OHI', path: '/architecture/ohi', group: 'Architecture', description: 'OHI layer role.', status: 'active' },
-      { title: 'Runtime', path: '/architecture/runtime', group: 'Architecture', description: 'Runtime model.', status: 'active' },
-      { title: 'Interfaces', path: '/architecture/interfaces', group: 'Architecture', description: 'Public/member interface boundaries.', status: 'active' },
-      { title: 'Infrastructure', path: '/architecture/infrastructure', group: 'Architecture', description: 'Infrastructure concerns.', status: 'active' },
-      { title: 'OMOS Sync', path: '/architecture/omos-sync', group: 'Architecture', description: 'OMOS sync pathway.', status: 'active' }
-    ]
-  },
-  {
-    title: 'Algorithm', path: '/algorithm', group: 'Algorithm', description: 'OneGodian algorithm overview.', status: 'active', children: [
+    title: 'Algorithm',
+    path: '/algorithm',
+    group: 'Algorithm',
+    description: 'OneGodian algorithm overview.',
+    status: 'active',
+    children: [
       { title: 'Protocol', path: '/algorithm/protocol', group: 'Algorithm', description: 'Protocol perspective.', status: 'active' },
       { title: 'Experience', path: '/algorithm/experience', group: 'Algorithm', description: 'Experience layer.', status: 'active' },
       { title: 'Community', path: '/algorithm/community', group: 'Algorithm', description: 'Community layer.', status: 'active' },
@@ -46,21 +47,11 @@ export const appSitemap: AppRouteNode[] = [
   },
   { title: 'Registry', path: '/registry', group: 'Core', description: 'Public/member registry surface.', status: 'active' },
   { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time tools.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Core', description: 'OneGodian: Remember campaign page.', status: 'active' },
+  { title: 'Remember', path: '/remember', group: 'Campaigns', description: 'OneGodian: Remember campaign page.', status: 'active' },
   { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership entry route.', status: 'active' },
   { title: 'Commerce', path: '/commerce', group: 'Core', description: 'OneGodian commerce and identity engine route.', status: 'active' },
   { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional clarity and legal boundary route.', status: 'active' },
-
   { title: 'Portfolio', path: '/portfolio', group: 'Core', description: 'Public portfolio snapshot.', status: 'active' },
   { title: 'Records', path: '/records', group: 'Core', description: 'Public/member record index.', status: 'active' },
   { title: 'Tools', path: '/tools', group: 'Core', description: 'Public tools collection.', status: 'active' }
-  { title: 'Home', path: '/', group: 'Core', description: 'OneGodian App public entry.', status: 'active' },
-  { title: 'Dashboard', path: '/dashboard', group: 'Core', description: 'Public/member dashboard entry.', status: 'active' },
-  { title: 'Ecosystem', path: '/ecosystem', group: 'Core', description: 'Domain ecosystem map and statuses.', status: 'active' },
-  { title: 'OMOS', path: '/omos', group: 'Core', description: 'OMOS operating model and structure overview.', status: 'active' },
-  { title: 'Remember', path: '/remember', group: 'Campaigns', description: 'OneGodian: Remember campaign page.', status: 'active' },
-  { title: 'Membership', path: '/membership', group: 'Core', description: 'Membership pathways and dashboard entry.', status: 'active' },
-  { title: 'Time', path: '/time', group: 'Core', description: 'OneGodian Time™ / OTS-V5 overview.', status: 'active' },
-  { title: 'Commerce', path: '/commerce', group: 'Core', description: 'Commerce and identity product engine overview.', status: 'active' },
-  { title: 'Institutional', path: '/institutional', group: 'Core', description: 'Institutional and legal clarity guidance.', status: 'active' }
 ];

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,8 +1,9 @@
 import { appDashboardCards, appFooterBoundary, appHomeHero, appNavigation, ecosystemPortals } from '@/lib/app-content';
-import { consoleDashboardCards, consoleNavigation, consoleFooterBoundary } from '@/lib/console-content';
+import { consoleDashboardCards, consoleFooterBoundary, consoleNavigation } from '@/lib/console-content';
 
 export const appMeta = appHomeHero;
 export { appNavigation, consoleNavigation, ecosystemPortals };
+
 export const ecosystemLinks = [
   { label: 'OneGodian.org', href: 'https://onegodian.org' },
   { label: 'OneGodian.com', href: 'https://onegodian.com' },
@@ -18,17 +19,13 @@ export const dashboardCards = appDashboardCards;
 export { appDashboardCards, consoleDashboardCards };
 
 export const appStructureLayers = ['Public App', 'Member Dashboard', 'Membership', 'Certificates', 'Campaigns', 'Media', 'Products', 'Learning', 'Tools', 'Profile'];
-export const coreRoutes = ['/','/dashboard','/ecosystem','/omos','/remember','/membership','/time','/commerce','/institutional','/api/manifest'];
 
-export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'OMOS', href: '/omos' }, { label: 'Remember', href: '/remember' }] },
 export const coreRoutes = ['/', '/dashboard', '/ecosystem', '/omos', '/remember', '/membership', '/time', '/commerce', '/institutional', '/api/manifest'];
 
 export const footerSections = [
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Remember', href: '/remember' }, { label: 'Membership', href: '/membership' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Membership', href: '/membership' }, { label: 'Remember', href: '/remember' }, { label: 'Institutional', href: '/institutional' }] },
-  { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'U OneGodian', href: 'https://u.onegodian.org' }, { label: 'Capital OneGodian', href: 'https://capital.onegodian.com' }] },
-  { title: 'More', links: [{ label: 'Membership', href: '/membership' }, { label: 'Time', href: '/time' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] }
+  { title: 'OneGodian App', links: [{ label: 'Dashboard', href: '/dashboard' }, { label: 'Ecosystem', href: '/ecosystem' }, { label: 'Remember', href: '/remember' }, { label: 'Membership', href: '/membership' }] },
+  { title: 'Ecosystem', links: [{ label: 'OneGodian.org', href: 'https://onegodian.org' }, { label: 'OneGodian.com', href: 'https://onegodian.com' }, { label: 'U OneGodian', href: 'https://u.onegodian.com' }, { label: 'QRV Network', href: 'https://qrv.network' }] },
+  { title: 'Operations', links: [{ label: 'OMOS', href: '/omos' }, { label: 'Time', href: '/time' }, { label: 'Commerce', href: '/commerce' }, { label: 'Institutional', href: '/institutional' }] }
 ];
 
 export const systemsModel = [
@@ -42,5 +39,14 @@ export const appStatus = { ...apiStatus, store: 'https://onegodian.com', publicS
 export const appBoundaryCopy = appFooterBoundary;
 export const consoleBoundaryCopy = consoleFooterBoundary;
 
-export const pluginCategories = [{ title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }];
-export const rememberCampaign = { officialStartDate: 'May 9, 2026', onegodianDate: 'Wisdom 23, OT 0001', message: 'You were always One — you simply forgot. Remember who you are.', purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.', dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status'] };
+export const pluginCategories = [
+  { title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }
+];
+
+export const rememberCampaign = {
+  officialStartDate: 'May 9, 2026',
+  onegodianDate: 'Wisdom 23, OT 0001',
+  message: 'You were always One — you simply forgot. Remember who you are.',
+  purpose: 'A public-facing awareness campaign centered on remembrance, identity, unity, origin, and shared human connection.',
+  dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status']
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,9 +5,27 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        abyss: '#040816',
+        abyss: '#030712',
+        midnight: '#07111f',
+        obsidian: '#05050a',
+        gold: {
+          100: '#fff4bf',
+          200: '#f8df86',
+          300: '#eac85a',
+          400: '#c99a2e',
+          500: '#9f741d'
+        },
         neon: '#67e8f9',
-        sovereign: '#a78bfa'
+        sovereign: '#a78bfa',
+        royal: '#7c3aed'
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'Segoe UI', 'Arial', 'sans-serif'],
+        display: ['Inter', 'ui-sans-serif', 'system-ui', 'Segoe UI', 'Arial', 'sans-serif']
+      },
+      boxShadow: {
+        sovereign: '0 24px 80px rgba(5, 5, 10, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.08)',
+        gold: '0 18px 60px rgba(234, 200, 90, 0.16)'
       }
     }
   },


### PR DESCRIPTION
### Motivation
- Modernize the visual system and unify page/components with a consistent OneGodian production design language. 
- Convert legacy slate/cyan UI to a new gold/purple-themed design system and surface-level utility classes for mobile/card experiences. 
- Consolidate app content and manifest metadata to reflect current runtime and host relationships. 

### Description
- Introduced a new global design system in `src/app/globals.css` with utility components like `glass-panel`, `mobile-card`, `premium-button`, and updated selection/background visuals. 
- Restyled many pages under `src/app/(app)/*` (home, `ecosystem`, `omos`, `membership`, `commerce`, `dashboard`, `time`, `remember`, `institutional`, certificates, privacy, legal, offerings, investor-portal, disclosures, production-readiness, pricing, use-cases) to use the new layout classes and updated content snippets and CTAs. 
- Updated numerous components (`AppFrame`, `AppShell`, `ModuleCard`, `ModuleHeader`, `CapitalNavigation`, `CapitalFooter`, `CapitalReadinessTable`, `LiveVerifyForm`, `AppStatusPanel`, `ModuleShellPage`, `ModuleUI`, etc.) to adopt new styles, typography, glyphs, and semantics (e.g. `OG` logo, OneGodian copy, gold/purple accents). 
- Extended Tailwind config in `tailwind.config.ts` with new colors, fonts, and shadows; adjusted class names across the codebase to match the extension. 
- Normalized and expanded app content in `src/lib/*`: updated `app-content.ts`, `onegodian-content.ts`, `app-sitemap.ts`, and `data/manifest.json` with refreshed metadata, routes, host fields, and content constants used by pages/components. 

### Testing
- Ran TypeScript checks with `tsc --noEmit`, which completed successfully. 
- Performed a Next.js production build via `npm run build` / `next build`, and the build succeeded without errors. 
- Executed linting (`npm run lint`) and existing unit tests (`npm test`) where present, and they passed on the updated codebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab9b27a5c832da3d16ae4fa3ad613)