### PR TITLE
Add Algonquian Offer Generator module and register `[algq_offer_generator]` shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,29 @@ Production runtime and documentation platform for **https://omos.onegodian.com**
 
 ## Compliance Positioning
 ONEGODIAN, LLC is the commercial/IP/software entity. OMOS is a voluntary educational, documentation, runtime-support, protocol, and systems architecture layer.
+
+## WordPress plugin shortcode list
+
+- `[algq_deal_intake]`
+- `[algq_mao_engine]`
+- `[algq_offer_generator]`
+- `[algq_pipeline_crm]`
+- `[algq_buyer_portal]`
+- `[algq_product_library]`
+- `[omos_manifest]`
+- `[omos_runtime_status]`
+- `[omos_bridge_builder]`
+- `[omos_tool_grid]`
+- `[omos_docs_grid]`
+
+## Algonquian Offer Generator module layout
+
+- `algq-offer-generator/` — standalone Offer Generator module package with `plugin/`, `docs/`, and `tests/` source areas.
+
+## WPBakery shortcode usage
+
+```text
+[vc_column_text]
+[algq_offer_generator]
+[/vc_column_text]
+```

--- a/algonquian-real-estate/README.md
+++ b/algonquian-real-estate/README.md
@@ -9,7 +9,7 @@ This directory contains the modular WordPress plugin architecture for the Algonq
 | `algq-deal-intake` | Lead capture, validation, scoring, tagging, and import/export workflows. | Planned |
 | `algq-pipeline-crm` | Kanban pipeline, activity history, assignment, and audit trail workflows. | Planned |
 | `algq-mao-engine` | Maximum Allowable Offer calculations, scenario storage, REST endpoints, and shortcodes. | Scaffolded |
-| `algq-offer-generator` | LOI, purchase agreement, seller-financing, PDF, and merge-field workflows. | Planned |
+| `algq-offer-generator` | LOI, purchase agreement, seller-financing, PDF, and merge-field workflows. | Scaffolded |
 | `algq-buyer-portal` | Buyer onboarding, NDA gating, downloads, and interest submissions. | Planned |
 | `algq-funding-tracker` | Lenders, commitments, funding status, and deal-to-lender mapping. | Planned |
 | `algq-automation-engine` | Trigger/action automation, notifications, document triggers, and closeout workflows. | Planned |
@@ -71,3 +71,14 @@ bash algonquian-real-estate/scripts/build-plugin-zips.sh
 - `[algq_pipeline_crm]`
 - `[algq_buyer_portal]`
 - `[algq_product_library]`
+
+## WPBakery usage
+
+Use the Offer Generator shortcode inside a valid WPBakery text block wrapper:
+
+```text
+[vc_column_text]
+[algq_offer_generator]
+[/vc_column_text]
+```
+

--- a/algq-offer-generator/README.md
+++ b/algq-offer-generator/README.md
@@ -1,0 +1,64 @@
+# Algonquian Offer Generator
+
+The Algonquian Offer Generator is a WordPress shortcode module for creating seller-facing offer previews from structured acquisition terms. It supports creative finance scenarios, document merge-field review, and printable summaries for internal or WPBakery-hosted deal pages.
+
+## Shortcode
+
+```text
+[algq_offer_generator]
+```
+
+## Purpose
+
+Use the Offer Generator to:
+
+- Enter property, seller, buyer, and proposed financing terms.
+- Calculate financed amount, estimated monthly payment, total seller income, and total interest.
+- Preview key merge fields before generating or copying terms into deal documents.
+- Print or save the offer summary as a PDF from the browser.
+
+## Supported documents
+
+The current interface supports these document workflows:
+
+- Letter of Intent
+- Purchase Agreement
+- Seller Financing Term Sheet
+- Assignment Summary
+
+## Merge fields
+
+The shortcode interface previews these merge fields for downstream document assembly:
+
+| Merge field | Description |
+| --- | --- |
+| `{{seller_name}}` | Seller or authorized representative name. |
+| `{{buyer_entity}}` | Buyer entity, acquisition entity, or assignee. |
+| `{{property_address}}` | Subject property address. |
+| `{{closing_date}}` | Target closing date or `TBD`. |
+| `{{purchase_price}}` | Proposed purchase price. |
+| `{{down_payment}}` | Proposed down payment. |
+| `{{financed_amount}}` | Purchase price less down payment. |
+| `{{annual_rate}}` | Annual interest rate. |
+| `{{term_months}}` | Financing term in months. |
+| `{{monthly_payment}}` | Estimated monthly payment. |
+| `{{seller_total_income}}` | Down payment plus estimated installment payments. |
+
+## Admin usage
+
+1. Install or copy `algq-offer-generator/plugin/` into the WordPress plugins directory.
+2. Activate **Algonquian Offer Generator** in WordPress Admin → Plugins.
+3. Add `[algq_offer_generator]` to a page, post, or protected deal workspace.
+4. Publish the page and use the form to generate a seller-facing offer preview.
+
+## WPBakery usage
+
+Add the shortcode inside a WPBakery Text Block or Raw HTML-safe content area. Use valid WPBakery wrapper tags only:
+
+```text
+[vc_column_text]
+[algq_offer_generator]
+[/vc_column_text]
+```
+
+Use the closing shortcode shown above so the Text Block wrapper remains valid.

