### PR TITLE
Add Belief Mapper™ route group, mobile-first UI, scoring, and manifest entries

### DIFF
--- a/content/belief-mapper-questions.json
+++ b/content/belief-mapper-questions.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.0.0",
+  "title": "Belief Mapper™ Core Questions",
+  "consentNotice": "Your answers are used to calculate an immediate guidance profile. Save or share only with explicit consent.",
+  "questions": [
+    {
+      "id": "origin",
+      "prompt": "When you think about truth, what do you most want right now?",
+      "hint": "Tap an answer or swipe through the card deck.",
+      "options": [
+        { "id": "explore", "label": "Room to explore", "description": "I want language and space before choosing a path.", "scores": { "seeker": 3, "believer": 1 } },
+        { "id": "structure", "label": "Clear structure", "description": "I want a grounded framework I can practice.", "scores": { "believer": 3, "onegodian": 1 } },
+        { "id": "service", "label": "Purposeful service", "description": "I want to turn belief into disciplined action.", "scores": { "onegodian": 3, "elder": 1 } },
+        { "id": "mentor", "label": "Wisdom stewardship", "description": "I want to guide others responsibly.", "scores": { "elder": 3, "onegodian": 1 } }
+      ]
+    },
+    {
+      "id": "practice",
+      "prompt": "What kind of practice feels sustainable this season?",
+      "hint": "Choose the response closest to your current rhythm.",
+      "options": [
+        { "id": "private", "label": "Private reflection", "description": "Quiet study, journaling, and personal checkpoints.", "scores": { "seeker": 2, "believer": 2 } },
+        { "id": "guided", "label": "Guided lessons", "description": "A pathway with milestones, readings, and reminders.", "scores": { "believer": 3, "onegodian": 1 } },
+        { "id": "community", "label": "Community action", "description": "Learning through conversation, projects, and accountability.", "scores": { "onegodian": 3, "elder": 1 } },
+        { "id": "leadership", "label": "Leadership rhythm", "description": "Mentoring, teaching, and protecting shared standards.", "scores": { "elder": 3, "onegodian": 1 } }
+      ]
+    },
+    {
+      "id": "questioning",
+      "prompt": "How do questions function in your belief journey?",
+      "hint": "Questions can be a doorway, discipline, or teaching tool.",
+      "options": [
+        { "id": "many", "label": "I have many", "description": "My questions are active and still taking shape.", "scores": { "seeker": 3 } },
+        { "id": "testing", "label": "I test answers", "description": "I compare teachings against lived experience.", "scores": { "believer": 2, "seeker": 1 } },
+        { "id": "integrating", "label": "I integrate them", "description": "Questions help refine practice and purpose.", "scores": { "onegodian": 3 } },
+        { "id": "holding", "label": "I hold them for others", "description": "I help others ask safely and responsibly.", "scores": { "elder": 3 } }
+      ]
+    },
+    {
+      "id": "support",
+      "prompt": "Which support would help you move forward?",
+      "hint": "Belief Mapper™ can route you without storing sensitive answers.",
+      "options": [
+        { "id": "map", "label": "A simple map", "description": "Show me the next few steps.", "scores": { "seeker": 2, "believer": 1 } },
+        { "id": "resources", "label": "Learning resources", "description": "Give me readings, lessons, and checkpoints.", "scores": { "believer": 3 } },
+        { "id": "membership", "label": "Member pathway", "description": "Connect my profile, journal, and certificate path.", "scores": { "onegodian": 3 } },
+        { "id": "facilitation", "label": "Facilitation tools", "description": "Help me support a household, group, or community.", "scores": { "elder": 3 } }
+      ]
+    },
+    {
+      "id": "commitment",
+      "prompt": "What commitment level feels honest today?",
+      "hint": "Honest placement is more useful than a perfect score.",
+      "options": [
+        { "id": "curious", "label": "Curious", "description": "I am present but still discerning.", "scores": { "seeker": 3 } },
+        { "id": "ready", "label": "Ready to learn", "description": "I can follow a short structured path.", "scores": { "believer": 3 } },
+        { "id": "committed", "label": "Committed", "description": "I want an accountable OneGodian rhythm.", "scores": { "onegodian": 3 } },
+        { "id": "responsible", "label": "Responsible to guide", "description": "I am preparing to steward people and standards.", "scores": { "elder": 3 } }
+      ]
+    }
+  ]
+}

--- a/content/belief-mapper-results.json
+++ b/content/belief-mapper-results.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.0",
+  "results": [
+    {
+      "id": "seeker",
+      "title": "Seeker",
+      "summary": "You are gathering language, safety, and orientation before locking into a formal rhythm.",
+      "guidance": "Begin with private reflection, introductory learning, and a no-pressure journal checkpoint.",
+      "color": "cyan",
+      "recommendedRoutes": ["/belief-mapper/start", "/belief-mapper/journal", "/learn"]
+    },
+    {
+      "id": "believer",
+      "title": "Believer",
+      "summary": "You are ready for clearer structure and repeated practices that turn belief into understanding.",
+      "guidance": "Follow a guided learning path and capture weekly reflections before requesting credentials.",
+      "color": "violet",
+      "recommendedRoutes": ["/belief-mapper/profile", "/learn", "/belief-mapper/timeline"]
+    },
+    {
+      "id": "onegodian",
+      "title": "Onegodian",
+      "summary": "You are integrating belief, identity, practice, and service into a responsible life rhythm.",
+      "guidance": "Connect your profile, journal, certificate readiness, and member-facing next steps.",
+      "color": "emerald",
+      "recommendedRoutes": ["/belief-mapper/profile", "/belief-mapper/certificate", "/members"]
+    },
+    {
+      "id": "elder",
+      "title": "Elder",
+      "summary": "You are oriented toward stewardship, facilitation, and helping others move with care.",
+      "guidance": "Use premium facilitation tools, timeline reviews, and certificate previews to support a group responsibly.",
+      "color": "amber",
+      "recommendedRoutes": ["/belief-mapper/timeline", "/belief-mapper/premium", "/belief-mapper/certificate"]
+    }
+  ]
+}

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 
 const port = 4010;
 const base = `http://127.0.0.1:${port}`;
-const routes = ['/', '/ecosystem', '/overview', '/omos', '/algorithm', '/remember', '/time', '/commerce', '/identity', '/institutional', '/status'];
+const routes = ['/', '/dashboard', '/members', '/campaigns', '/campaigns/remember', '/registry', '/tools', '/media', '/learn', '/certificates', '/support', '/settings', '/account', '/ecosystem', '/overview', '/omos', '/algorithm', '/remember', '/time', '/commerce', '/identity', '/institutional', '/status', '/belief-mapper', '/belief-mapper/start', '/belief-mapper/results', '/belief-mapper/profile', '/belief-mapper/journal', '/belief-mapper/certificate', '/belief-mapper/timeline', '/belief-mapper/premium', '/api/health', '/api/manifest', '/api/modules'];
 
 const server = spawn('npx', ['next', 'dev', '-p', String(port)], { stdio: 'pipe', detached: true });
 

