### PR TITLE
Add Algonquian PDF & Signature Engine WordPress plugin

### DIFF
--- a/algonquian-real-estate/plugins/algq-pdf-signature/README.md
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/README.md
@@ -1,3 +1,26 @@
-# Algonquian PDF & Signature
+# Algonquian PDF & Signature Engine
 
-Planned v1.1+ module for PDF generation, signature requests, audit logs, purchase agreements, LOIs, assignment contracts, and seller-financing agreements.
+WordPress module for real-estate document execution workflows.
+
+## Capabilities
+
+- PDF rendering from structured deal payloads and archived document records.
+- Signature requests with public shortcodes and REST signing endpoints.
+- Document archive tables for source payloads, rendered HTML, PDF checksums, signature hashes, and timestamps.
+- Execution status tracking across draft, sent, signed, archived, voided, and expired states.
+- Audit-event logging for create, send, signature completion, archive, and void actions.
+
+## REST API
+
+- `GET /wp-json/algq/v1/documents` — list document archive records.
+- `POST /wp-json/algq/v1/documents` — render and create a document.
+- `GET /wp-json/algq/v1/documents/{id}` — retrieve one document and audit events.
+- `GET /wp-json/algq/v1/documents/{id}/pdf` — retrieve a base64 PDF payload with checksum headers.
+- `POST /wp-json/algq/v1/documents/{id}/send` — mark a signature request as sent.
+- `POST /wp-json/algq/v1/documents/{id}/archive` — archive a document.
+- `POST /wp-json/algq/v1/documents/{id}/void` — void a document.
+- `POST /wp-json/algq/v1/documents/{uid}/sign` — public signature completion endpoint.
+
+## Shortcode
+
+Use `[algq_signature document_uid="DOC-YYYYMMDD-ABC12345"]` on a protected page to show the rendered document preview and signature form.