--- a/algq-offer-generator/docs/offer-generator.md
+++ b/algq-offer-generator/docs/offer-generator.md
@@ -1,0 +1,27 @@
+# Offer Generator Module Notes
+
+## Interface
+
+The `[algq_offer_generator]` shortcode renders a responsive form for offer terms and a result panel with calculated payment values and merge-field previews.
+
+## Source layout
+
+```text
+algq-offer-generator/
+├── README.md
+├── docs/
+├── plugin/
+│   ├── algq-offer-generator.php
+│   ├── assets/
+│   ├── includes/
+│   └── templates/
+└── tests/
+```
+
+## WPBakery embed
+
+```text
+[vc_column_text]
+[algq_offer_generator]
+[/vc_column_text]
+```

--- a/algq-offer-generator/plugin/algq-offer-generator.php
+++ b/algq-offer-generator/plugin/algq-offer-generator.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Plugin Name: Algonquian Offer Generator
+ * Description: Creative offer, amortization, seller financing, and printable offer summary tools.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ * Text Domain: algq-offer-generator
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-algq-offer-engine.php';
+
+add_action('wp_enqueue_scripts', function (): void {
+    wp_register_style(
+        'algq-offer-generator',
+        plugins_url('assets/css/offer-generator.css', __FILE__),
+        [],
+        '0.1.0'
+    );
+
+    wp_register_script(
+        'algq-offer-generator',
+        plugins_url('assets/js/offer-generator.js', __FILE__),
+        [],
+        '0.1.0',
+        true
+    );
+});
+
+add_shortcode('algq_offer_generator', function (): string {
+    wp_enqueue_style('algq-offer-generator');
+    wp_enqueue_script('algq-offer-generator');
+
+    $offer = null;
+    $inputs = [
+        'property_address' => '',
+        'seller_name' => '',
+        'buyer_entity' => '',
+        'purchase_price' => 0,
+        'down_payment' => 0,
+        'annual_rate' => 0,
+        'term_months' => 60,
+        'closing_date' => '',
+        'document_type' => 'Letter of Intent',
+    ];
+
+    if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_offer_nonce'])) {
+        $nonce = sanitize_text_field(wp_unslash($_POST['algq_offer_nonce']));
+
+        if (wp_verify_nonce($nonce, 'algq_offer_generate')) {
+            $inputs = [
+                'property_address' => sanitize_text_field(wp_unslash($_POST['property_address'] ?? '')),
+                'seller_name' => sanitize_text_field(wp_unslash($_POST['seller_name'] ?? '')),
+                'buyer_entity' => sanitize_text_field(wp_unslash($_POST['buyer_entity'] ?? '')),
+                'purchase_price' => (float) ($_POST['purchase_price'] ?? 0),
+                'down_payment' => (float) ($_POST['down_payment'] ?? 0),
+                'annual_rate' => (float) ($_POST['annual_rate'] ?? 0),
+                'term_months' => max(1, (int) ($_POST['term_months'] ?? 60)),
+                'closing_date' => sanitize_text_field(wp_unslash($_POST['closing_date'] ?? '')),
+                'document_type' => sanitize_text_field(wp_unslash($_POST['document_type'] ?? 'Letter of Intent')),
+            ];
+
+            $offer = (new ALGQ_Offer_Engine())->generate($inputs);
+        }
+    }
+
+    ob_start();
+    include __DIR__ . '/templates/offer-generator.php';
+    return (string) ob_get_clean();
+});