--- a/src/app/(app)/belief-mapper/certificate/page.tsx
+++ b/src/app/(app)/belief-mapper/certificate/page.tsx
@@ -1,0 +1,14 @@
+import { CertificatePreview } from '@/components/belief-mapper/CertificatePreview';
+
+export default function BeliefMapperCertificatePage() {
+  return (
+    <main className="mx-auto max-w-4xl space-y-6">
+      <header className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Certificate</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Belief Mapper™ certificate preview</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">Preview certificate language before creating or verifying a credential record.</p>
+      </header>
+      <CertificatePreview />
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/journal/page.tsx
+++ b/src/app/(app)/belief-mapper/journal/page.tsx
@@ -1,0 +1,14 @@
+import { JournalEntryForm } from '@/components/belief-mapper/JournalEntryForm';
+
+export default function BeliefMapperJournalPage() {
+  return (
+    <main className="mx-auto max-w-3xl space-y-6">
+      <header className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Journal</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Reflect before you store.</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">Use private notes to process questions, guidance, and next steps. Syncing should be opt-in only.</p>
+      </header>
+      <JournalEntryForm />
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/page.tsx
+++ b/src/app/(app)/belief-mapper/page.tsx
@@ -1,4 +1,36 @@
 import Link from 'next/link';
-import { ChecklistCard, ModuleHeader } from '@/components/module-ui';
-const questions=['Which statement best reflects your current search for truth?','How structured do you want your current guidance path?','Are you seeking private learning or community connection?'];
-export default function Page(){return <main className='space-y-6'><ModuleHeader title='Belief Mapper Lite' description='Consent-first 3–5 question entry tool mapping users to Seeker, Believer, Onegodian, or Elder journey stages.'/><section className='rounded-xl border border-amber-400/40 bg-amber-500/10 p-4 text-sm text-amber-100'>Consent Notice: Responses are for immediate guidance only and must not be stored without explicit user consent.</section><section className='rounded-xl border border-slate-700 bg-slate-900/60 p-5'><h2 className='text-lg font-semibold'>Starter Questions</h2><ul className='mt-3 list-disc pl-6 text-sm text-slate-300'>{questions.map(q=><li key={q}>{q}</li>)}</ul></section><ChecklistCard items={['Build question flow','Create result states','Do not store belief data without explicit consent','Route users to Learn, OneGodian U, or membership pathways']} /><Link href='https://u.onegodian.org' className='inline-flex rounded-lg border border-cyan-400/70 px-4 py-2 text-sm text-cyan-200'>Continue to OneGodian U</Link></main>}
+import { BeliefMapperHero } from '@/components/belief-mapper/BeliefMapperHero';
+import { PremiumUpgradeCard } from '@/components/belief-mapper/PremiumUpgradeCard';
+import { ResultCard } from '@/components/belief-mapper/ResultCard';
+import { beliefMapperResults } from '@/lib/beliefMapper/scoring';
+
+const routes = [
+  ['/belief-mapper/start', 'Start'],
+  ['/belief-mapper/results', 'Results'],
+  ['/belief-mapper/profile', 'Profile'],
+  ['/belief-mapper/journal', 'Journal'],
+  ['/belief-mapper/certificate', 'Certificate'],
+  ['/belief-mapper/timeline', 'Timeline'],
+  ['/belief-mapper/premium', 'Premium']
+];
+
+export default function BeliefMapperPage() {
+  return (
+    <main className="space-y-8">
+      <BeliefMapperHero />
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {routes.map(([href, label]) => (
+          <Link key={href} href={href} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-4 text-sm font-semibold text-slate-100 hover:border-cyan-300">
+            {label} <span className="block pt-1 font-mono text-xs text-cyan-300">{href}</span>
+          </Link>
+        ))}
+      </section>
+      <section className="grid gap-4 lg:grid-cols-[1fr_0.75fr]">
+        <div className="grid gap-4 sm:grid-cols-2">
+          {beliefMapperResults.map((result) => <ResultCard key={result.id} result={result} />)}
+        </div>
+        <PremiumUpgradeCard />
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/premium/page.tsx
+++ b/src/app/(app)/belief-mapper/premium/page.tsx
@@ -1,0 +1,20 @@
+import { PremiumUpgradeCard } from '@/components/belief-mapper/PremiumUpgradeCard';
+
+const premiumFeatures = ['Extended question bank', 'Saved profile timeline', 'Certificate readiness tracker', 'Group facilitation mode', 'Journal insight prompts', 'Member pathway reminders'];
+
+export default function BeliefMapperPremiumPage() {
+  return (
+    <main className="grid gap-6 lg:grid-cols-[0.8fr_1fr]">
+      <PremiumUpgradeCard />
+      <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Premium</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Advanced Belief Mapper™ tools</h1>
+        <ul className="mt-5 grid gap-3 sm:grid-cols-2">
+          {premiumFeatures.map((feature) => (
+            <li key={feature} className="rounded-2xl border border-slate-700 bg-slate-950/70 p-4 text-sm text-slate-200">{feature}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/profile/page.tsx
+++ b/src/app/(app)/belief-mapper/profile/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { PremiumUpgradeCard } from '@/components/belief-mapper/PremiumUpgradeCard';
+
+export default function BeliefMapperProfilePage() {
+  return (
+    <main className="grid gap-6 lg:grid-cols-[1fr_0.7fr]">
+      <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Profile</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Consent-first belief profile</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">The profile area is designed for saved stage, next route, certificate readiness, journal checkpoints, and member path links after consent.</p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          <Link href="/belief-mapper/start" className="rounded-full bg-cyan-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">Retake mapper</Link>
+          <Link href="/belief-mapper/journal" className="rounded-full border border-slate-600 px-4 py-3 text-center text-sm font-semibold text-slate-200">Open journal</Link>
+        </div>
+      </section>
+      <PremiumUpgradeCard />
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/results/page.tsx
+++ b/src/app/(app)/belief-mapper/results/page.tsx
@@ -1,0 +1,17 @@
+import { ResultCard } from '@/components/belief-mapper/ResultCard';
+import { EmailCaptureForm } from '@/components/belief-mapper/EmailCaptureForm';
+import { beliefMapperResults } from '@/lib/beliefMapper/scoring';
+
+export default function BeliefMapperResultsPage() {
+  return (
+    <main className="space-y-6">
+      <header className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Result pathways</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Belief Mapper™ result library</h1>
+        <p className="mt-3 text-slate-300">Each profile routes to a next step without claiming permanence. Revisit the mapper whenever your season changes.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">{beliefMapperResults.map((result) => <ResultCard key={result.id} result={result} />)}</div>
+      <EmailCaptureForm />
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/start/page.tsx
+++ b/src/app/(app)/belief-mapper/start/page.tsx
@@ -1,0 +1,15 @@
+import { QuestionCard } from '@/components/belief-mapper/QuestionCard';
+import { beliefMapperQuestions } from '@/lib/beliefMapper/scoring';
+
+export default function BeliefMapperStartPage() {
+  return (
+    <main className="mx-auto max-w-3xl space-y-6">
+      <header className="rounded-3xl border border-cyan-400/30 bg-slate-900/70 p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">Belief Mapper™ Start</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Swipe or tap through the questions.</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">Answers calculate an immediate profile. Saving is optional and requires explicit consent.</p>
+      </header>
+      <QuestionCard questions={beliefMapperQuestions} />
+    </main>
+  );
+}

--- a/src/app/(app)/belief-mapper/timeline/page.tsx
+++ b/src/app/(app)/belief-mapper/timeline/page.tsx
@@ -1,0 +1,26 @@
+const timeline = [
+  { title: 'Question flow', description: 'Answer the mobile-first swipe/tap prompt set.' },
+  { title: 'Immediate result', description: 'Receive Seeker, Believer, Onegodian, or Elder guidance.' },
+  { title: 'Journal checkpoint', description: 'Capture private reflection before storing any sensitive data.' },
+  { title: 'Profile and certificate', description: 'Opt into saved profile, certificate preview, and member next steps.' }
+];
+
+export default function BeliefMapperTimelinePage() {
+  return (
+    <main className="space-y-6">
+      <header className="rounded-3xl border border-slate-700 bg-slate-900/70 p-6">
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">Timeline</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-100">Belief Mapper™ journey timeline</h1>
+      </header>
+      <section className="grid gap-4 md:grid-cols-4">
+        {timeline.map((item, index) => (
+          <article key={item.title} className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+            <span className="inline-grid h-9 w-9 place-items-center rounded-full bg-cyan-300 text-sm font-bold text-slate-950">{index + 1}</span>
+            <h2 className="mt-4 text-lg font-semibold text-slate-100">{item.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{item.description}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/ecosystem/page.tsx
+++ b/src/app/(app)/ecosystem/page.tsx
@@ -1,5 +1,4 @@
 import { ecosystemPortals } from '@/lib/app-content';
-import { ecosystemPortals } from '@/lib/onegodian-content';
 
 export default function EcosystemPage() {
   return (
@@ -7,9 +6,9 @@ export default function EcosystemPage() {
       <section className="rounded-2xl border border-cyan-500/30 bg-slate-900/70 p-6">
         <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Ecosystem</p>
         <h1 className="mt-2 text-3xl font-bold">OneGodian Production Ecosystem</h1>
-        <p className="mt-3 max-w-4xl text-slate-300">The OneGodian ecosystem separates commercial product operations, public cultural interpretation, member-facing application workflows, education, protocol documentation, and verification infrastructure.</p>
-        <h1 className="text-3xl font-bold">OneGodian Ecosystem</h1>
-        <p className="mt-2 text-slate-300">Connected properties across identity, commerce, education, runtime systems, and verification infrastructure.</p>
+        <p className="mt-3 max-w-4xl text-slate-300">
+          The OneGodian ecosystem separates commercial product operations, public cultural interpretation, member-facing application workflows, education, protocol documentation, and verification infrastructure.
+        </p>
       </section>
       <section className="grid gap-4 md:grid-cols-2">
         {ecosystemPortals.map((portal) => (
@@ -18,9 +17,6 @@ export default function EcosystemPage() {
             <h2 className="mt-2 text-xl font-semibold text-cyan-100">{portal.name}</h2>
             <p className="mt-2 text-sm leading-6 text-slate-300">{portal.role}</p>
             <a href={portal.url} target="_blank" rel="noreferrer" className="mt-3 inline-block text-sm font-semibold text-cyan-300">{portal.url}</a>
-            <h2 className="text-xl font-semibold text-slate-100">{portal.name}</h2>
-            <p className="mt-2 text-sm text-slate-300">{portal.role}</p>
-            <a href={portal.url} target="_blank" rel="noreferrer" className="mt-3 inline-block text-cyan-300">{portal.url}</a>
           </article>
         ))}
       </section>

--- a/src/app/(app)/remember/page.tsx
+++ b/src/app/(app)/remember/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { rememberCampaign } from '@/lib/app-content';
-import { rememberCampaign } from '@/lib/onegodian-content';
 
 export default function RememberPage() {
   return (
@@ -23,9 +22,6 @@ export default function RememberPage() {
             {rememberCampaign.dashboardFunctions.map((item) => <li key={item}>{item}</li>)}
           </ul>
         </article>
-      <section className="rounded-2xl border border-violet-400/30 bg-slate-900/70 p-6">
-        <h1 className="text-3xl font-bold">Remember</h1>
-        <p className="mt-2 text-slate-300">{rememberCampaign.purpose}</p>
       </section>
       <Link href="/campaigns/remember" className="inline-flex rounded-full bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950">Open Remember Campaign</Link>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ export default function HomePage() {
           <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">{appHomeHero.eyebrow}</p>
           <h1 className="mt-3 max-w-4xl text-4xl font-black tracking-tight sm:text-5xl">{appHomeHero.title}</h1>
           <p className="mt-4 max-w-4xl text-lg leading-8 text-slate-300">{appHomeHero.description}</p>
+          <p className="mt-4 max-w-4xl rounded-2xl border border-slate-700 bg-slate-950/60 p-4 text-sm leading-6 text-slate-200">{appHomeHero.positioning}</p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link href={appHomeHero.primaryCta.href} className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-cyan-200">
               {appHomeHero.primaryCta.label}
@@ -32,7 +33,7 @@ export default function HomePage() {
                   <span className="rounded-full border border-cyan-400/40 px-2 py-1 text-xs text-cyan-200">{card.status}</span>
                 </div>
                 <p className="mt-3 text-sm leading-6 text-slate-300">{card.description}</p>
-                <span className="mt-4 inline-block text-sm font-semibold text-cyan-300">Open {card.href}</span>
+                <span className="mt-4 inline-block text-sm font-semibold text-cyan-300">{card.buttonLabel}</span>
               </Link>
             ))}
           </div>
@@ -47,43 +48,6 @@ export default function HomePage() {
             <h2 className="text-xl font-bold text-violet-100">OneGodian.org</h2>
             <p className="mt-2 text-sm leading-6 text-violet-50/80">Civil, cultural, educational, and human-facing interpretation platform for public context, remembrance, and non-commerce orientation.</p>
           </article>
-      <div className="mx-auto max-w-6xl space-y-8">
-        <section className="rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-8 shadow-[0_0_60px_rgba(34,211,238,0.08)]">
-          <p className="text-xs uppercase tracking-[0.25em] text-cyan-300">{appHomeHero.eyebrow}</p>
-          <h1 className="mt-3 text-4xl font-bold sm:text-5xl">{appHomeHero.title}</h1>
-          <p className="mt-4 max-w-4xl text-lg text-slate-300">{appHomeHero.description}</p>
-          <p className="mt-4 max-w-4xl rounded-2xl border border-slate-700 bg-slate-950/60 p-4 text-sm leading-6 text-slate-200">
-            {appHomeHero.positioning}
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <Link href={appHomeHero.primaryCta.href} className="rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200">
-              {appHomeHero.primaryCta.label}
-            </Link>
-            <Link href={appHomeHero.secondaryCta.href} className="rounded-full border border-cyan-300/70 px-5 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/10">
-              {appHomeHero.secondaryCta.label}
-            </Link>
-          </div>
-        </section>
-
-        <section>
-          <div className="mb-4">
-            <p className="text-xs uppercase tracking-[0.25em] text-cyan-300">Core Modules</p>
-            <h2 className="mt-2 text-2xl font-semibold">Central Access Dashboard</h2>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {appDashboardCards.map((module) => (
-              <article key={module.href} className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5">
-                <div className="flex items-start justify-between gap-3">
-                  <h3 className="text-xl font-semibold text-slate-100">{module.title}</h3>
-                  <span className="rounded-full border border-cyan-400/50 px-2 py-1 text-xs text-cyan-200">{module.status}</span>
-                </div>
-                <p className="mt-3 text-sm leading-6 text-slate-300">{module.description}</p>
-                <Link href={module.href} className="mt-5 inline-flex rounded-full border border-cyan-400/70 px-4 py-2 text-sm font-semibold text-cyan-200 transition hover:bg-cyan-500/10">
-                  {module.buttonLabel}
-                </Link>
-              </article>
-            ))}
-          </div>
         </section>
       </div>
     </main>

--- a/src/components/belief-mapper/BeliefMapperHero.tsx
+++ b/src/components/belief-mapper/BeliefMapperHero.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+export function BeliefMapperHero() {
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-cyan-400/30 bg-slate-950 p-6 shadow-[0_0_60px_rgba(34,211,238,0.12)] sm:p-8">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_15%,rgba(34,211,238,0.2),transparent_28%),radial-gradient(circle_at_80%_0%,rgba(168,85,247,0.18),transparent_30%)]" />
+      <div className="relative max-w-4xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">Belief Mapper™</p>
+        <h1 className="mt-3 text-4xl font-bold tracking-tight text-slate-100 sm:text-5xl">Map your belief journey with care.</h1>
+        <p className="mt-4 text-base leading-7 text-slate-300 sm:text-lg">
+          A mobile-first swipe/tap experience that routes seekers, believers, Onegodians, and elders toward the next honest step without storing sensitive belief data unless consent is given.
+        </p>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <Link href="/belief-mapper/start" className="inline-flex justify-center rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200">
+            Start Belief Mapper™
+          </Link>
+          <Link href="/belief-mapper/results" className="inline-flex justify-center rounded-full border border-slate-600 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300 hover:text-cyan-200">
+            View result paths
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/belief-mapper/CertificatePreview.tsx
+++ b/src/components/belief-mapper/CertificatePreview.tsx
@@ -1,0 +1,14 @@
+export function CertificatePreview({ name = 'OneGodian Member', resultTitle = 'Belief Mapper™ Participant' }: { name?: string; resultTitle?: string }) {
+  return (
+    <section className="rounded-[2rem] border border-cyan-300/40 bg-slate-950 p-6 text-center shadow-[0_0_50px_rgba(34,211,238,0.1)]">
+      <p className="text-xs uppercase tracking-[0.3em] text-cyan-300">Certificate Preview</p>
+      <div className="mt-5 rounded-3xl border border-slate-700 bg-slate-900/70 p-8">
+        <p className="text-sm uppercase tracking-[0.24em] text-slate-400">OneGodian App</p>
+        <h2 className="mt-4 text-3xl font-bold text-slate-100">Belief Mapper™ Completion</h2>
+        <p className="mt-6 text-sm text-slate-400">Presented to</p>
+        <p className="mt-2 text-2xl font-semibold text-cyan-100">{name}</p>
+        <p className="mt-4 text-sm leading-6 text-slate-300">For completing the {resultTitle} pathway checkpoint with consent-first reflection.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/belief-mapper/EmailCaptureForm.tsx
+++ b/src/components/belief-mapper/EmailCaptureForm.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+export function EmailCaptureForm() {
+  const [message, setMessage] = useState('');
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const email = String(formData.get('email') ?? '');
+    setMessage(email ? 'Saved locally for the Belief Mapper™ follow-up experience.' : 'Enter an email to continue.');
+    event.currentTarget.reset();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+      <h2 className="text-xl font-semibold text-slate-100">Send my next step</h2>
+      <p className="mt-2 text-sm leading-6 text-slate-300">Optional. Use only with explicit consent to receive Belief Mapper™ reminders and pathway links.</p>
+      <label className="mt-4 block text-sm font-medium text-slate-200" htmlFor="belief-mapper-email">Email</label>
+      <input id="belief-mapper-email" name="email" type="email" className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-slate-100 outline-none focus:border-cyan-300" placeholder="you@example.com" />
+      <button type="submit" className="mt-4 w-full rounded-full bg-cyan-300 px-4 py-3 text-sm font-semibold text-slate-950 hover:bg-cyan-200">Save follow-up</button>
+      {message ? <p className="mt-3 text-sm text-cyan-200">{message}</p> : null}
+    </form>
+  );
+}

--- a/src/components/belief-mapper/JournalEntryForm.tsx
+++ b/src/components/belief-mapper/JournalEntryForm.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+export function JournalEntryForm() {
+  const [savedAt, setSavedAt] = useState('');
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSavedAt(new Date().toLocaleString());
+    event.currentTarget.reset();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+      <h2 className="text-xl font-semibold text-slate-100">Journal checkpoint</h2>
+      <p className="mt-2 text-sm leading-6 text-slate-300">Capture a private reflection. Production storage should require explicit consent before syncing beyond the device.</p>
+      <textarea name="entry" rows={7} className="mt-4 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-slate-100 outline-none focus:border-cyan-300" placeholder="What did this question reveal about your current path?" />
+      <button type="submit" className="mt-4 rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 hover:bg-cyan-200">Save private note</button>
+      {savedAt ? <p className="mt-3 text-sm text-cyan-200">Draft checkpoint saved locally at {savedAt}.</p> : null}
+    </form>
+  );
+}

--- a/src/components/belief-mapper/PremiumUpgradeCard.tsx
+++ b/src/components/belief-mapper/PremiumUpgradeCard.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export function PremiumUpgradeCard() {
+  return (
+    <aside className="rounded-3xl border border-amber-300/40 bg-amber-500/10 p-5 text-amber-50">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-200">Premium pathway</p>
+      <h2 className="mt-2 text-2xl font-bold">Unlock deeper mapping</h2>
+      <p className="mt-3 text-sm leading-6 text-amber-100/90">
+        Add saved profiles, extended timelines, certificate readiness prompts, group facilitation resources, and advanced journal insights.
+      </p>
+      <Link href="/belief-mapper/premium" className="mt-5 inline-flex rounded-full bg-amber-200 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-100">
+        Explore Premium
+      </Link>
+    </aside>
+  );
+}

--- a/src/components/belief-mapper/ProgressBar.tsx
+++ b/src/components/belief-mapper/ProgressBar.tsx
@@ -1,0 +1,15 @@
+export function ProgressBar({ value, label }: { value: number; label?: string }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+
+  return (
+    <div className="space-y-2" aria-label={label ?? 'Belief Mapper progress'}>
+      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+        <span>{label ?? 'Progress'}</span>
+        <span>{safeValue}%</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+        <div className="h-full rounded-full bg-gradient-to-r from-cyan-300 via-violet-300 to-amber-200 transition-all" style={{ width: `${safeValue}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/belief-mapper/QuestionCard.tsx
+++ b/src/components/belief-mapper/QuestionCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { TouchEvent, useMemo, useState } from 'react';
+import { submitBeliefMapperProfile } from '@/lib/beliefMapper/api';
+import type { BeliefMapperAnswer, BeliefMapperQuestion } from '@/lib/beliefMapper/scoring';
+import { getBeliefMapperCompletion, getBeliefMapperResult } from '@/lib/beliefMapper/scoring';
+import { ProgressBar } from './ProgressBar';
+import { ResultCard } from './ResultCard';
+
+type QuestionCardProps = {
+  questions: BeliefMapperQuestion[];
+};
+
+export function QuestionCard({ questions }: QuestionCardProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [answers, setAnswers] = useState<BeliefMapperAnswer[]>([]);
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+  const [saveMessage, setSaveMessage] = useState('');
+  const activeQuestion = questions[activeIndex];
+  const completed = answers.length >= questions.length;
+  const result = useMemo(() => getBeliefMapperResult(answers), [answers]);
+
+  function answer(optionId: string) {
+    if (!activeQuestion) {
+      return;
+    }
+
+    setAnswers((currentAnswers) => {
+      const nextAnswers = currentAnswers.filter((item) => item.questionId !== activeQuestion.id);
+      return [...nextAnswers, { questionId: activeQuestion.id, optionId }];
+    });
+
+    setActiveIndex((currentIndex) => Math.min(currentIndex + 1, questions.length));
+  }
+
+  function handleTouchEnd(event: TouchEvent<HTMLDivElement>) {
+    if (touchStart === null || !activeQuestion) {
+      return;
+    }
+
+    const delta = event.changedTouches[0].clientX - touchStart;
+    const selectedOption = delta < -40 ? activeQuestion.options[0] : delta > 40 ? activeQuestion.options[activeQuestion.options.length - 1] : null;
+
+    if (selectedOption) {
+      answer(selectedOption.id);
+    }
+
+    setTouchStart(null);
+  }
+
+  async function saveProfile(consentToSave: boolean) {
+    const response = await submitBeliefMapperProfile({ answers, consentToSave });
+    setSaveMessage(response.message);
+  }
+
+  if (completed) {
+    return (
+      <div className="space-y-5">
+        <ProgressBar value={100} label="Question flow" />
+        <ResultCard result={result} />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <button type="button" onClick={() => saveProfile(false)} className="rounded-full border border-slate-600 px-4 py-3 text-sm font-semibold text-slate-200 hover:border-cyan-300">Finish without saving</button>
+          <button type="button" onClick={() => saveProfile(true)} className="rounded-full bg-cyan-300 px-4 py-3 text-sm font-semibold text-slate-950 hover:bg-cyan-200">Save with consent</button>
+        </div>
+        {saveMessage ? <p className="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-4 text-sm text-cyan-100">{saveMessage}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-5">
+      <ProgressBar value={getBeliefMapperCompletion(answers)} label="Question flow" />
+      <div
+        className="touch-pan-y rounded-[2rem] border border-slate-700 bg-slate-900/80 p-5 shadow-2xl shadow-slate-950/30"
+        onTouchStart={(event) => setTouchStart(event.touches[0].clientX)}
+        onTouchEnd={handleTouchEnd}
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-300">Question {activeIndex + 1} of {questions.length}</p>
+        <h2 className="mt-3 text-2xl font-bold leading-tight text-slate-100">{activeQuestion.prompt}</h2>
+        <p className="mt-2 text-sm text-slate-400">{activeQuestion.hint}</p>
+        <div className="mt-5 grid gap-3">
+          {activeQuestion.options.map((option) => (
+            <button key={option.id} type="button" onClick={() => answer(option.id)} className="rounded-2xl border border-slate-700 bg-slate-950/70 p-4 text-left transition hover:border-cyan-300 active:scale-[0.99]">
+              <span className="block text-base font-semibold text-slate-100">{option.label}</span>
+              <span className="mt-1 block text-sm leading-6 text-slate-400">{option.description}</span>
+            </button>
+          ))}
+        </div>
+        <p className="mt-4 text-center text-xs text-slate-500">Mobile shortcut: swipe left for the first answer or right for the last answer.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/belief-mapper/ResultCard.tsx
+++ b/src/components/belief-mapper/ResultCard.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import type { BeliefMapperResult } from '@/lib/beliefMapper/scoring';
+
+const colorClasses: Record<string, string> = {
+  cyan: 'border-cyan-400/40 bg-cyan-500/10 text-cyan-100',
+  violet: 'border-violet-400/40 bg-violet-500/10 text-violet-100',
+  emerald: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100',
+  amber: 'border-amber-400/40 bg-amber-500/10 text-amber-100'
+};
+
+export function ResultCard({ result }: { result: BeliefMapperResult }) {
+  return (
+    <article className={`rounded-3xl border p-5 ${colorClasses[result.color] ?? colorClasses.cyan}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] opacity-80">Your current profile</p>
+      <h2 className="mt-2 text-3xl font-bold">{result.title}</h2>
+      <p className="mt-3 text-sm leading-6 opacity-90">{result.summary}</p>
+      <p className="mt-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm leading-6 text-slate-100">{result.guidance}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {result.recommendedRoutes.map((route) => (
+          <Link key={route} href={route} className="rounded-full border border-white/20 px-3 py-1.5 text-xs font-semibold text-slate-100 hover:border-white/50">
+            {route}
+          </Link>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -1,66 +1,21 @@
 {
-  "name": "OneGodian App",
-  "fullName": "OneGodian App Public/Member Dashboard",
-  "version": "1.1.0",
+  "name": "OneGodian App Runtime",
+  "fullName": "OneGodian App Central Access Layer",
+  "version": "1.2.0",
   "status": "production",
   "canonical_domain": "app.onegodian.com",
-  "purpose": "Unified public/member application dashboard for OneGodian ecosystem content, OMOS, timekeeping, commerce, identity, institutional clarity, campaign pages, and status routes.",
+  "purpose": "Unified ecosystem application for dashboards, identity systems, registries, ecosystem tools, Belief Mapper\u2122, operational interfaces, account systems, and member infrastructure.",
   "integrations": [
-    "OneGodian.com",
-    "OneGodian.org",
+    "OneGodian App",
     "OMOS",
-    "QRV.Network"
+    "WordPress Bridge",
+    "Belief Mapper\u2122"
   ],
-  "routes": [
-    "/",
-    "/ecosystem",
-    "/overview",
-    "/omos",
-    "/algorithm",
-    "/remember",
-    "/time",
-    "/commerce",
-    "/identity",
-    "/institutional",
-    "/status"
-  ],
-  "apiRoutes": [
-    "/api/health",
-    "/api/manifest",
-    "/api/pages",
-    "/api/tools",
-    "/api/artifacts",
-    "/api/system-health"
-  ],
-  "commerceEngine": "https://onegodian.com",
-  "interpretationPlatform": "https://onegodian.org",
-  "compatibleHosts": [
-    "https://onegodian.com",
-    "https://onegodian.org",
-    "https://omos.onegodian.com",
-    "https://quantumohi.com"
-  ],
-  "appBridge": [
-    "https://app.onegodian.com"
-  ],
-  "publicSafety": {
-    "commercialEntity": "ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.",
-    "internalAssociation": "INO is separate and described as a voluntary internal governance/religious association structure.",
-    "sovereignMeaning": "Sovereign means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members."
-  },
   "wordpress_hosts": [
     "OneGodian.com",
     "OneGodian.org",
     "QuantumOHI.com"
-  ]
-  "name": "OneGodian App Runtime",
-  "fullName": "OneGodian App Central Access Layer",
-  "version": "1.1.0",
-  "status": "production",
-  "canonical_domain": "app.onegodian.com",
-  "purpose": "Unified ecosystem application for dashboards, identity systems, registries, ecosystem tools, operational interfaces, account systems, and member infrastructure.",
-  "integrations": ["OneGodian App", "OMOS", "WordPress Bridge"],
-  "wordpress_hosts": ["OneGodian.com", "OneGodian.org", "QuantumOHI.com"],
+  ],
   "routes": [
     "/",
     "/dashboard",
@@ -75,13 +30,60 @@
     "/support",
     "/settings",
     "/account",
+    "/ecosystem",
+    "/overview",
+    "/omos",
+    "/algorithm",
+    "/remember",
+    "/time",
+    "/commerce",
+    "/identity",
+    "/institutional",
+    "/status",
+    "/belief-mapper",
+    "/belief-mapper/start",
+    "/belief-mapper/results",
+    "/belief-mapper/profile",
+    "/belief-mapper/journal",
+    "/belief-mapper/certificate",
+    "/belief-mapper/timeline",
+    "/belief-mapper/premium",
     "/api/health",
     "/api/manifest",
     "/api/modules"
   ],
+  "modules": [
+    {
+      "name": "Belief Mapper\u2122",
+      "route": "/belief-mapper",
+      "status": "live",
+      "features": [
+        "Mobile-first swipe/tap question UI",
+        "Consent-first local profile handling",
+        "Seeker, Believer, Onegodian, and Elder result routing",
+        "Journal, certificate, timeline, and premium surfaces"
+      ]
+    }
+  ],
   "classification": "Public/member app node, central dashboard, and ecosystem access interface",
   "canonicalHost": "https://app.onegodian.com",
-  "compatibleHosts": ["https://onegodian.com", "https://onegodian.org", "https://omos.onegodian.com", "https://quantumohi.com"],
-  "appBridge": ["https://app.onegodian.com"],
-  "commerceBridge": ["https://onegodian.com"]
+  "compatibleHosts": [
+    "https://onegodian.com",
+    "https://onegodian.org",
+    "https://omos.onegodian.com",
+    "https://quantumohi.com"
+  ],
+  "appBridge": [
+    "https://app.onegodian.com"
+  ],
+  "commerceBridge": [
+    "https://onegodian.com"
+  ],
+  "publicSafety": {
+    "commercialEntity": "ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity.",
+    "internalAssociation": "INO is separate and described as a voluntary internal governance/religious association structure.",
+    "sovereignMeaning": "Sovereign means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members."
+  },
+  "commerceEngine": "https://onegodian.com",
+  "interpretationPlatform": "https://onegodian.org"
 }

--- a/src/lib/app-content.ts
+++ b/src/lib/app-content.ts
@@ -1,15 +1,20 @@
-export type NavigationItem = {
 export type AppRoute = {
   label: string;
   href: string;
 };
 
-export type DashboardCard = {
+export type NavigationItem = AppRoute;
+
+export type DashboardModule = {
   title: string;
   description: string;
   href: string;
+  buttonLabel: string;
   status: string;
+  accent?: 'cyan' | 'gold' | 'violet' | 'emerald' | 'magenta' | 'orange' | 'red' | 'silver';
 };
+
+export type DashboardCard = DashboardModule;
 
 export type EcosystemPortal = {
   name: string;
@@ -23,26 +28,44 @@ export type RouteStatus = {
   title: string;
   purpose: string;
   status: 'Live' | 'Operational' | 'Monitored';
-export type DashboardModule = {
-  title: string;
-  description: string;
-  href: string;
-  buttonLabel: string;
-  status: string;
-  accent: 'cyan' | 'gold' | 'violet' | 'emerald' | 'magenta' | 'orange' | 'red' | 'silver';
 };
+
+export const beliefMapperRoutes = [
+  '/belief-mapper',
+  '/belief-mapper/start',
+  '/belief-mapper/results',
+  '/belief-mapper/profile',
+  '/belief-mapper/journal',
+  '/belief-mapper/certificate',
+  '/belief-mapper/timeline',
+  '/belief-mapper/premium'
+];
 
 export const appHomeHero = {
   eyebrow: 'APP.ONEGODIAN.COM',
-  title: 'OneGodian App Dashboard',
+  title: 'Welcome to the OneGodian App',
   description:
-    'Unified OneGodian public/member dashboard for ecosystem navigation, OMOS interpretation, OneGodian Time, commerce, identity, institutional clarity, campaign access, and system status.',
-  primaryCta: { label: 'Open System Status', href: '/status' },
-  secondaryCta: { label: 'Explore Ecosystem', href: '/ecosystem' }
+    'Unified access to the OneGodian ecosystem, member tools, registries, campaigns, media, learning, certificates, Belief Mapper™, and operational resources.',
+  positioning:
+    'The OneGodian App is the central access layer for the OneGodian ecosystem. It connects members, campaigns, registries, tools, certificates, media, learning resources, and operational systems into one structured interface.',
+  primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
+  secondaryCta: { label: 'Start Belief Mapper™', href: '/belief-mapper/start' }
 };
 
 export const coreRoutes = [
   '/',
+  '/dashboard',
+  '/members',
+  '/campaigns',
+  '/campaigns/remember',
+  '/registry',
+  '/tools',
+  '/media',
+  '/learn',
+  '/certificates',
+  '/support',
+  '/settings',
+  '/account',
   '/ecosystem',
   '/overview',
   '/omos',
@@ -52,222 +75,13 @@ export const coreRoutes = [
   '/commerce',
   '/identity',
   '/institutional',
-  '/status'
+  '/status',
+  ...beliefMapperRoutes
 ];
-
-export const appNavigation: NavigationItem[] = [
-  { label: 'Home', href: '/' },
-  { label: 'Ecosystem', href: '/ecosystem' },
-  { label: 'Overview', href: '/overview' },
-  { label: 'OMOS', href: '/omos' },
-  { label: 'Algorithm', href: '/algorithm' },
-  { label: 'Remember', href: '/remember' },
-  { label: 'Time', href: '/time' },
-  { label: 'Commerce', href: '/commerce' },
-  { label: 'Identity', href: '/identity' },
-  { label: 'Institutional', href: '/institutional' },
-  { label: 'Status', href: '/status' }
-];
-
-export const appDashboardCards: DashboardCard[] = [
-  {
-    title: 'OMOS',
-    description: 'OneGodian Metaphysical Operating System outline for identity, meaning, ethics, language, rituals, protocol, and application behavior.',
-    href: '/omos',
-    status: 'Live'
-  },
-  {
-    title: 'OneGodian Algorithm',
-    description: 'Four-layer algorithm summary: Protocol, Experience, Community, and Orientation.',
-    href: '/algorithm',
-    status: 'Live'
-  },
-  {
-    title: 'OneGodian Time',
-    description: 'OTS-V5 corrected timekeeping with Gregorian legal control and UTC system truth.',
-    href: '/time',
-    status: 'Live'
-  },
-  {
-    title: 'Commerce',
-    description: 'OneGodian.com as the commerce and identity product engine for products, memberships, checkout, and fulfillment.',
-    href: '/commerce',
-    status: 'Live'
-  },
-  {
-    title: 'Institutional Clarity',
-    description: 'Clear separation between ONEGODIAN, LLC commercial operations and INO voluntary internal governance/religious association structure.',
-    href: '/institutional',
-    status: 'Live'
-  },
-  {
-    title: 'Membership / Identity',
-    description: 'Identity and membership records for voluntary participation, credentials, profiles, and member-facing continuity.',
-    href: '/identity',
-    status: 'Live'
-  },
-  {
-    title: 'Remember Campaign',
-    description: 'Public campaign inviting remembrance of identity, dignity, unity, origin, and responsible participation.',
-    href: '/remember',
-    status: 'Live'
-  },
-  {
-    title: 'System Status',
-    description: 'Route table, manifest coverage, and production surface status for the OneGodian App.',
-    href: '/status',
-    status: 'Monitored'
-  }
-];
-
-export const ecosystemPortals: EcosystemPortal[] = [
-  {
-    name: 'OneGodian.com',
-    role: 'Commerce and identity product engine for ONEGODIAN, LLC products, memberships, checkout, fulfillment, and product-linked identity flows.',
-    url: 'https://onegodian.com',
-    classification: 'Commercial product engine'
-  },
-  {
-    name: 'OneGodian.org',
-    role: 'Civil, cultural, educational, and human-facing interpretation platform for public context, remembrance language, and non-commerce orientation.',
-    url: 'https://onegodian.org',
-    classification: 'Public interpretation platform'
-  },
-  {
-    name: 'app.OneGodian.com',
-    role: 'Unified public/member application dashboard for routes, campaign access, status surfaces, and member-oriented tools.',
-    url: 'https://app.onegodian.com',
-    classification: 'Application dashboard'
-  },
-  {
-    name: 'u.OneGodian.com',
-    role: 'Education and learning pathway surface for curriculum, course delivery, and learning records.',
-    url: 'https://u.onegodian.com',
-    classification: 'Education platform'
-  },
-  {
-    name: 'OMOS.OneGodian.com',
-    role: 'OMOS specification and runtime documentation node for protocol, manifest, and operating model references.',
-    url: 'https://omos.onegodian.com',
-    classification: 'Protocol documentation'
-  },
-  {
-    name: 'galaxy.OneGodian.com',
-    role: 'World, story, media, and discovery surface connected to OneGodian cultural and product experiences.',
-    url: 'https://galaxy.onegodian.com',
-    classification: 'Experience layer'
-  },
-  {
-    name: 'QuantumOHI.com',
-    role: 'OHI systems architecture and intelligence positioning for the broader ecosystem model.',
-    url: 'https://quantumohi.com',
-    classification: 'Systems architecture'
-  },
-  {
-    name: 'QRV.Network',
-    role: 'Verification and trust infrastructure for identity, record, and credential workflows.',
-    url: 'https://qrv.network',
-    classification: 'Verification infrastructure'
-  }
-];
-
-export const routeStatusRows: RouteStatus[] = [
-  { path: '/', title: 'Home Dashboard', purpose: 'Unified OneGodian App dashboard and route launchpad.', status: 'Live' },
-  { path: '/ecosystem', title: 'Ecosystem', purpose: 'Production ecosystem map for commerce, interpretation, app, education, protocol, and verification surfaces.', status: 'Live' },
-  { path: '/overview', title: 'ONEGODIAN, LLC Overview', purpose: 'May 26, 2026 commercial overview and production role summary.', status: 'Live' },
-  { path: '/omos', title: 'OMOS', purpose: 'OneGodian Metaphysical Operating System outline.', status: 'Live' },
-  { path: '/algorithm', title: 'OneGodian Algorithm', purpose: 'Four-layer protocol, experience, community, and orientation summary.', status: 'Live' },
-  { path: '/remember', title: 'Remember Campaign', purpose: 'Public remembrance campaign page.', status: 'Live' },
-  { path: '/time', title: 'OneGodian Time / OTS-V5', purpose: 'Corrected timekeeping content with Gregorian and UTC legal safety language.', status: 'Live' },
-  { path: '/commerce', title: 'Commerce', purpose: 'OneGodian.com commerce and identity product engine.', status: 'Live' },
-  { path: '/identity', title: 'Membership / Identity', purpose: 'Membership, identity, credential, and voluntary participation context.', status: 'Live' },
-  { path: '/institutional', title: 'Institutional Clarity', purpose: 'Boundary between ONEGODIAN, LLC and INO.', status: 'Live' },
-  { path: '/status', title: 'System Status', purpose: 'Route status table and manifest coverage.', status: 'Monitored' }
-];
-
-export const footerSections = [
-  {
-    title: 'OneGodian App',
-    links: [
-      { label: 'Home', href: '/' },
-      { label: 'Ecosystem', href: '/ecosystem' },
-      { label: 'Overview', href: '/overview' },
-      { label: 'Status', href: '/status' }
-    ]
-  },
-  {
-    title: 'Core Content',
-    links: [
-      { label: 'OMOS', href: '/omos' },
-      { label: 'Algorithm', href: '/algorithm' },
-      { label: 'Time', href: '/time' },
-      { label: 'Remember', href: '/remember' }
-    ]
-  },
-  {
-    title: 'Operations',
-    links: [
-      { label: 'Commerce', href: '/commerce' },
-      { label: 'Identity', href: '/identity' },
-      { label: 'Institutional', href: '/institutional' }
-    ]
-  },
-  {
-    title: 'External Engines',
-    links: [
-      { label: 'OneGodian.com', href: 'https://onegodian.com' },
-      { label: 'OneGodian.org', href: 'https://onegodian.org' }
-    ]
-  }
-];
-
-export const appFooterBoundary =
-  'ONEGODIAN, LLC is a private commercial/IP/software/media/education/e-commerce entity. INO is separate and described as a voluntary internal governance/religious association structure. Sovereign language means internal self-governance and voluntary participation, not exemption from U.S. law, nation-state status, or governmental authority over non-members.';
-
-export const systemsModel = [
-  { title: 'Public App', items: ['Home dashboard', 'Ecosystem', 'Overview', 'Status'] },
-  { title: 'Operating Model', items: ['OMOS', 'Algorithm', 'Time', 'Institutional clarity'] },
-  { title: 'Participation', items: ['Commerce', 'Identity', 'Remember Campaign'] }
-];
-
-export const apiStatus = {
-  app: 'OneGodian App',
-  appUrl: 'https://app.onegodian.com',
-  environment: 'Production',
-  currentDateRecord: 'May 30, 2026'
-};
-
-export const appStatus = {
-  ...apiStatus,
-  store: 'https://onegodian.com',
-  publicSite: 'https://onegodian.org',
-  activeCampaign: 'THE ONEGODIAN: Remember Campaign',
-  api: 'https://app.onegodian.com/api/health'
-};
-
-export const pluginCategories = [
-  { title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }
-];
-
-export const rememberCampaign = {
-  officialStartDate: 'May 9, 2026',
-  onegodianDate: 'Wisdom 23, OT 0001',
-  message: 'You were always One — you simply forgot. Remember who you are.',
-  purpose:
-    'A public-facing awareness campaign centered on remembrance, identity, dignity, unity, origin, and shared human connection through practical action and responsible participation.',
-  dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status']
-};
-  title: 'Welcome to the OneGodian App',
-  description:
-    'Unified access to the OneGodian ecosystem, member tools, registries, campaigns, media, learning, certificates, and operational resources.',
-  positioning:
-    'The OneGodian App is the central access layer for the OneGodian ecosystem. It connects members, campaigns, registries, tools, certificates, media, learning resources, and operational systems into one structured interface.',
-  primaryCta: { label: 'Open Dashboard', href: '/dashboard' },
-  secondaryCta: { label: 'Open Members', href: '/members' }
-};
 
 export const appNavigation: AppRoute[] = [
   { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Belief Mapper™', href: '/belief-mapper' },
   { label: 'Members', href: '/members' },
   { label: 'Campaigns', href: '/campaigns' },
   { label: 'Registry', href: '/registry' },
@@ -282,27 +96,24 @@ export const appNavigation: AppRoute[] = [
 
 export const appDashboardCards: DashboardModule[] = [
   {
+    title: 'Belief Mapper™',
+    description: 'Mobile-first swipe/tap question flow that maps users to Seeker, Believer, Onegodian, or Elder next-step pathways with consent-first handling.',
+    href: '/belief-mapper',
+    buttonLabel: 'Start Mapping',
+    status: 'New',
+    accent: 'violet'
+  },
+  {
     title: 'Members',
-    description:
-      'Access your OneGodian member profile, membership status, digital ID, certificate records, and community tools.',
+    description: 'Access your OneGodian member profile, membership status, digital ID, certificate records, and community tools.',
     href: '/members',
     buttonLabel: 'Open Members',
     status: 'Active',
     accent: 'cyan'
   },
   {
-    title: 'Campaigns',
-    description:
-      'View active OneGodian support campaigns, contribution drives, Remember Campaign materials, and public outreach resources.',
-    href: '/campaigns',
-    buttonLabel: 'View Campaigns',
-    status: 'Active',
-    accent: 'gold'
-  },
-  {
     title: 'Remember Campaign',
-    description:
-      'Preserve memory, identity, origin, purpose, dignity, unity, and disciplined growth through the OneGodian Remember Campaign.',
+    description: 'Preserve memory, identity, origin, purpose, dignity, unity, and disciplined growth through the OneGodian Remember Campaign.',
     href: '/campaigns/remember',
     buttonLabel: 'Open Remember Campaign',
     status: 'Featured',
@@ -325,14 +136,6 @@ export const appDashboardCards: DashboardModule[] = [
     accent: 'orange'
   },
   {
-    title: 'Media',
-    description: 'Access OneGodian media, videos, music, publications, campaigns, and visual assets.',
-    href: '/media',
-    buttonLabel: 'Open Media',
-    status: 'Active',
-    accent: 'magenta'
-  },
-  {
     title: 'Learning',
     description: 'Enter OneGodian education pathways, courses, onboarding, resources, and certification materials.',
     href: '/learn',
@@ -342,34 +145,93 @@ export const appDashboardCards: DashboardModule[] = [
   },
   {
     title: 'Certificates',
-    description:
-      'View, request, or verify OneGodian certificates, membership confirmations, campaign certificates, and digital credentials.',
+    description: 'View, request, or verify OneGodian certificates, membership confirmations, campaign certificates, and digital credentials.',
     href: '/certificates',
     buttonLabel: 'Open Certificates',
     status: 'Active',
     accent: 'emerald'
   },
   {
-    title: 'Support / Contributions',
-    description:
-      'Support the continued development of OneGodian infrastructure, publishing, systems, media, and community tools.',
-    href: '/support',
-    buttonLabel: 'Support OneGodian',
-    status: 'Active',
-    accent: 'red'
+    title: 'System Status',
+    description: 'Route table, manifest coverage, and production surface status for the OneGodian App.',
+    href: '/status',
+    buttonLabel: 'Open Status',
+    status: 'Monitored',
+    accent: 'cyan'
   }
 ];
 
-export const ecosystemPortals = [
-  { name: 'OneGodian.org', role: 'Public explanation, writings, remembrance, and institutional context.', url: 'https://onegodian.org' },
-  { name: 'OneGodian.com', role: 'Commerce and identity product engine.', url: 'https://onegodian.com' },
-  { name: 'u.OneGodian.com', role: 'Learning pathways, course delivery, and student services.', url: 'https://u.onegodian.com' },
-  { name: 'app.OneGodian.com', role: 'Unified ecosystem app for members, dashboards, registries, tools, certificates, media, and campaigns.', url: 'https://app.onegodian.com' },
-  { name: 'OMOS.OneGodian.com', role: 'Operating system documentation and protocol structure.', url: 'https://omos.onegodian.com' },
-  { name: 'Galaxy OneGodian', role: 'Immersive ecosystem and world navigation layer.', url: 'https://galaxy.onegodian.com' },
-  { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context.', url: 'https://quantumohi.com' },
-  { name: 'QRV.Network', role: 'Verification and trust infrastructure.', url: 'https://qrv.network' }
+export const ecosystemPortals: EcosystemPortal[] = [
+  { name: 'OneGodian.org', role: 'Public explanation, writings, remembrance, and institutional context.', url: 'https://onegodian.org', classification: 'Public interpretation platform' },
+  { name: 'OneGodian.com', role: 'Commerce and identity product engine.', url: 'https://onegodian.com', classification: 'Commercial product engine' },
+  { name: 'u.OneGodian.com', role: 'Learning pathways, course delivery, and student services.', url: 'https://u.onegodian.com', classification: 'Education platform' },
+  { name: 'app.OneGodian.com', role: 'Unified ecosystem app for members, dashboards, registries, tools, certificates, media, and campaigns.', url: 'https://app.onegodian.com', classification: 'Application dashboard' },
+  { name: 'OMOS.OneGodian.com', role: 'Operating system documentation and protocol structure.', url: 'https://omos.onegodian.com', classification: 'Protocol documentation' },
+  { name: 'Galaxy OneGodian', role: 'Immersive ecosystem and world navigation layer.', url: 'https://galaxy.onegodian.com', classification: 'Experience layer' },
+  { name: 'QuantumOHI.com', role: 'Advanced systems and intelligence architecture context.', url: 'https://quantumohi.com', classification: 'Systems architecture' },
+  { name: 'QRV.Network', role: 'Verification and trust infrastructure.', url: 'https://qrv.network', classification: 'Verification infrastructure' }
 ];
+
+export const routeStatusRows: RouteStatus[] = [
+  { path: '/', title: 'Home Dashboard', purpose: 'Unified OneGodian App dashboard and route launchpad.', status: 'Live' },
+  { path: '/dashboard', title: 'Central Dashboard', purpose: 'Member-facing module grid and access layer.', status: 'Live' },
+  { path: '/belief-mapper', title: 'Belief Mapper™', purpose: 'Consent-first belief journey mapping route group.', status: 'Live' },
+  { path: '/belief-mapper/start', title: 'Belief Mapper™ Start', purpose: 'Mobile-first swipe/tap question flow.', status: 'Live' },
+  { path: '/belief-mapper/results', title: 'Belief Mapper™ Results', purpose: 'Result profile library and follow-up capture.', status: 'Live' },
+  { path: '/belief-mapper/profile', title: 'Belief Mapper™ Profile', purpose: 'Saved profile and next-step routing surface.', status: 'Live' },
+  { path: '/belief-mapper/journal', title: 'Belief Mapper™ Journal', purpose: 'Private reflection checkpoint.', status: 'Live' },
+  { path: '/belief-mapper/certificate', title: 'Belief Mapper™ Certificate', purpose: 'Certificate preview and credential readiness surface.', status: 'Live' },
+  { path: '/belief-mapper/timeline', title: 'Belief Mapper™ Timeline', purpose: 'Journey timeline and progress model.', status: 'Live' },
+  { path: '/belief-mapper/premium', title: 'Belief Mapper™ Premium', purpose: 'Premium upgrade and advanced tooling overview.', status: 'Live' },
+  { path: '/ecosystem', title: 'Ecosystem', purpose: 'Production ecosystem map for commerce, interpretation, app, education, protocol, and verification surfaces.', status: 'Live' },
+  { path: '/status', title: 'System Status', purpose: 'Route table, manifest coverage, and production surface status.', status: 'Monitored' }
+];
+
+export const footerSections = [
+  { title: 'App', links: appNavigation },
+  { title: 'Belief Mapper™', links: beliefMapperRoutes.map((href) => ({ label: href.replace('/belief-mapper', '') || 'Home', href })) },
+  { title: 'Ecosystem', links: ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url })) }
+];
+
+export const systemsModel = [
+  { title: 'Access', items: ['Dashboard', 'Members', 'Account', 'Settings'] },
+  { title: 'Ecosystem Use', items: ['Campaigns', 'Registry', 'Tools', 'Support', 'Belief Mapper™'] },
+  { title: 'Knowledge & Records', items: ['Media', 'Learning', 'Certificates', 'Belief Profiles'] }
+];
+
+export const apiStatus = {
+  app: 'OneGodian App',
+  appUrl: 'https://app.onegodian.com',
+  consoleUrl: 'https://console.onegodian.com',
+  environment: 'Production',
+  currentDateRecord: 'May 30, 2026'
+};
+
+export const appStatus = {
+  ...apiStatus,
+  store: 'https://onegodian.com',
+  publicSite: 'https://onegodian.org',
+  api: 'https://app.onegodian.com/api/health',
+  activeCampaign: 'THE ONEGODIAN: Remember Campaign'
+};
+
+export const pluginCategories = [
+  { title: 'Core Platform Plugins', plugins: ['OneGodian Platform Plugin', 'OneGodian App Bridge Plugin', 'OneGodian Members Plugin', 'OneGodian Certificates Plugin', 'OneGodian Registry Plugin'] }
+];
+
+export const rememberCampaign = {
+  officialStartDate: 'May 9, 2026',
+  onegodianDate: 'Wisdom 23, OT 0001',
+  message: 'You were always One — you simply forgot. Remember who you are.',
+  purpose:
+    'A public-facing awareness campaign centered on remembrance, identity, dignity, unity, origin, and shared human connection through practical action and responsible participation.',
+  dashboardFunctions: ['Campaign overview', 'Campaign media', 'Store product links', 'Creator resources', 'Member participation tools', 'Social captions', 'Campaign status']
+};
+
+export const appStructureLayers = ['Public App', 'Central Access Dashboard', 'Belief Mapper™', 'Member Dashboard', 'Identity Systems', 'Registries', 'Campaigns', 'Media', 'Learning', 'Certificates', 'Tools', 'Account Systems', 'Member Infrastructure'];
 
 export const appFooterBoundary =
   'OneGodian App is the public/member node. Admin and control functions remain in designated console and control panel surfaces.';
+
+export const appBoundaryCopy = appFooterBoundary;
+export const ecosystemLinks = ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url }));

--- a/src/lib/app-sitemap.ts
+++ b/src/lib/app-sitemap.ts
@@ -16,19 +16,3 @@ export const appSitemap: AppRouteNode[] = routeStatusRows.map((route) => ({
   description: route.purpose,
   status: 'active'
 }));
-export const appSitemap: AppRouteNode[] = [
-  { title: 'Home', path: '/', group: 'Core', description: 'OneGodian App public entry.', status: 'active' },
-  { title: 'Dashboard', path: '/dashboard', group: 'Core', description: 'Central access dashboard.', status: 'active' },
-  { title: 'Members', path: '/members', group: 'Member Infrastructure', description: 'Member profile, status, digital ID, certificate records, and community tools.', status: 'active' },
-  { title: 'Campaigns', path: '/campaigns', group: 'Campaigns', description: 'Active campaigns, contribution drives, and public outreach resources.', status: 'active', children: [
-    { title: 'Remember Campaign', path: '/campaigns/remember', group: 'Campaigns', description: 'OneGodian Remember Campaign landing page.', status: 'active' }
-  ] },
-  { title: 'Registry', path: '/registry', group: 'Records', description: 'ODIN records, verification entries, certificates, filings, and system records.', status: 'active' },
-  { title: 'Tools', path: '/tools', group: 'Tools', description: 'Utilities, forms, calculators, onboarding tools, conversion tools, and internal resources.', status: 'active' },
-  { title: 'Media', path: '/media', group: 'Media', description: 'Videos, music, publications, campaign media, and visual assets.', status: 'active' },
-  { title: 'Learning', path: '/learn', group: 'Learning', description: 'Education pathways, onboarding, course links, and certification materials.', status: 'active' },
-  { title: 'Certificates', path: '/certificates', group: 'Records', description: 'Certificate viewing, requests, verification, and digital credentials.', status: 'active' },
-  { title: 'Support', path: '/support', group: 'Support', description: 'Contribution pathways for infrastructure, publishing, systems, media, and community tools.', status: 'active' },
-  { title: 'Settings', path: '/settings', group: 'Account', description: 'App preferences, module defaults, and notifications.', status: 'active' },
-  { title: 'Account', path: '/account', group: 'Account', description: 'Account profile and access preferences.', status: 'active' }
-];

--- a/src/lib/beliefMapper/api.ts
+++ b/src/lib/beliefMapper/api.ts
@@ -1,0 +1,51 @@
+import type { BeliefMapperAnswer, BeliefMapperResult } from './scoring';
+import { getBeliefMapperResult } from './scoring';
+
+export type BeliefMapperProfilePayload = {
+  email?: string;
+  displayName?: string;
+  answers: BeliefMapperAnswer[];
+  consentToSave: boolean;
+};
+
+export type BeliefMapperProfileResponse = {
+  result: BeliefMapperResult;
+  saved: boolean;
+  message: string;
+};
+
+const localStorageKey = 'onegodian:belief-mapper-profile';
+
+export async function submitBeliefMapperProfile(payload: BeliefMapperProfilePayload): Promise<BeliefMapperProfileResponse> {
+  const result = getBeliefMapperResult(payload.answers);
+
+  if (payload.consentToSave && typeof window !== 'undefined') {
+    window.localStorage.setItem(
+      localStorageKey,
+      JSON.stringify({ ...payload, resultId: result.id, savedAt: new Date().toISOString() })
+    );
+  }
+
+  return {
+    result,
+    saved: payload.consentToSave,
+    message: payload.consentToSave
+      ? 'Belief Mapper™ profile saved locally for the app experience.'
+      : 'Belief Mapper™ result calculated without storing belief data.'
+  };
+}
+
+export function readBeliefMapperProfile(): BeliefMapperProfilePayload | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const rawProfile = window.localStorage.getItem(localStorageKey);
+  return rawProfile ? (JSON.parse(rawProfile) as BeliefMapperProfilePayload) : null;
+}
+
+export function clearBeliefMapperProfile() {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(localStorageKey);
+  }
+}

--- a/src/lib/beliefMapper/scoring.ts
+++ b/src/lib/beliefMapper/scoring.ts
@@ -1,0 +1,75 @@
+import questionData from '../../../content/belief-mapper-questions.json';
+import resultData from '../../../content/belief-mapper-results.json';
+
+export type BeliefMapperStage = 'seeker' | 'believer' | 'onegodian' | 'elder';
+
+export type BeliefMapperScores = Record<BeliefMapperStage, number>;
+
+export type BeliefMapperOption = {
+  id: string;
+  label: string;
+  description: string;
+  scores: Partial<BeliefMapperScores>;
+};
+
+export type BeliefMapperQuestion = {
+  id: string;
+  prompt: string;
+  hint: string;
+  options: BeliefMapperOption[];
+};
+
+export type BeliefMapperAnswer = {
+  questionId: string;
+  optionId: string;
+};
+
+export type BeliefMapperResult = {
+  id: BeliefMapperStage;
+  title: string;
+  summary: string;
+  guidance: string;
+  color: string;
+  recommendedRoutes: string[];
+};
+
+export const beliefMapperQuestions = questionData.questions as BeliefMapperQuestion[];
+export const beliefMapperResults = resultData.results as BeliefMapperResult[];
+
+export const emptyBeliefMapperScores = (): BeliefMapperScores => ({
+  seeker: 0,
+  believer: 0,
+  onegodian: 0,
+  elder: 0
+});
+
+export function scoreBeliefMapperAnswers(answers: BeliefMapperAnswer[]): BeliefMapperScores {
+  return answers.reduce<BeliefMapperScores>((scores, answer) => {
+    const question = beliefMapperQuestions.find((item) => item.id === answer.questionId);
+    const option = question?.options.find((item) => item.id === answer.optionId);
+
+    if (!option) {
+      return scores;
+    }
+
+    (Object.entries(option.scores) as [BeliefMapperStage, number][]).forEach(([stage, value]) => {
+      scores[stage] += value;
+    });
+
+    return scores;
+  }, emptyBeliefMapperScores());
+}
+
+export function getBeliefMapperResult(answers: BeliefMapperAnswer[]): BeliefMapperResult {
+  const scores = scoreBeliefMapperAnswers(answers);
+  const [topStage] = (Object.entries(scores) as [BeliefMapperStage, number][]).sort((a, b) => b[1] - a[1]);
+  return beliefMapperResults.find((result) => result.id === topStage[0]) ?? beliefMapperResults[0];
+}
+
+export function getBeliefMapperCompletion(answers: BeliefMapperAnswer[]): number {
+  if (beliefMapperQuestions.length === 0) {
+    return 0;
+  }
+
+  return Math.round((answers.length / beliefMapperQuestions.length) * 100);
+}

--- a/src/lib/onegodian-content.ts
+++ b/src/lib/onegodian-content.ts
@@ -1,143 +1,19 @@
-import {
-  appDashboardCards,
-  appFooterBoundary,
-  appHomeHero,
-  appNavigation,
-  coreRoutes,
-  ecosystemPortals,
-  footerSections,
-  rememberCampaign,
-  routeStatusRows,
-  systemsModel,
-  apiStatus,
-  appStatus,
-  pluginCategories
-} from '@/lib/app-content';
-import { consoleDashboardCards, consoleFooterBoundary, consoleNavigation } from '@/lib/console-content';
-
-export const appMeta = appHomeHero;
-export const dashboardCards = appDashboardCards;
-export const ecosystemLinks = ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url }));
-import { appDashboardCards, appFooterBoundary, appHomeHero, appNavigation, ecosystemPortals } from '@/lib/app-content';
-
-export const appMeta = appHomeHero;
-export { appNavigation, ecosystemPortals, appDashboardCards };
-
-export const ecosystemLinks = ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url }));
-
-export const dashboardCards = appDashboardCards;
-
-export const appStructureLayers = [
-  'Public App',
-  'Central Access Dashboard',
-  'Member Dashboard',
-  'Identity Systems',
-  'Registries',
-  'Campaigns',
-  'Media',
-  'Learning',
-  'Certificates',
-  'Tools',
-  'Account Systems',
-  'Member Infrastructure'
-];
-
-export const coreRoutes = [
-  '/',
-  '/dashboard',
-  '/members',
-  '/campaigns',
-  '/campaigns/remember',
-  '/registry',
-  '/tools',
-  '/media',
-  '/learn',
-  '/certificates',
-  '/support',
-  '/settings',
-  '/account',
-  '/api/health',
-  '/api/manifest',
-  '/api/modules'
-];
-
-export const footerSections = [
-  { title: 'App', links: appNavigation },
-  {
-    title: 'Ecosystem',
-    links: ecosystemPortals.map((portal) => ({ label: portal.name, href: portal.url }))
-  }
-];
-
-export const systemsModel = [
-  { title: 'Access', items: ['Dashboard', 'Members', 'Account', 'Settings'] },
-  { title: 'Ecosystem Use', items: ['Campaigns', 'Registry', 'Tools', 'Support'] },
-  { title: 'Knowledge & Records', items: ['Media', 'Learning', 'Certificates'] }
-];
-
-export const apiStatus = {
-  app: 'OneGodian App',
-  appUrl: 'https://app.onegodian.com',
-  consoleUrl: 'https://console.onegodian.com',
-  environment: 'Production',
-  currentDateRecord: 'May 30, 2026'
-};
-
-export const appStatus = {
-  ...apiStatus,
-  store: 'https://onegodian.com',
-  publicSite: 'https://onegodian.org',
-  api: 'https://app.onegodian.com/api/health',
-  activeCampaign: 'THE ONEGODIAN: Remember Campaign'
-};
-
-export const appBoundaryCopy = appFooterBoundary;
-
 export {
+  apiStatus,
+  appBoundaryCopy,
   appDashboardCards,
   appFooterBoundary,
   appHomeHero,
   appNavigation,
-  consoleDashboardCards,
-  consoleNavigation,
+  appStatus,
+  appStructureLayers,
+  beliefMapperRoutes,
   coreRoutes,
+  ecosystemLinks,
   ecosystemPortals,
   footerSections,
+  pluginCategories,
   rememberCampaign,
   routeStatusRows,
-  systemsModel,
-  apiStatus,
-  appStatus,
-  pluginCategories
-};
-
-export const appStructureLayers = ['Public Dashboard', 'Ecosystem', 'Overview', 'OMOS', 'Algorithm', 'Time', 'Commerce', 'Identity', 'Remember', 'Status'];
-export const rememberCampaign = {
-  officialStartDate: 'May 9, 2026',
-  onegodianDate: 'Wisdom 23, OT 0001',
-  message: 'You were always One — you simply forgot. Remember who you are.',
-  purpose:
-    'Preserve memory, identity, origin, purpose, dignity, unity, and disciplined growth through the OneGodian Remember Campaign.',
-  dashboardFunctions: [
-    'Campaign overview',
-    'Remember materials',
-    'Contribution and support pathways',
-    'Public outreach resources',
-    'Media and captions',
-    'Member participation tools',
-    'Campaign certificate pathways'
-  ]
-};
-
-export const pluginCategories = [
-  {
-    title: 'Core Platform Plugins',
-    plugins: [
-      'OneGodian Platform Plugin',
-      'OneGodian App Bridge Plugin',
-      'OneGodian Members Plugin',
-      'OneGodian Certificates Plugin',
-      'OneGodian Registry Plugin'
-    ]
-  }
-];
+  systemsModel
+} from '@/lib/app-content';


### PR DESCRIPTION
### Motivation

- Provide an on-app, consent-first Belief Mapper™ experience that maps users to Seeker/Believer/Onegodian/Elder profiles via a short mobile-first question flow.
- Surface the tool in navigation, dashboard modules, route manifest, and API route coverage so it’s discoverable and testable.

### Description

- Added route group and pages under `/belief-mapper`: `index`, `start`, `results`, `profile`, `journal`, `certificate`, `timeline`, and `premium`, implemented as app routes in `src/app/(app)/belief-mapper/*`.
- Created question and result data files at `content/belief-mapper-questions.json` and `content/belief-mapper-results.json` with scored options and recommended routes.
- Implemented scoring and helpers in `src/lib/beliefMapper/scoring.ts` and a consent-first client/local storage API in `src/lib/beliefMapper/api.ts` to calculate results and optionally persist a local profile.
- Built reusable UI components for the flow and surfaces in `src/components/belief-mapper/*` (`BeliefMapperHero`, `QuestionCard`, `ProgressBar`, `ResultCard`, `EmailCaptureForm`, `PremiumUpgradeCard`, `JournalEntryForm`, `CertificatePreview`) and wired the mobile-first swipe/tap interaction in `QuestionCard`.
- Registered Belief Mapper routes, added dashboard card and nav entry, updated `src/lib/app-content.ts` and `src/lib/onegodian-content.ts`, and extended `src/data/manifest.json` and `scripts/smoke-test.mjs` so manifest and smoke tests include the new routes.

### Testing

- Ran type checking with `npm run typecheck` (TypeScript checks passed after fixes). ✅
- Ran linting with `npm run lint` (no ESLint warnings/errors). ✅
- Executed smoke tests with `npm test` (updated `scripts/smoke-test.mjs`) and verified the server responded 200 for the new route set and `api/manifest` matched expected routes. ✅
- Built the app with `npm run build` to verify pages compile and static pages generate successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1abcc20554832d94e82f0ef12b58b3)