--- a/algonquian-real-estate/plugins/algq-pdf-signature/admin/class-algq-pdf-signature-admin.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/admin/class-algq-pdf-signature-admin.php
@@ -1,0 +1,167 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Admin
+{
+    private ALGQ_PDF_Signature_Repository $repository;
+    private ALGQ_PDF_Signature_Renderer $renderer;
+
+    public function __construct(ALGQ_PDF_Signature_Repository $repository, ALGQ_PDF_Signature_Renderer $renderer)
+    {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'register_admin_page']);
+        add_action('admin_post_algq_document_create', [$this, 'handle_create']);
+        add_action('admin_post_algq_document_send', [$this, 'handle_send']);
+        add_action('admin_post_algq_document_archive', [$this, 'handle_archive']);
+        add_action('admin_post_algq_document_void', [$this, 'handle_void']);
+        add_action('admin_post_algq_document_pdf', [$this, 'handle_pdf']);
+    }
+
+    public function register_admin_page(): void
+    {
+        add_menu_page('PDF & Signatures', 'PDF & Signatures', 'manage_options', 'algq-documents', [$this, 'render_admin_page'], 'dashicons-media-document', 27);
+    }
+
+    public function handle_create(): void
+    {
+        $this->guard_action('algq_document_create');
+        $payload = [
+            'property_address' => sanitize_text_field($_POST['property_address'] ?? ''),
+            'terms' => sanitize_textarea_field($_POST['terms'] ?? ''),
+        ];
+        $data = [
+            'title' => sanitize_text_field($_POST['title'] ?? ''),
+            'document_type' => sanitize_key($_POST['document_type'] ?? 'purchase_agreement'),
+            'related_deal_id' => sanitize_text_field($_POST['related_deal_id'] ?? ''),
+            'recipient_name' => sanitize_text_field($_POST['recipient_name'] ?? ''),
+            'recipient_email' => sanitize_email($_POST['recipient_email'] ?? ''),
+            'payload' => $payload,
+        ];
+        $html = $this->renderer->render_html($data);
+        $pdf = $this->renderer->render_pdf_binary($data);
+        $this->repository->create_document($data, $html, $this->renderer->checksum($pdf));
+        wp_safe_redirect(admin_url('admin.php?page=algq-documents'));
+        exit;
+    }
+
+    public function handle_send(): void
+    {
+        $this->guard_action('algq_document_send');
+        $this->repository->mark_sent((int) ($_GET['id'] ?? 0), wp_get_current_user()->user_login);
+        wp_safe_redirect(admin_url('admin.php?page=algq-documents'));
+        exit;
+    }
+
+    public function handle_archive(): void
+    {
+        $this->guard_action('algq_document_archive');
+        $this->repository->archive((int) ($_GET['id'] ?? 0), wp_get_current_user()->user_login);
+        wp_safe_redirect(admin_url('admin.php?page=algq-documents&status=archived'));
+        exit;
+    }
+
+    public function handle_void(): void
+    {
+        $this->guard_action('algq_document_void');
+        $this->repository->void((int) ($_GET['id'] ?? 0), wp_get_current_user()->user_login);
+        wp_safe_redirect(admin_url('admin.php?page=algq-documents&status=voided'));
+        exit;
+    }
+
+    public function handle_pdf(): void
+    {
+        $this->guard_action('algq_document_pdf');
+        $document = $this->repository->find((int) ($_GET['id'] ?? 0));
+        if (!$document) {
+            wp_die(esc_html__('Document not found.', 'algq-pdf-signature'));
+        }
+
+        $pdf = $this->renderer->render_pdf_binary($document);
+        header('Content-Type: application/pdf');
+        header('Content-Disposition: attachment; filename="' . sanitize_file_name($document['document_uid']) . '.pdf"');
+        header('Content-Length: ' . strlen($pdf));
+        echo $pdf;
+        exit;
+    }
+
+    public function render_admin_page(): void
+    {
+        $filters = [
+            'status' => sanitize_key($_GET['status'] ?? ''),
+            'execution_status' => sanitize_key($_GET['execution_status'] ?? ''),
+        ];
+        $rows = $this->repository->all(100, array_filter($filters));
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Algonquian PDF & Signature Engine', 'algq-pdf-signature'); ?></h1>
+            <p><?php esc_html_e('Render deal documents, send signature requests, track execution state, and archive completed agreements.', 'algq-pdf-signature'); ?></p>
+
+            <h2><?php esc_html_e('Create Document', 'algq-pdf-signature'); ?></h2>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <?php wp_nonce_field('algq_document_create'); ?>
+                <input type="hidden" name="action" value="algq_document_create" />
+                <table class="form-table" role="presentation">
+                    <tr><th><label for="algq-title"><?php esc_html_e('Title', 'algq-pdf-signature'); ?></label></th><td><input class="regular-text" id="algq-title" name="title" required /></td></tr>
+                    <tr><th><label for="algq-type"><?php esc_html_e('Document Type', 'algq-pdf-signature'); ?></label></th><td><select id="algq-type" name="document_type"><option value="purchase_agreement"><?php esc_html_e('Purchase Agreement', 'algq-pdf-signature'); ?></option><option value="loi"><?php esc_html_e('LOI', 'algq-pdf-signature'); ?></option><option value="assignment_contract"><?php esc_html_e('Assignment Contract', 'algq-pdf-signature'); ?></option><option value="seller_financing"><?php esc_html_e('Seller Financing', 'algq-pdf-signature'); ?></option></select></td></tr>
+                    <tr><th><label for="algq-deal"><?php esc_html_e('Related Deal ID', 'algq-pdf-signature'); ?></label></th><td><input class="regular-text" id="algq-deal" name="related_deal_id" /></td></tr>
+                    <tr><th><label for="algq-recipient"><?php esc_html_e('Recipient Name', 'algq-pdf-signature'); ?></label></th><td><input class="regular-text" id="algq-recipient" name="recipient_name" required /></td></tr>
+                    <tr><th><label for="algq-email"><?php esc_html_e('Recipient Email', 'algq-pdf-signature'); ?></label></th><td><input class="regular-text" id="algq-email" type="email" name="recipient_email" required /></td></tr>
+                    <tr><th><label for="algq-property"><?php esc_html_e('Property Address', 'algq-pdf-signature'); ?></label></th><td><input class="large-text" id="algq-property" name="property_address" /></td></tr>
+                    <tr><th><label for="algq-terms"><?php esc_html_e('Terms', 'algq-pdf-signature'); ?></label></th><td><textarea class="large-text" id="algq-terms" name="terms" rows="4"></textarea></td></tr>
+                </table>
+                <p><button class="button button-primary" type="submit"><?php esc_html_e('Render & Save Document', 'algq-pdf-signature'); ?></button></p>
+            </form>
+
+            <h2><?php esc_html_e('Document Archive & Execution Status', 'algq-pdf-signature'); ?></h2>
+            <table class="widefat striped">
+                <thead><tr><th><?php esc_html_e('UID', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Title', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Recipient', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Status', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Execution', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Signed', 'algq-pdf-signature'); ?></th><th><?php esc_html_e('Actions', 'algq-pdf-signature'); ?></th></tr></thead>
+                <tbody>
+                <?php if (empty($rows)) : ?>
+                    <tr><td colspan="7"><?php esc_html_e('No documents yet.', 'algq-pdf-signature'); ?></td></tr>
+                <?php endif; ?>
+                <?php foreach ($rows as $row) : ?>
+                    <tr>
+                        <td><?php echo esc_html($row['document_uid']); ?></td>
+                        <td><?php echo esc_html($row['title']); ?></td>
+                        <td><?php echo esc_html($row['recipient_name'] . ' <' . $row['recipient_email'] . '>'); ?></td>
+                        <td><?php echo esc_html($row['status']); ?></td>
+                        <td><?php echo esc_html($row['execution_status']); ?></td>
+                        <td><?php echo esc_html($row['signed_at'] ?: '—'); ?></td>
+                        <td><?php $this->render_actions($row); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+
+    private function render_actions(array $row): void
+    {
+        $actions = [
+            'PDF' => wp_nonce_url(admin_url('admin-post.php?action=algq_document_pdf&id=' . (int) $row['id']), 'algq_document_pdf'),
+            'Send' => wp_nonce_url(admin_url('admin-post.php?action=algq_document_send&id=' . (int) $row['id']), 'algq_document_send'),
+            'Archive' => wp_nonce_url(admin_url('admin-post.php?action=algq_document_archive&id=' . (int) $row['id']), 'algq_document_archive'),
+            'Void' => wp_nonce_url(admin_url('admin-post.php?action=algq_document_void&id=' . (int) $row['id']), 'algq_document_void'),
+        ];
+        foreach ($actions as $label => $url) {
+            echo '<a class="button button-small" href="' . esc_url($url) . '">' . esc_html($label) . '</a> ';
+        }
+        echo '<code>[algq_signature document_uid="' . esc_attr($row['document_uid']) . '"]</code>';
+    }
+
+    private function guard_action(string $nonce_action): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Insufficient permissions.', 'algq-pdf-signature'));
+        }
+        check_admin_referer($nonce_action);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/algq-pdf-signature.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/algq-pdf-signature.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Algonquian PDF & Signature Engine
+ * Description: PDF rendering, signature workflow, document archive, and execution status tracking for Algonquian Real Estate documents.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ * Text Domain: algq-pdf-signature
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('ALGQ_PDF_SIGNATURE_VERSION', '0.1.0');
+define('ALGQ_PDF_SIGNATURE_FILE', __FILE__);
+define('ALGQ_PDF_SIGNATURE_DIR', plugin_dir_path(__FILE__));
+
+require_once ALGQ_PDF_SIGNATURE_DIR . 'includes/class-algq-pdf-signature-repository.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'includes/class-algq-pdf-signature-renderer.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'includes/class-algq-pdf-signature-activator.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'includes/class-algq-pdf-signature-rest-controller.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'admin/class-algq-pdf-signature-admin.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'public/class-algq-pdf-signature-public.php';
+require_once ALGQ_PDF_SIGNATURE_DIR . 'includes/class-algq-pdf-signature-plugin.php';
+
+register_activation_hook(__FILE__, ['ALGQ_PDF_Signature_Activator', 'activate']);
+
+add_action('plugins_loaded', static function (): void {
+    ALGQ_PDF_Signature_Plugin::instance()->run();
+});

--- a/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-activator.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-activator.php
@@ -1,0 +1,65 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Activator
+{
+    public static function activate(): void
+    {
+        global $wpdb;
+
+        $charset = $wpdb->get_charset_collate();
+        $documents = ALGQ_PDF_Signature_Repository::documents_table();
+        $events = ALGQ_PDF_Signature_Repository::events_table();
+
+        $documents_sql = "CREATE TABLE {$documents} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            document_uid varchar(40) NOT NULL,
+            title varchar(191) NOT NULL,
+            document_type varchar(80) NOT NULL DEFAULT 'purchase_agreement',
+            related_deal_id varchar(64) DEFAULT '',
+            recipient_name varchar(191) NOT NULL,
+            recipient_email varchar(191) NOT NULL,
+            signer_name varchar(191) DEFAULT '',
+            signature_hash varchar(128) DEFAULT '',
+            status varchar(40) NOT NULL DEFAULT 'draft',
+            execution_status varchar(40) NOT NULL DEFAULT 'not_started',
+            source_payload longtext NULL,
+            rendered_html longtext NULL,
+            pdf_checksum varchar(128) DEFAULT '',
+            archived_at datetime NULL,
+            sent_at datetime NULL,
+            signed_at datetime NULL,
+            expires_at datetime NULL,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY document_uid (document_uid),
+            KEY document_type (document_type),
+            KEY related_deal_id (related_deal_id),
+            KEY status (status),
+            KEY execution_status (execution_status),
+            KEY recipient_email (recipient_email)
+        ) {$charset};";
+
+        $events_sql = "CREATE TABLE {$events} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            document_id bigint(20) unsigned NOT NULL,
+            event_type varchar(80) NOT NULL,
+            actor varchar(191) DEFAULT '',
+            actor_ip varchar(64) DEFAULT '',
+            message text NULL,
+            metadata longtext NULL,
+            created_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY document_id (document_id),
+            KEY event_type (event_type),
+            KEY created_at (created_at)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($documents_sql);
+        dbDelta($events_sql);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-plugin.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-plugin.php
@@ -1,0 +1,39 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Plugin
+{
+    private static ?self $instance = null;
+
+    private ALGQ_PDF_Signature_Repository $repository;
+    private ALGQ_PDF_Signature_Renderer $renderer;
+    private ALGQ_PDF_Signature_REST_Controller $rest;
+    private ALGQ_PDF_Signature_Admin $admin;
+    private ALGQ_PDF_Signature_Public $public;
+
+    private function __construct()
+    {
+        $this->repository = new ALGQ_PDF_Signature_Repository();
+        $this->renderer = new ALGQ_PDF_Signature_Renderer();
+        $this->rest = new ALGQ_PDF_Signature_REST_Controller($this->repository, $this->renderer);
+        $this->admin = new ALGQ_PDF_Signature_Admin($this->repository, $this->renderer);
+        $this->public = new ALGQ_PDF_Signature_Public($this->repository, $this->renderer);
+    }
+
+    public static function instance(): self
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function run(): void
+    {
+        $this->admin->register();
+        $this->public->register();
+        add_action('rest_api_init', [$this->rest, 'register_routes']);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-renderer.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-renderer.php
@@ -1,0 +1,118 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Renderer
+{
+    public function render_html(array $data): string
+    {
+        $payload = $data['payload'] ?? [];
+        $title = sanitize_text_field($data['title'] ?? 'Algonquian Real Estate Document');
+        $document_type = sanitize_text_field($data['document_type'] ?? 'purchase_agreement');
+        $recipient = sanitize_text_field($data['recipient_name'] ?? 'Recipient');
+        $property = sanitize_text_field($payload['property_address'] ?? $data['property_address'] ?? 'Property address pending');
+        $terms = sanitize_textarea_field($payload['terms'] ?? $data['terms'] ?? 'Execution terms pending final approval.');
+        $generated_at = current_time('mysql');
+
+        ob_start();
+        ?>
+        <article class="algq-document">
+            <header>
+                <p><strong><?php esc_html_e('Algonquian Real Estate', 'algq-pdf-signature'); ?></strong></p>
+                <h1><?php echo esc_html($title); ?></h1>
+                <p><?php echo esc_html(ucwords(str_replace('_', ' ', $document_type))); ?> · <?php echo esc_html($generated_at); ?></p>
+            </header>
+            <section>
+                <h2><?php esc_html_e('Parties', 'algq-pdf-signature'); ?></h2>
+                <p><?php echo esc_html($recipient); ?> <?php esc_html_e('is requested to review and execute this document.', 'algq-pdf-signature'); ?></p>
+            </section>
+            <section>
+                <h2><?php esc_html_e('Property', 'algq-pdf-signature'); ?></h2>
+                <p><?php echo esc_html($property); ?></p>
+            </section>
+            <section>
+                <h2><?php esc_html_e('Terms', 'algq-pdf-signature'); ?></h2>
+                <p><?php echo nl2br(esc_html($terms)); ?></p>
+            </section>
+            <section>
+                <h2><?php esc_html_e('Execution', 'algq-pdf-signature'); ?></h2>
+                <p><?php esc_html_e('Electronic signatures are captured with signer name, timestamp, IP metadata, and an immutable signature hash.', 'algq-pdf-signature'); ?></p>
+                <p><?php esc_html_e('Signer:', 'algq-pdf-signature'); ?> ____________________________</p>
+                <p><?php esc_html_e('Date:', 'algq-pdf-signature'); ?> ____________________________</p>
+            </section>
+        </article>
+        <?php
+        return trim((string) ob_get_clean());
+    }
+
+    public function render_pdf_binary(array $document): string
+    {
+        $lines = $this->document_lines($document);
+        $content = "BT\n/F1 12 Tf\n72 740 Td\n";
+        foreach ($lines as $index => $line) {
+            if ($index > 0) {
+                $content .= "0 -18 Td\n";
+            }
+            $content .= '(' . $this->escape_pdf_text($line) . ") Tj\n";
+        }
+        $content .= "ET\n";
+
+        $objects = [];
+        $objects[] = '<< /Type /Catalog /Pages 2 0 R >>';
+        $objects[] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+        $objects[] = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>';
+        $objects[] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+        $objects[] = '<< /Length ' . strlen($content) . " >>\nstream\n" . $content . "endstream";
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $number => $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= ($number + 1) . " 0 obj\n" . $object . "\nendobj\n";
+        }
+
+        $xref_offset = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n";
+        $pdf .= "0000000000 65535 f \n";
+        for ($i = 1; $i <= count($objects); $i++) {
+            $pdf .= sprintf('%010d 00000 n ', $offsets[$i]) . "\n";
+        }
+        $pdf .= "trailer\n<< /Size " . (count($objects) + 1) . " /Root 1 0 R >>\nstartxref\n{$xref_offset}\n%%EOF";
+
+        return $pdf;
+    }
+
+    public function checksum(string $pdf_binary): string
+    {
+        return hash('sha256', $pdf_binary);
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function document_lines(array $document): array
+    {
+        $payload = $document['source_payload'] ?? $document['payload'] ?? [];
+        return array_filter([
+            'Algonquian Real Estate',
+            (string) ($document['title'] ?? 'Document'),
+            'Document UID: ' . (string) ($document['document_uid'] ?? 'Pending'),
+            'Type: ' . ucwords(str_replace('_', ' ', (string) ($document['document_type'] ?? 'document'))),
+            'Recipient: ' . (string) ($document['recipient_name'] ?? ''),
+            'Email: ' . (string) ($document['recipient_email'] ?? ''),
+            'Property: ' . (string) ($payload['property_address'] ?? 'Property address pending'),
+            'Terms: ' . (string) ($payload['terms'] ?? 'Execution terms pending final approval.'),
+            'Status: ' . (string) ($document['status'] ?? 'draft'),
+            'Execution Status: ' . (string) ($document['execution_status'] ?? 'not_started'),
+            'Signature Hash: ' . (string) ($document['signature_hash'] ?? ''),
+        ]);
+    }
+
+    private function escape_pdf_text(string $text): string
+    {
+        $text = wp_strip_all_tags($text);
+        $text = substr($text, 0, 140);
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-repository.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-repository.php
@@ -1,0 +1,230 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Repository
+{
+    public const DOCUMENTS_TABLE = 'algq_documents';
+    public const EVENTS_TABLE = 'algq_document_events';
+
+    public static function documents_table(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . self::DOCUMENTS_TABLE;
+    }
+
+    public static function events_table(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . self::EVENTS_TABLE;
+    }
+
+    /**
+     * @return int|false
+     */
+    public function create_document(array $data, string $rendered_html = '', string $pdf_checksum = '')
+    {
+        global $wpdb;
+
+        $now = current_time('mysql');
+        $document_uid = $data['document_uid'] ?? $this->generate_document_uid();
+        $expires_at = !empty($data['expires_at']) ? $data['expires_at'] : gmdate('Y-m-d H:i:s', strtotime('+14 days'));
+        $status = sanitize_key($data['status'] ?? 'draft');
+        $execution_status = $this->execution_status_for($status);
+
+        $inserted = $wpdb->insert(
+            self::documents_table(),
+            [
+                'document_uid' => $document_uid,
+                'title' => sanitize_text_field($data['title'] ?? 'Untitled Document'),
+                'document_type' => sanitize_key($data['document_type'] ?? 'purchase_agreement'),
+                'related_deal_id' => sanitize_text_field($data['related_deal_id'] ?? ''),
+                'recipient_name' => sanitize_text_field($data['recipient_name'] ?? ''),
+                'recipient_email' => sanitize_email($data['recipient_email'] ?? ''),
+                'status' => $status,
+                'execution_status' => $execution_status,
+                'source_payload' => wp_json_encode($data['payload'] ?? []),
+                'rendered_html' => wp_kses_post($rendered_html),
+                'pdf_checksum' => sanitize_text_field($pdf_checksum),
+                'expires_at' => $expires_at,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            ['%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s']
+        );
+
+        if (false === $inserted) {
+            return false;
+        }
+
+        $id = (int) $wpdb->insert_id;
+        $this->record_event($id, 'document.created', get_current_user_id() ? wp_get_current_user()->user_login : 'system', 'Document created and rendered.');
+        return $id;
+    }
+
+    public function find(int $id): ?array
+    {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . self::documents_table() . ' WHERE id = %d', $id), ARRAY_A);
+        return $row ? $this->hydrate_document($row) : null;
+    }
+
+    public function find_by_uid(string $uid): ?array
+    {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . self::documents_table() . ' WHERE document_uid = %s', sanitize_text_field($uid)), ARRAY_A);
+        return $row ? $this->hydrate_document($row) : null;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function all(int $limit = 50, array $filters = []): array
+    {
+        global $wpdb;
+        $limit = $limit > 0 ? max(1, min(200, $limit)) : 50;
+        $where = 'WHERE 1=1';
+        $args = [];
+
+        foreach (['status', 'execution_status', 'document_type', 'related_deal_id'] as $field) {
+            if (!empty($filters[$field])) {
+                $where .= " AND {$field} = %s";
+                $args[] = 'related_deal_id' === $field ? sanitize_text_field($filters[$field]) : sanitize_key($filters[$field]);
+            }
+        }
+
+        $sql = 'SELECT * FROM ' . self::documents_table() . " {$where} ORDER BY created_at DESC LIMIT %d";
+        $args[] = $limit;
+        $rows = $wpdb->get_results($wpdb->prepare($sql, $args), ARRAY_A);
+
+        return array_map([$this, 'hydrate_document'], $rows ?: []);
+    }
+
+    public function mark_sent(int $id, string $actor = ''): bool
+    {
+        $updated = $this->update_status($id, 'sent', ['sent_at' => current_time('mysql')]);
+        if ($updated) {
+            $this->record_event($id, 'signature.sent', $actor, 'Signature request sent to recipient.');
+        }
+        return $updated;
+    }
+
+    public function sign_document(int $id, string $signer_name, string $signature_payload, string $actor_ip = ''): bool
+    {
+        global $wpdb;
+
+        $hash = hash('sha256', $id . '|' . $signer_name . '|' . $signature_payload . '|' . wp_salt('auth'));
+        $updated = false !== $wpdb->update(
+            self::documents_table(),
+            [
+                'signer_name' => sanitize_text_field($signer_name),
+                'signature_hash' => $hash,
+                'status' => 'signed',
+                'execution_status' => $this->execution_status_for('signed'),
+                'signed_at' => current_time('mysql'),
+                'archived_at' => current_time('mysql'),
+                'updated_at' => current_time('mysql'),
+            ],
+            ['id' => $id],
+            ['%s', '%s', '%s', '%s', '%s', '%s', '%s'],
+            ['%d']
+        );
+
+        if ($updated) {
+            $this->record_event($id, 'signature.completed', $signer_name, 'Document signed and archived.', ['signature_hash' => $hash], $actor_ip);
+        }
+
+        return $updated;
+    }
+
+    public function archive(int $id, string $actor = ''): bool
+    {
+        $updated = $this->update_status($id, 'archived', ['archived_at' => current_time('mysql')]);
+        if ($updated) {
+            $this->record_event($id, 'document.archived', $actor, 'Document moved into archive.');
+        }
+        return $updated;
+    }
+
+    public function void(int $id, string $actor = '', string $reason = ''): bool
+    {
+        $updated = $this->update_status($id, 'voided');
+        if ($updated) {
+            $this->record_event($id, 'document.voided', $actor, $reason ?: 'Document voided.');
+        }
+        return $updated;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function events(int $document_id): array
+    {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare('SELECT * FROM ' . self::events_table() . ' WHERE document_id = %d ORDER BY created_at ASC, id ASC', $document_id), ARRAY_A);
+        return array_map(static function (array $row): array {
+            $row['id'] = (int) $row['id'];
+            $row['document_id'] = (int) $row['document_id'];
+            $row['metadata'] = json_decode((string) ($row['metadata'] ?? '{}'), true) ?: [];
+            return $row;
+        }, $rows ?: []);
+    }
+
+    public function record_event(int $document_id, string $event_type, string $actor = '', string $message = '', array $metadata = [], string $actor_ip = ''): void
+    {
+        global $wpdb;
+        $wpdb->insert(
+            self::events_table(),
+            [
+                'document_id' => $document_id,
+                'event_type' => sanitize_key(str_replace('.', '_', $event_type)),
+                'actor' => sanitize_text_field($actor),
+                'actor_ip' => sanitize_text_field($actor_ip),
+                'message' => sanitize_textarea_field($message),
+                'metadata' => wp_json_encode($metadata),
+                'created_at' => current_time('mysql'),
+            ],
+            ['%d', '%s', '%s', '%s', '%s', '%s', '%s']
+        );
+    }
+
+    private function update_status(int $id, string $status, array $extra = []): bool
+    {
+        global $wpdb;
+        $status = sanitize_key($status);
+        $data = array_merge($extra, [
+            'status' => $status,
+            'execution_status' => $this->execution_status_for($status),
+            'updated_at' => current_time('mysql'),
+        ]);
+        $formats = array_fill(0, count($data), '%s');
+        return false !== $wpdb->update(self::documents_table(), $data, ['id' => $id], $formats, ['%d']);
+    }
+
+    private function execution_status_for(string $status): string
+    {
+        $map = [
+            'draft' => 'not_started',
+            'sent' => 'awaiting_signature',
+            'viewed' => 'awaiting_signature',
+            'signed' => 'fully_executed',
+            'archived' => 'fully_executed',
+            'voided' => 'cancelled',
+            'expired' => 'expired',
+        ];
+        return $map[$status] ?? 'in_progress';
+    }
+
+    private function generate_document_uid(): string
+    {
+        return 'DOC-' . gmdate('Ymd') . '-' . strtoupper(wp_generate_password(8, false, false));
+    }
+
+    private function hydrate_document(array $row): array
+    {
+        $row['id'] = (int) ($row['id'] ?? 0);
+        $row['source_payload'] = json_decode((string) ($row['source_payload'] ?? '{}'), true) ?: [];
+        return $row;
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-rest-controller.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/includes/class-algq-pdf-signature-rest-controller.php
@@ -1,0 +1,210 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_REST_Controller
+{
+    private ALGQ_PDF_Signature_Repository $repository;
+    private ALGQ_PDF_Signature_Renderer $renderer;
+
+    public function __construct(ALGQ_PDF_Signature_Repository $repository, ALGQ_PDF_Signature_Renderer $renderer)
+    {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route('algq/v1', '/documents', [
+            [
+                'methods' => WP_REST_Server::READABLE,
+                'callback' => [$this, 'index'],
+                'permission_callback' => [$this, 'can_manage'],
+            ],
+            [
+                'methods' => WP_REST_Server::CREATABLE,
+                'callback' => [$this, 'create'],
+                'permission_callback' => [$this, 'can_manage'],
+            ],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<id>\d+)', [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'show'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<id>\d+)/pdf', [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'download_pdf'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<id>\d+)/send', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'send'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<id>\d+)/archive', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'archive'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<id>\d+)/void', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'void'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/documents/(?P<uid>[A-Za-z0-9-]+)/sign', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'public_sign'],
+            'permission_callback' => '__return_true',
+        ]);
+    }
+
+    public function index(WP_REST_Request $request): WP_REST_Response
+    {
+        return rest_ensure_response($this->repository->all((int) ($request->get_param('limit') ?: 50), [
+            'status' => $request->get_param('status'),
+            'execution_status' => $request->get_param('execution_status'),
+            'document_type' => $request->get_param('document_type'),
+            'related_deal_id' => $request->get_param('related_deal_id'),
+        ]));
+    }
+
+    public function show(WP_REST_Request $request)
+    {
+        $document = $this->repository->find((int) $request['id']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+        $document['events'] = $this->repository->events((int) $document['id']);
+        return rest_ensure_response($document);
+    }
+
+    public function create(WP_REST_Request $request)
+    {
+        $data = $request->get_json_params() ?: $request->get_params();
+        $validation = $this->validate_document($data);
+        if (!$validation['valid']) {
+            return new WP_Error('algq_document_invalid', __('Document validation failed.', 'algq-pdf-signature'), ['status' => 400, 'errors' => $validation['errors']]);
+        }
+
+        $html = $this->renderer->render_html($validation['data']);
+        $pdf = $this->renderer->render_pdf_binary(array_merge($validation['data'], ['rendered_html' => $html]));
+        $id = $this->repository->create_document($validation['data'], $html, $this->renderer->checksum($pdf));
+
+        if (!$id) {
+            return new WP_Error('algq_document_insert_failed', __('Document could not be saved.', 'algq-pdf-signature'), ['status' => 500]);
+        }
+
+        return new WP_REST_Response($this->repository->find($id), 201);
+    }
+
+    public function download_pdf(WP_REST_Request $request)
+    {
+        $document = $this->repository->find((int) $request['id']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+
+        return new WP_REST_Response(base64_encode($this->renderer->render_pdf_binary($document)), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="' . sanitize_file_name($document['document_uid']) . '.pdf"',
+            'X-Algq-Document-Checksum' => $this->renderer->checksum($this->renderer->render_pdf_binary($document)),
+        ]);
+    }
+
+    public function send(WP_REST_Request $request)
+    {
+        $document = $this->repository->find((int) $request['id']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+
+        $this->repository->mark_sent((int) $document['id'], wp_get_current_user()->user_login);
+        return rest_ensure_response($this->repository->find((int) $document['id']));
+    }
+
+    public function archive(WP_REST_Request $request)
+    {
+        $document = $this->repository->find((int) $request['id']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+
+        $this->repository->archive((int) $document['id'], wp_get_current_user()->user_login);
+        return rest_ensure_response($this->repository->find((int) $document['id']));
+    }
+
+    public function void(WP_REST_Request $request)
+    {
+        $document = $this->repository->find((int) $request['id']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+
+        $params = $request->get_json_params() ?: $request->get_params();
+        $this->repository->void((int) $document['id'], wp_get_current_user()->user_login, sanitize_textarea_field($params['reason'] ?? ''));
+        return rest_ensure_response($this->repository->find((int) $document['id']));
+    }
+
+    public function public_sign(WP_REST_Request $request)
+    {
+        $document = $this->repository->find_by_uid((string) $request['uid']);
+        if (!$document) {
+            return new WP_Error('algq_document_not_found', __('Document not found.', 'algq-pdf-signature'), ['status' => 404]);
+        }
+
+        if (in_array($document['status'], ['signed', 'archived', 'voided', 'expired'], true)) {
+            return new WP_Error('algq_document_not_signable', __('Document is not open for signature.', 'algq-pdf-signature'), ['status' => 409]);
+        }
+
+        $params = $request->get_json_params() ?: $request->get_params();
+        $signer = sanitize_text_field($params['signer_name'] ?? '');
+        $signature = sanitize_textarea_field($params['signature'] ?? '');
+        if ('' === $signer || '' === $signature) {
+            return new WP_Error('algq_signature_invalid', __('Signer name and signature are required.', 'algq-pdf-signature'), ['status' => 400]);
+        }
+
+        $ip = sanitize_text_field($_SERVER['REMOTE_ADDR'] ?? '');
+        $this->repository->sign_document((int) $document['id'], $signer, $signature, $ip);
+        return rest_ensure_response($this->repository->find((int) $document['id']));
+    }
+
+    public function can_manage(): bool
+    {
+        return current_user_can('manage_options');
+    }
+
+    private function validate_document(array $data): array
+    {
+        $errors = [];
+        foreach (['title', 'recipient_name', 'recipient_email'] as $field) {
+            if (empty($data[$field])) {
+                $errors[$field] = __('This field is required.', 'algq-pdf-signature');
+            }
+        }
+        if (!empty($data['recipient_email']) && !is_email($data['recipient_email'])) {
+            $errors['recipient_email'] = __('Enter a valid email address.', 'algq-pdf-signature');
+        }
+
+        return [
+            'valid' => empty($errors),
+            'errors' => $errors,
+            'data' => [
+                'title' => sanitize_text_field($data['title'] ?? ''),
+                'document_type' => sanitize_key($data['document_type'] ?? 'purchase_agreement'),
+                'related_deal_id' => sanitize_text_field($data['related_deal_id'] ?? ''),
+                'recipient_name' => sanitize_text_field($data['recipient_name'] ?? ''),
+                'recipient_email' => sanitize_email($data['recipient_email'] ?? ''),
+                'payload' => is_array($data['payload'] ?? null) ? $data['payload'] : [],
+                'expires_at' => sanitize_text_field($data['expires_at'] ?? ''),
+            ],
+        ];
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pdf-signature/public/class-algq-pdf-signature-public.php
+++ b/algonquian-real-estate/plugins/algq-pdf-signature/public/class-algq-pdf-signature-public.php
@@ -1,0 +1,78 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_PDF_Signature_Public
+{
+    private ALGQ_PDF_Signature_Repository $repository;
+    private ALGQ_PDF_Signature_Renderer $renderer;
+
+    public function __construct(ALGQ_PDF_Signature_Repository $repository, ALGQ_PDF_Signature_Renderer $renderer)
+    {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function register(): void
+    {
+        add_shortcode('algq_signature', [$this, 'render_signature_shortcode']);
+        add_action('admin_post_nopriv_algq_public_sign', [$this, 'handle_public_sign']);
+        add_action('admin_post_algq_public_sign', [$this, 'handle_public_sign']);
+    }
+
+    public function render_signature_shortcode(array $atts): string
+    {
+        $atts = shortcode_atts(['document_uid' => ''], $atts, 'algq_signature');
+        $document = $this->repository->find_by_uid((string) $atts['document_uid']);
+        if (!$document) {
+            return '<p>' . esc_html__('Document not found.', 'algq-pdf-signature') . '</p>';
+        }
+
+        if (in_array($document['status'], ['signed', 'archived'], true)) {
+            return '<p>' . esc_html__('This document has already been fully executed and archived.', 'algq-pdf-signature') . '</p>';
+        }
+
+        ob_start();
+        ?>
+        <div class="algq-signature-workflow">
+            <h2><?php echo esc_html($document['title']); ?></h2>
+            <p><strong><?php esc_html_e('Execution status:', 'algq-pdf-signature'); ?></strong> <?php echo esc_html($document['execution_status']); ?></p>
+            <div class="algq-document-preview"><?php echo wp_kses_post($document['rendered_html']); ?></div>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <?php wp_nonce_field('algq_public_sign_' . $document['document_uid']); ?>
+                <input type="hidden" name="action" value="algq_public_sign" />
+                <input type="hidden" name="document_uid" value="<?php echo esc_attr($document['document_uid']); ?>" />
+                <p><label><?php esc_html_e('Legal name', 'algq-pdf-signature'); ?><br /><input name="signer_name" required /></label></p>
+                <p><label><?php esc_html_e('Signature', 'algq-pdf-signature'); ?><br /><input name="signature" required placeholder="<?php esc_attr_e('Type your full legal name', 'algq-pdf-signature'); ?>" /></label></p>
+                <p><button type="submit"><?php esc_html_e('Sign Document', 'algq-pdf-signature'); ?></button></p>
+            </form>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    public function handle_public_sign(): void
+    {
+        $uid = sanitize_text_field($_POST['document_uid'] ?? '');
+        $document = $this->repository->find_by_uid($uid);
+        if (!$document) {
+            wp_die(esc_html__('Document not found.', 'algq-pdf-signature'));
+        }
+
+        check_admin_referer('algq_public_sign_' . $uid);
+        if (in_array($document['status'], ['signed', 'archived', 'voided', 'expired'], true)) {
+            wp_die(esc_html__('Document is not open for signature.', 'algq-pdf-signature'));
+        }
+
+        $signer = sanitize_text_field($_POST['signer_name'] ?? '');
+        $signature = sanitize_text_field($_POST['signature'] ?? '');
+        if ('' === $signer || '' === $signature) {
+            wp_die(esc_html__('Signer name and signature are required.', 'algq-pdf-signature'));
+        }
+
+        $this->repository->sign_document((int) $document['id'], $signer, $signature, sanitize_text_field($_SERVER['REMOTE_ADDR'] ?? ''));
+        wp_safe_redirect(wp_get_referer() ?: home_url('/'));
+        exit;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a first-class document execution system for the project to render PDFs, request and capture signatures, archive documents, and track execution state and audit events.
- Expose programmatic and admin workflows so deals can generate legal artifacts, send signature requests, and inspect execution lifecycle via REST, admin UI, and public shortcodes.

### Description

- Add plugin bootstrap `algq-pdf-signature.php` and service wiring (`class-algq-pdf-signature-plugin.php`) to register activation and runtime hooks and register REST routes and admin/public handlers. 
- Create activation logic (`class-algq-pdf-signature-activator.php`) to provision two DB tables for `algq_documents` and `algq_document_events` with indexes and fields for checksums, signature hashes, timestamps, and execution status. 
- Implement repository and state management (`class-algq-pdf-signature-repository.php`) for create/find/list, status transitions (send, sign, archive, void), event recording, and UID generation. 
- Add renderer (`class-algq-pdf-signature-renderer.php`) producing sanitized HTML previews plus a lightweight PDF binary generator and checksum method. 
- Add REST controller (`class-algq-pdf-signature-rest-controller.php`) with endpoints for listing/creating documents, retrieving PDFs, marking send/archive/void, and a public signing endpoint. 
- Add admin UI (`admin/class-algq-pdf-signature-admin.php`) for rendering/saving documents, downloading PDFs, sending requests, and viewing the archive, and public shortcode/handlers (`public/class-algq-pdf-signature-public.php`) to render the signing workflow and accept nonce-protected signatures. 
- Update README with capabilities, REST route list, and shortcode usage. 

### Testing

- Ran syntax checks for all created PHP files with `find algonquian-real-estate/plugins/algq-pdf-signature -name '*.php' -print0 | xargs -0 -n1 php -l` and received no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2db83e10832daa66ae96417c481f)