--- a/algq-offer-generator/plugin/assets/css/offer-generator.css
+++ b/algq-offer-generator/plugin/assets/css/offer-generator.css
@@ -1,0 +1,86 @@
+.algq-offer-generator {
+  border: 1px solid #d7dee8;
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  color: #172033;
+  max-width: 980px;
+  padding: 1.25rem;
+}
+
+.algq-offer-generator__eyebrow {
+  color: #4263eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+}
+
+.algq-offer-generator__header h2 {
+  margin: 0 0 0.4rem;
+}
+
+.algq-offer-generator__grid,
+.algq-offer-generator__cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.algq-offer-generator label {
+  display: grid;
+  font-weight: 700;
+  gap: 0.35rem;
+}
+
+.algq-offer-generator input,
+.algq-offer-generator select {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.7rem 0.8rem;
+}
+
+.algq-offer-generator__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.algq-offer-generator button {
+  background: #172033;
+  border: 0;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.75rem 1rem;
+}
+
+.algq-offer-generator button[type='button'] {
+  background: #4263eb;
+}
+
+.algq-offer-generator__results {
+  background: #f8fafc;
+  border-radius: 14px;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.algq-offer-generator__cards > div {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.algq-offer-generator__cards span {
+  display: block;
+  font-size: 1.2rem;
+  margin-top: 0.25rem;
+}
+
+.algq-offer-generator__merge-preview {
+  border-top: 1px solid #d7dee8;
+  margin-top: 1rem;
+  padding-top: 1rem;
+}

--- a/algq-offer-generator/plugin/assets/js/offer-generator.js
+++ b/algq-offer-generator/plugin/assets/js/offer-generator.js
@@ -1,0 +1,9 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-algq-print-offer]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        window.print();
+      });
+    });
+  });
+})();

--- a/algq-offer-generator/plugin/includes/class-algq-offer-engine.php
+++ b/algq-offer-generator/plugin/includes/class-algq-offer-engine.php
@@ -1,0 +1,43 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Engine
+{
+    /**
+     * @param array<string, mixed> $input
+     * @return array<string, mixed>
+     */
+    public function generate(array $input): array
+    {
+        $purchase_price = max(0, (float) ($input['purchase_price'] ?? 0));
+        $down_payment = min($purchase_price, max(0, (float) ($input['down_payment'] ?? 0)));
+        $financed_amount = max(0, $purchase_price - $down_payment);
+        $annual_rate = max(0, (float) ($input['annual_rate'] ?? 0));
+        $term_months = max(1, (int) ($input['term_months'] ?? 1));
+        $monthly_rate = ($annual_rate / 100) / 12;
+        $monthly_payment = $monthly_rate > 0
+            ? $financed_amount * ($monthly_rate * ((1 + $monthly_rate) ** $term_months)) / (((1 + $monthly_rate) ** $term_months) - 1)
+            : $financed_amount / $term_months;
+
+        $total_payments = $monthly_payment * $term_months;
+        $seller_total = $down_payment + $total_payments;
+
+        return [
+            'document_type' => (string) ($input['document_type'] ?? 'Letter of Intent'),
+            'property_address' => (string) ($input['property_address'] ?? ''),
+            'seller_name' => (string) ($input['seller_name'] ?? ''),
+            'buyer_entity' => (string) ($input['buyer_entity'] ?? ''),
+            'purchase_price' => round($purchase_price, 2),
+            'down_payment' => round($down_payment, 2),
+            'financed_amount' => round($financed_amount, 2),
+            'annual_rate' => round($annual_rate, 3),
+            'term_months' => $term_months,
+            'monthly_payment' => round($monthly_payment, 2),
+            'seller_total_income' => round($seller_total, 2),
+            'total_interest' => round(max(0, $total_payments - $financed_amount), 2),
+            'closing_date' => (string) ($input['closing_date'] ?? ''),
+        ];
+    }
+}

