### PR TITLE
Add automation engine, workflows API and admin Automation Engine dashboard

### DIFF
--- a/src/app/(admin)/admin/workflows/page.tsx
+++ b/src/app/(admin)/admin/workflows/page.tsx
@@ -1,1 +1,111 @@
-export default function Page() { return <main className='mx-auto max-w-6xl px-4 py-10 text-slate-100'><h1 className='text-3xl font-bold'>OneGodian Console · workflows</h1><p className='mt-2 text-slate-300'>Internal operator/admin control plane route.</p></main>; }
+import { automationActionLabels, automationRules, getAutomationSummary } from '@/lib/automation-engine';
+
+const statusClassName = {
+  active: 'border-emerald-300/30 bg-emerald-300/10 text-emerald-100',
+  paused: 'border-amber-300/30 bg-amber-300/10 text-amber-100',
+  draft: 'border-slate-300/30 bg-slate-300/10 text-slate-100'
+};
+
+export default function Page() {
+  const summary = getAutomationSummary();
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10 text-slate-100">
+      <section className="rounded-[2rem] border border-white/10 bg-white/[0.06] p-8 shadow-2xl shadow-black/30">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.24em] text-gold-300">Automation Engine</p>
+            <h1 className="mt-3 text-4xl font-black tracking-tight text-white md:text-5xl">Trigger/action workflows for status operations</h1>
+            <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+              Operator-ready automation rules coordinate status changes, email notifications, document generation, and closeout workflows without exposing production credentials.
+            </p>
+          </div>
+          <a
+            className="inline-flex items-center justify-center rounded-full border border-gold-300/50 bg-gold-300 px-5 py-3 text-sm font-black uppercase tracking-[0.16em] text-slate-950 shadow-lg shadow-gold-300/10"
+            href="/api/workflows?pretty=1"
+          >
+            View API
+          </a>
+        </div>
+
+        <dl className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-6">
+          <SummaryCard label="Rules" value={summary.totalRules} />
+          <SummaryCard label="Active" value={summary.activeRules} />
+          <SummaryCard label="Paused" value={summary.pausedRules} />
+          <SummaryCard label="Email actions" value={summary.emailNotifications} />
+          <SummaryCard label="Docs" value={summary.documentTriggers} />
+          <SummaryCard label="Closeouts" value={summary.closeoutWorkflows} />
+        </dl>
+      </section>
+
+      <section className="mt-8 grid gap-6 lg:grid-cols-[1.4fr_0.6fr]">
+        <div className="space-y-5">
+          {automationRules.map((rule) => (
+            <article key={rule.id} className="rounded-3xl border border-white/10 bg-slate-950/50 p-6 shadow-xl shadow-black/20">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <h2 className="text-2xl font-black text-white">{rule.name}</h2>
+                    <span className={`rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] ${statusClassName[rule.status]}`}>
+                      {rule.status}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{rule.description}</p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-slate-300">
+                  <div className="font-bold text-white">{rule.runCount} runs</div>
+                  <div>Last run {new Date(rule.lastRunUtc).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</div>
+                </div>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-[0.8fr_1.2fr]">
+                <div className="rounded-2xl border border-purple-300/20 bg-purple-300/10 p-4">
+                  <p className="text-xs font-black uppercase tracking-[0.18em] text-purple-100">Trigger</p>
+                  <p className="mt-2 text-sm font-semibold text-white">{rule.trigger.type.replaceAll('_', ' ')}</p>
+                  <p className="mt-2 text-sm text-slate-300">
+                    {rule.trigger.fromStatus ? `${rule.trigger.fromStatus} → ${rule.trigger.toStatus}` : rule.trigger.documentType ?? rule.trigger.toStatus}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-gold-300/20 bg-gold-300/10 p-4">
+                  <p className="text-xs font-black uppercase tracking-[0.18em] text-gold-100">Actions</p>
+                  <ul className="mt-3 space-y-3">
+                    {rule.actions.map((action) => (
+                      <li key={`${rule.id}-${action.type}-${action.template}`} className="flex flex-col gap-1 rounded-2xl border border-white/10 bg-slate-950/40 p-3 sm:flex-row sm:items-center sm:justify-between">
+                        <span className="font-semibold text-white">{action.label}</span>
+                        <span className="text-xs uppercase tracking-[0.14em] text-slate-400">{automationActionLabels[action.type]} · {action.audience}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <aside className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 shadow-xl shadow-black/20">
+          <h2 className="text-2xl font-black text-white">Closeout control path</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Closeout automations keep a consistent handoff from intake review to document preparation, operator signoff, and final member communication.
+          </p>
+          <ol className="mt-6 space-y-4">
+            {['Status reaches closeout requested', 'Operator checklist is created', 'Closeout summary is generated', 'Member receives next-step email', 'Records queue receives archive reminder'].map((step, index) => (
+              <li key={step} className="flex gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-gold-300 text-sm font-black text-slate-950">{index + 1}</span>
+                <span className="text-sm font-semibold text-slate-100">{step}</span>
+              </li>
+            ))}
+          </ol>
+        </aside>
+      </section>
+    </main>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+      <dt className="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">{label}</dt>
+      <dd className="mt-2 text-3xl font-black text-white">{value}</dd>
+    </div>
+  );
+}

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,2 +1,38 @@
-import { NextResponse } from 'next/server';
-export async function GET() { return NextResponse.json({ service: 'workflows', surface: 'console', status: 'ok' }); }
+import { jsonResponse } from '@/lib/api-json';
+import { automationRules, evaluateAutomationEvent, getAutomationSummary, type AutomationEvent } from '@/lib/automation-engine';
+
+const sampleEvent: AutomationEvent = {
+  id: 'evt-sample-member-approved',
+  entityType: 'member',
+  entityId: 'member-demo-001',
+  previousStatus: 'review',
+  currentStatus: 'approved'
+};
+
+export async function GET(request: Request) {
+  return jsonResponse(
+    {
+      service: 'workflows',
+      surface: 'console',
+      status: 'ok',
+      engine: 'automation',
+      summary: getAutomationSummary(),
+      rules: automationRules,
+      sampleEvaluation: evaluateAutomationEvent(sampleEvent)
+    },
+    request
+  );
+}
+
+export async function POST(request: Request) {
+  const event = (await request.json()) as AutomationEvent;
+
+  return jsonResponse(
+    {
+      status: 'evaluated',
+      event,
+      runs: evaluateAutomationEvent(event)
+    },
+    request
+  );
+}

--- a/src/lib/automation-engine.ts
+++ b/src/lib/automation-engine.ts
@@ -1,0 +1,209 @@
+export type AutomationStatus = 'draft' | 'active' | 'paused';
+export type AutomationTriggerType = 'status_changed' | 'document_generated' | 'closeout_requested';
+export type AutomationActionType = 'send_email' | 'generate_document' | 'create_closeout_task' | 'notify_operator';
+export type CloseoutStage = 'intake' | 'review' | 'documents' | 'signoff' | 'complete';
+
+export type AutomationTrigger = {
+  type: AutomationTriggerType;
+  fromStatus?: string;
+  toStatus?: string;
+  documentType?: string;
+};
+
+export type AutomationAction = {
+  type: AutomationActionType;
+  label: string;
+  template: string;
+  audience: string;
+};
+
+export type AutomationRule = {
+  id: string;
+  name: string;
+  status: AutomationStatus;
+  description: string;
+  trigger: AutomationTrigger;
+  actions: AutomationAction[];
+  closeoutStage?: CloseoutStage;
+  lastRunUtc: string;
+  runCount: number;
+};
+
+export type AutomationEvent = {
+  id: string;
+  entityType: 'member' | 'document' | 'workflow' | 'closeout';
+  entityId: string;
+  currentStatus: string;
+  previousStatus?: string;
+  documentType?: string;
+};
+
+export type AutomationRun = {
+  ruleId: string;
+  ruleName: string;
+  matched: boolean;
+  actions: AutomationAction[];
+  reason: string;
+};
+
+export const automationRules: AutomationRule[] = [
+  {
+    id: 'auto-member-approved-welcome',
+    name: 'Approved member welcome packet',
+    status: 'active',
+    description: 'When an intake moves from review to approved, send the operator-approved welcome email and create the starter credential document.',
+    trigger: {
+      type: 'status_changed',
+      fromStatus: 'review',
+      toStatus: 'approved'
+    },
+    actions: [
+      {
+        type: 'send_email',
+        label: 'Send welcome email',
+        template: 'member-approved-welcome',
+        audience: 'member'
+      },
+      {
+        type: 'generate_document',
+        label: 'Generate starter credential PDF',
+        template: 'starter-credential',
+        audience: 'records'
+      }
+    ],
+    closeoutStage: 'documents',
+    lastRunUtc: '2026-05-29T17:20:00.000Z',
+    runCount: 18
+  },
+  {
+    id: 'auto-document-certificate-issued',
+    name: 'Certificate issued notification',
+    status: 'active',
+    description: 'When a certificate document is generated, notify the member and archive the artifact in the records workflow.',
+    trigger: {
+      type: 'document_generated',
+      documentType: 'certificate'
+    },
+    actions: [
+      {
+        type: 'send_email',
+        label: 'Email certificate delivery notice',
+        template: 'certificate-issued',
+        audience: 'member'
+      },
+      {
+        type: 'notify_operator',
+        label: 'Post artifact archive reminder',
+        template: 'records-archive-reminder',
+        audience: 'operators'
+      }
+    ],
+    closeoutStage: 'signoff',
+    lastRunUtc: '2026-05-30T11:12:00.000Z',
+    runCount: 9
+  },
+  {
+    id: 'auto-closeout-signoff',
+    name: 'Closeout signoff workflow',
+    status: 'active',
+    description: 'When a case enters closeout requested, create final review tasks, send closeout instructions, and prepare the closeout summary document.',
+    trigger: {
+      type: 'closeout_requested',
+      toStatus: 'closeout_requested'
+    },
+    actions: [
+      {
+        type: 'create_closeout_task',
+        label: 'Create operator signoff checklist',
+        template: 'closeout-signoff-checklist',
+        audience: 'operators'
+      },
+      {
+        type: 'send_email',
+        label: 'Send closeout instructions',
+        template: 'closeout-instructions',
+        audience: 'member'
+      },
+      {
+        type: 'generate_document',
+        label: 'Generate closeout summary',
+        template: 'closeout-summary',
+        audience: 'records'
+      }
+    ],
+    closeoutStage: 'signoff',
+    lastRunUtc: '2026-05-30T21:45:00.000Z',
+    runCount: 5
+  },
+  {
+    id: 'auto-payment-overdue-hold',
+    name: 'Overdue payment hold notice',
+    status: 'paused',
+    description: 'Status-based hold automation for overdue payment cases. Paused until payment-provider webhooks are connected.',
+    trigger: {
+      type: 'status_changed',
+      fromStatus: 'active',
+      toStatus: 'payment_overdue'
+    },
+    actions: [
+      {
+        type: 'send_email',
+        label: 'Email payment hold notice',
+        template: 'payment-hold-notice',
+        audience: 'member'
+      }
+    ],
+    closeoutStage: 'review',
+    lastRunUtc: '2026-05-24T14:05:00.000Z',
+    runCount: 3
+  }
+];
+
+export const automationActionLabels: Record<AutomationActionType, string> = {
+  send_email: 'Email notification',
+  generate_document: 'Document generation',
+  create_closeout_task: 'Closeout task',
+  notify_operator: 'Operator notification'
+};
+
+export function evaluateAutomationEvent(event: AutomationEvent, rules: AutomationRule[] = automationRules): AutomationRun[] {
+  return rules.map((rule) => {
+    if (rule.status !== 'active') {
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matched: false,
+        actions: [],
+        reason: `Rule is ${rule.status}`
+      };
+    }
+
+    const triggerMatches = rule.trigger.type === 'status_changed'
+      ? event.previousStatus === rule.trigger.fromStatus && event.currentStatus === rule.trigger.toStatus
+      : rule.trigger.type === 'document_generated'
+        ? event.documentType === rule.trigger.documentType
+        : event.currentStatus === rule.trigger.toStatus;
+
+    return {
+      ruleId: rule.id,
+      ruleName: rule.name,
+      matched: triggerMatches,
+      actions: triggerMatches ? rule.actions : [],
+      reason: triggerMatches ? 'Trigger conditions matched' : 'Trigger conditions did not match'
+    };
+  });
+}
+
+export function getAutomationSummary(rules: AutomationRule[] = automationRules) {
+  const activeRules = rules.filter((rule) => rule.status === 'active');
+  const allActions = rules.flatMap((rule) => rule.actions);
+
+  return {
+    totalRules: rules.length,
+    activeRules: activeRules.length,
+    pausedRules: rules.filter((rule) => rule.status === 'paused').length,
+    emailNotifications: allActions.filter((action) => action.type === 'send_email').length,
+    documentTriggers: allActions.filter((action) => action.type === 'generate_document').length,
+    closeoutWorkflows: rules.filter((rule) => rule.closeoutStage === 'signoff' || rule.trigger.type === 'closeout_requested').length
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a typed automation engine for trigger/action workflows to support status-based automations, email notifications, document generation, and closeout flows. 
- Surface rule summaries and evaluation via the console API and an operator-facing admin dashboard so operators can inspect and exercise rules.

### Description
- Added a new typed automation library at `src/lib/automation-engine.ts` that defines `AutomationRule`/`AutomationEvent` types, a set of example `automationRules`, `evaluateAutomationEvent`, and `getAutomationSummary` functions.
- Extended the workflows API at `src/app/api/workflows/route.ts` so `GET` returns engine metadata, summary metrics, full rule payloads, and a sample evaluation, and `POST` accepts an `AutomationEvent` and returns evaluation runs.
- Replaced the admin placeholder with an Automation Engine dashboard at `src/app/(admin)/admin/workflows/page.tsx` that renders summary cards, rule cards (triggers, actions, run counts), and a closeout control path.

### Testing
- Ran `npx eslint src/lib/automation-engine.ts src/app/api/workflows/route.ts 'src/app/(admin)/admin/workflows/page.tsx'` which completed without errors.
- Launched the dev server and exercised the API; `GET /api/workflows?pretty=1` returned the engine summary and rules successfully.
- POSTed an event to `/api/workflows` and confirmed `evaluateAutomationEvent` matched the expected rule (response included `evaluated auto-closeout-signoff`).
- Ran `npm run check` (Node syntax check) which passed.
- `npm run typecheck` fails due to pre-existing unrelated TSX / JSON syntax issues elsewhere in the repo, and rendering the admin page returned `500` because an unrelated malformed `CapitalFooter` contains nested/unclosed `<footer>` markup; these failures are outside the scope of the automation engine changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2dab8700832d9e66bb005b72f137)