--- a/algq-offer-generator/plugin/templates/offer-generator.php
+++ b/algq-offer-generator/plugin/templates/offer-generator.php
@@ -1,0 +1,65 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$document_types = [
+    'Letter of Intent',
+    'Purchase Agreement',
+    'Seller Financing Term Sheet',
+    'Assignment Summary',
+];
+?>
+<div class="algq-offer-generator" data-algq-offer-generator>
+    <div class="algq-offer-generator__header">
+        <p class="algq-offer-generator__eyebrow">Algonquian Real Estate</p>
+        <h2>Offer Generator</h2>
+        <p>Create seller-facing offer terms, merge-field previews, and printable summaries from a single shortcode.</p>
+    </div>
+
+    <form class="algq-offer-generator__form" method="post">
+        <?php wp_nonce_field('algq_offer_generate', 'algq_offer_nonce'); ?>
+        <div class="algq-offer-generator__grid">
+            <label>Document type
+                <select name="document_type">
+                    <?php foreach ($document_types as $document_type) : ?>
+                        <option value="<?php echo esc_attr($document_type); ?>" <?php selected($inputs['document_type'], $document_type); ?>><?php echo esc_html($document_type); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label>Property address <input name="property_address" value="<?php echo esc_attr($inputs['property_address']); ?>" placeholder="123 Main Street" /></label>
+            <label>Seller name <input name="seller_name" value="<?php echo esc_attr($inputs['seller_name']); ?>" placeholder="Seller Name" /></label>
+            <label>Buyer entity <input name="buyer_entity" value="<?php echo esc_attr($inputs['buyer_entity']); ?>" placeholder="Buyer LLC" /></label>
+            <label>Purchase price <input required name="purchase_price" type="number" min="0" step="0.01" value="<?php echo esc_attr((string) $inputs['purchase_price']); ?>" /></label>
+            <label>Down payment <input name="down_payment" type="number" min="0" step="0.01" value="<?php echo esc_attr((string) $inputs['down_payment']); ?>" /></label>
+            <label>Annual interest rate <input required name="annual_rate" type="number" min="0" step="0.001" value="<?php echo esc_attr((string) $inputs['annual_rate']); ?>" /></label>
+            <label>Term (months) <input required name="term_months" type="number" min="1" step="1" value="<?php echo esc_attr((string) $inputs['term_months']); ?>" /></label>
+            <label>Target closing date <input name="closing_date" type="date" value="<?php echo esc_attr($inputs['closing_date']); ?>" /></label>
+        </div>
+        <p class="algq-offer-generator__actions">
+            <button type="submit">Generate Offer</button>
+            <button type="button" data-algq-print-offer>Print / Save PDF</button>
+        </p>
+    </form>
+
+    <?php if (!empty($offer)) : ?>
+        <section class="algq-offer-generator__results" aria-live="polite">
+            <h3><?php echo esc_html($offer['document_type']); ?> Preview</h3>
+            <div class="algq-offer-generator__cards">
+                <div><strong>Purchase Price</strong><span>$<?php echo esc_html(number_format($offer['purchase_price'], 2)); ?></span></div>
+                <div><strong>Down Payment</strong><span>$<?php echo esc_html(number_format($offer['down_payment'], 2)); ?></span></div>
+                <div><strong>Financed Amount</strong><span>$<?php echo esc_html(number_format($offer['financed_amount'], 2)); ?></span></div>
+                <div><strong>Monthly Payment</strong><span>$<?php echo esc_html(number_format($offer['monthly_payment'], 2)); ?></span></div>
+                <div><strong>Total Seller Income</strong><span>$<?php echo esc_html(number_format($offer['seller_total_income'], 2)); ?></span></div>
+                <div><strong>Total Interest</strong><span>$<?php echo esc_html(number_format($offer['total_interest'], 2)); ?></span></div>
+            </div>
+            <div class="algq-offer-generator__merge-preview">
+                <h4>Merge-field preview</h4>
+                <p><code>{{seller_name}}</code>: <?php echo esc_html($offer['seller_name'] ?: 'Seller Name'); ?></p>
+                <p><code>{{buyer_entity}}</code>: <?php echo esc_html($offer['buyer_entity'] ?: 'Buyer Entity'); ?></p>
+                <p><code>{{property_address}}</code>: <?php echo esc_html($offer['property_address'] ?: 'Property Address'); ?></p>
+                <p><code>{{closing_date}}</code>: <?php echo esc_html($offer['closing_date'] ?: 'TBD'); ?></p>
+            </div>
+        </section>
+    <?php endif; ?>
+</div>

--- a/algq-offer-generator/tests/shortcode-structure.test.js
+++ b/algq-offer-generator/tests/shortcode-structure.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const pluginFile = fs.readFileSync(path.join(root, 'plugin', 'algq-offer-generator.php'), 'utf8');
+const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+const template = fs.readFileSync(path.join(root, 'plugin', 'templates', 'offer-generator.php'), 'utf8');
+
+assert.match(pluginFile, /add_shortcode\(\s*'algq_offer_generator'/, 'shortcode must be registered');
+assert.match(template, /data-algq-offer-generator/, 'template must render the Offer Generator interface');
+assert.match(readme, /\[algq_offer_generator\]/, 'README must document the shortcode');
+assert.match(readme, /\[vc_column_text\]\s*\n\[algq_offer_generator\]\s*\n\[\/vc_column_text\]/, 'README must show valid WPBakery usage');
+assert.doesNotMatch(readme, /\[\/vc_column\]/, 'README must not use invalid WPBakery closing tags');
+
+console.log('offer generator shortcode structure passed');

--- a/src/data/plugin-shortcodes.json
+++ b/src/data/plugin-shortcodes.json
@@ -4,6 +4,7 @@
     "[omos_runtime_status]",
     "[omos_bridge_builder]",
     "[omos_tool_grid]",
-    "[omos_docs_grid]"
+    "[omos_docs_grid]",
+    "[algq_offer_generator]"
   ]
 }


### PR DESCRIPTION
### Motivation

- Provide a standalone Offer Generator module for Algonquian Real Estate to render seller-facing offer UIs, amortization calculations, merge-field previews, and printable summaries via a shortcode. 
- Surface the new module in repository documentation and the plugin-shortcodes registry so it is discoverable and usable in WP pages and WPBakery content.

### Description

- Added a new top-level module folder `algq-offer-generator/` with `plugin/`, `docs/`, and `tests/` subdirectories and a `README.md` describing purpose, supported documents, merge fields, admin usage, and WPBakery usage. 
- Implemented `plugin/algq-offer-generator.php` which registers the shortcode `add_shortcode('algq_offer_generator', ...)`, enqueues assets, sanitizes and nonce-checks inputs, and renders the template. 
- Added an offer calculation engine in `plugin/includes/class-algq-offer-engine.php` that computes financed amount, monthly payment, total seller income, and total interest. 
- Created the shortcode UI template `plugin/templates/offer-generator.php` and assets (`assets/css/offer-generator.css`, `assets/js/offer-generator.js`) which include a `data-algq-offer-generator` marker so the shortcode renders an Offer Generator interface. 
- Documented valid WPBakery usage with the safe wrapper snippet `
[vc_column_text]
[algq_offer_generator]
[/vc_column_text]
` and ensured no invalid WPBakery closing tags are present. 
- Updated root `README.md`, `algonquian-real-estate/README.md`, and `src/data/plugin-shortcodes.json` to include `
[algq_offer_generator]
` in the shortcodes list.

### Testing

- Ran PHP linting `php -l` on plugin PHP files and they reported no syntax errors (passed). 
- Executed the module structural test `node algq-offer-generator/tests/shortcode-structure.test.js`, which verifies shortcode registration, presence of the `data-algq-offer-generator` interface marker, README documentation, valid WPBakery usage, and absence of invalid `[/vc_column]` tags (passed). 
- Validated `src/data/plugin-shortcodes.json` is valid JSON with a Node check (passed). 
- Ran repository `npm run check` (Node check) which completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b4b520478832db0409bf3483b0f99)