### PR TITLE
Add funding tracker workspace and typed lender/deal models for Capital

### DIFF
--- a/src/app/(app)/capital/funding-tracker/page.tsx
+++ b/src/app/(app)/capital/funding-tracker/page.tsx
@@ -1,0 +1,160 @@
+import { CapitalStatusBadge } from '@/components/capital/status-badge';
+import { capitalComplianceDisclaimer, getFundingTracker, type FundingStage } from '@/lib/capital';
+
+const stageToCapitalStatus: Record<FundingStage, Parameters<typeof CapitalStatusBadge>[0]['status']> = {
+  Prospecting: 'Planned',
+  Introduced: 'Development-stage',
+  Diligence: 'Compliance Review',
+  Commitment: 'Active',
+  Funded: 'Closed',
+  Paused: 'Paused'
+};
+
+export default async function FundingTrackerPage() {
+  const tracker = await getFundingTracker();
+
+  const relationshipActions = [
+    'Log lender touchpoints and relationship owner accountability.',
+    'Track diligence requests, closing blockers, and next-step commitments.',
+    'Keep deal-to-lender mappings visible before capital committee review.'
+  ];
+
+  return (
+    <main className="space-y-6 text-slate-100">
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-5 shadow-2xl shadow-slate-950/40">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">Capital Command Center</p>
+        <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-white">Funding Tracker</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+              Internal operating view for lender database coverage, capital commitments, funding status, deal-to-lender mapping, and relationship management.
+            </p>
+          </div>
+          <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-5 text-amber-200 lg:max-w-md">
+            {capitalComplianceDisclaimer}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5" aria-label="Funding tracker totals">
+        <MetricCard label="Lenders" value={String(tracker.totals.lenderCount)} />
+        <MetricCard label="Target commitments" value={tracker.totals.targetCommitments} />
+        <MetricCard label="Committed" value={tracker.totals.committedCapital} />
+        <MetricCard label="Funded" value={tracker.totals.fundedCapital} />
+        <MetricCard label="Active deals" value={String(tracker.totals.activeDeals)} />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[1.45fr_0.95fr]">
+        <div className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-white">Lender Database</h2>
+              <p className="text-sm text-slate-400">Relationship records with priority, status, commitments, next steps, and mapped deals.</p>
+            </div>
+            <span className="rounded-full border border-cyan-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">CRM-ready</span>
+          </div>
+
+          <div className="grid gap-3">
+            {tracker.lenders.map((lender) => (
+              <article key={lender.id} className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-lg font-semibold text-white">{lender.name}</h3>
+                      <CapitalStatusBadge status={stageToCapitalStatus[lender.stage]} />
+                    </div>
+                    <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">{lender.id} · {lender.lenderType} · {lender.priority} priority</p>
+                    <p className="mt-3 text-sm leading-6 text-slate-300">{lender.relationshipNotes}</p>
+                  </div>
+                  <div className="grid min-w-[15rem] gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-3 text-sm">
+                    <FundingAmount label="Target" value={lender.targetCommitment} />
+                    <FundingAmount label="Committed" value={lender.committedAmount} />
+                    <FundingAmount label="Funded" value={lender.fundedAmount} />
+                  </div>
+                </div>
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  <InfoBlock label="Owner" value={lender.relationshipOwner} />
+                  <InfoBlock label="Last touch" value={lender.lastTouch} />
+                  <InfoBlock label="Next step" value={lender.nextStep} />
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {lender.mappedDeals.map((dealId) => (
+                    <span key={dealId} className="rounded-full border border-purple-300/30 bg-purple-300/10 px-3 py-1 text-xs text-purple-100">{dealId}</span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <aside className="space-y-4">
+          <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <h2 className="text-xl font-semibold text-white">Deal-to-Lender Mapping</h2>
+            <p className="mt-1 text-sm text-slate-400">Each capital need is mapped to one or more lender relationships.</p>
+            <div className="mt-4 space-y-3">
+              {tracker.deals.map((deal) => (
+                <article key={deal.id} className="rounded-xl border border-slate-800 bg-slate-950/50 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-semibold text-white">{deal.name}</h3>
+                      <p className="text-xs text-slate-500">{deal.id}</p>
+                    </div>
+                    <CapitalStatusBadge status={stageToCapitalStatus[deal.fundingStatus]} />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm text-slate-300">
+                    <FundingAmount label="Need" value={deal.capitalNeed} />
+                    <FundingAmount label="Target close" value={deal.targetClose} />
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {deal.mappedLenderIds.map((lenderId) => (
+                      <span key={lenderId} className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-xs text-cyan-100">{lenderId}</span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <h2 className="text-xl font-semibold text-white">Relationship Management</h2>
+            <ul className="mt-3 space-y-3 text-sm leading-6 text-slate-300">
+              {relationshipActions.map((action) => (
+                <li key={action} className="flex gap-3">
+                  <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-cyan-300" />
+                  <span>{action}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </aside>
+      </section>
+    </main>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</p>
+      <p className="mt-2 text-2xl font-bold text-white">{value}</p>
+    </article>
+  );
+}
+
+function FundingAmount({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-slate-500">{label}</span>
+      <span className="font-medium text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/50 p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{label}</p>
+      <p className="mt-1 text-sm text-slate-200">{value}</p>
+    </div>
+  );
+}

--- a/src/app/(app)/capital/page.tsx
+++ b/src/app/(app)/capital/page.tsx
@@ -1,5 +1,52 @@
+import Link from 'next/link';
 import { ModuleShellPage } from '@/components/module-shell-page';
 
+const capitalWorkspaces = [
+  {
+    href: '/capital/funding-tracker',
+    title: 'Funding Tracker',
+    description: 'Lender database, capital commitments, funding status, deal-to-lender mapping, and relationship management.'
+  },
+  {
+    href: '/capital/instruments',
+    title: 'Capital Instruments',
+    description: 'Notes, bonds, circulation pools, API plans, and platform licensing instruments.'
+  },
+  {
+    href: '/capital/valuation',
+    title: 'Capital Valuation',
+    description: 'Strategic value ranges, allocation model, and infrastructure progress indicators.'
+  },
+  {
+    href: '/capital/licensing',
+    title: 'Capital Licensing',
+    description: 'Developer preview, API plans, and institutional licensing tracks.'
+  }
+];
+
 export default function CapitalPage() {
-  return <ModuleShellPage slug="capital" />;
+  return (
+    <div className="space-y-6">
+      <ModuleShellPage slug="capital" />
+      <section className="mobile-card">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">Capital Operations</p>
+            <h2 className="mt-2 text-2xl font-bold text-white">Capital workspaces</h2>
+          </div>
+          <Link href="/capital/funding-tracker" className="rounded-full border border-cyan-400/50 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-400/10">
+            Open Funding Tracker
+          </Link>
+        </div>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {capitalWorkspaces.map((workspace) => (
+            <Link key={workspace.href} href={workspace.href} className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 transition hover:border-cyan-400/50 hover:bg-cyan-400/10">
+              <h3 className="font-semibold text-white">{workspace.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{workspace.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/app/api/capital/funding-tracker/route.ts
+++ b/src/app/api/capital/funding-tracker/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { defaultFundingTracker } from '@/lib/capital';
+
+export async function GET() {
+  return NextResponse.json(defaultFundingTracker);
+}

--- a/src/lib/capital.ts
+++ b/src/lib/capital.ts
@@ -51,6 +51,45 @@ export type CapitalTransaction = { id: string; source: string; amount: string; s
 export type CapitalLicense = { name: string; description: string; monthlyPrice: string; apiLimit: string; status: CapitalStatus; cta: string };
 export type CapitalApiStatus = { health: string; usageThisMonth: string; endpoints: string[]; webhookLogs: string; docs: { label: string; href: string }[] };
 
+export type FundingStage = 'Prospecting' | 'Introduced' | 'Diligence' | 'Commitment' | 'Funded' | 'Paused';
+
+export type LenderRelationship = {
+  id: string;
+  name: string;
+  lenderType: 'Bank' | 'CDFI' | 'Private Credit' | 'Family Office' | 'Strategic Partner' | 'Grant / Program';
+  relationshipOwner: string;
+  priority: 'High' | 'Medium' | 'Low';
+  stage: FundingStage;
+  targetCommitment: string;
+  committedAmount: string;
+  fundedAmount: string;
+  lastTouch: string;
+  nextStep: string;
+  relationshipNotes: string;
+  mappedDeals: string[];
+};
+
+export type FundingDeal = {
+  id: string;
+  name: string;
+  capitalNeed: string;
+  fundingStatus: FundingStage;
+  targetClose: string;
+  mappedLenderIds: string[];
+};
+
+export type FundingTracker = {
+  totals: {
+    lenderCount: number;
+    targetCommitments: string;
+    committedCapital: string;
+    fundedCapital: string;
+    activeDeals: number;
+  };
+  lenders: LenderRelationship[];
+  deals: FundingDeal[];
+};
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_ONEGODIAN_API_URL ?? 'https://api.onegodian.org';
 
 async function safeFetch<T>(path: string, init?: RequestInit): Promise<T | null> {
@@ -77,3 +116,142 @@ export async function submitCapitalIntake(payload: CapitalIntakePayload) { const
 export async function getCapitalPayments() { return (await safeFetch<CapitalTransaction[]>('/api/capital/payments')) ?? []; }
 export async function getCapitalLicenses() { return (await safeFetch<CapitalLicense[]>('/api/capital/licensing')) ?? [ { name: 'Free Developer Preview', description: 'Sandbox access for development-stage API exploration.', monthlyPrice: '$0/mo', apiLimit: '10k requests/mo', status: 'Active', cta: 'Start Preview' }, { name: 'Builder API Plan', description: 'API subscription for early production apps.', monthlyPrice: '$99/mo', apiLimit: '250k requests/mo', status: 'Planned', cta: 'Request Access' }, { name: 'Pro API Plan', description: 'Higher-throughput API subscription with webhook support.', monthlyPrice: '$399/mo', apiLimit: '1M requests/mo', status: 'Planned', cta: 'Join Waitlist' }, { name: 'Enterprise License', description: 'Platform license for enterprise integration workflows.', monthlyPrice: 'Custom', apiLimit: 'Custom', status: 'Compliance Review', cta: 'Contact Team' }, { name: 'Institutional Integration', description: 'Institutional platform license and onboarding pathway.', monthlyPrice: 'Custom', apiLimit: 'Custom', status: 'Needs API', cta: 'Schedule Intake' } ]; }
 export async function getCapitalApiStatus() { return (await safeFetch<CapitalApiStatus>('/api/capital/status')) ?? { health: 'Needs API', usageThisMonth: '0 requests (fallback)', endpoints: ['/api/capital/summary', '/api/capital/valuation', '/api/capital/instruments', '/api/capital/intake'], webhookLogs: 'No webhook logs connected.', docs: [{ label: 'OneGodian API Gateway', href: 'https://api.onegodian.org' }] }; }
+
+
+export const defaultFundingTracker: FundingTracker = {
+  totals: {
+    lenderCount: 6,
+    targetCommitments: '$5,650,000',
+    committedCapital: '$1,075,000',
+    fundedCapital: '$417,000',
+    activeDeals: 4
+  },
+  lenders: [
+    {
+      id: 'LDR-CDFI-001',
+      name: 'Community Development Credit Desk',
+      lenderType: 'CDFI',
+      relationshipOwner: 'Capital Lead',
+      priority: 'High',
+      stage: 'Diligence',
+      targetCommitment: '$850,000',
+      committedAmount: '$250,000',
+      fundedAmount: '$100,000',
+      lastTouch: '2026-05-24',
+      nextStep: 'Send updated use-of-funds schedule and collateral checklist.',
+      relationshipNotes: 'Mission-aligned lender for land restoration and community infrastructure phases.',
+      mappedDeals: ['DEAL-GENESIS-ROAD', 'DEAL-FOREST-RESTORE']
+    },
+    {
+      id: 'LDR-PC-002',
+      name: 'Sovereign Growth Private Credit',
+      lenderType: 'Private Credit',
+      relationshipOwner: 'Founder Office',
+      priority: 'High',
+      stage: 'Commitment',
+      targetCommitment: '$1,500,000',
+      committedAmount: '$625,000',
+      fundedAmount: '$235,000',
+      lastTouch: '2026-05-27',
+      nextStep: 'Finalize closing checklist and reporting cadence.',
+      relationshipNotes: 'Primary candidate for note financing and bridge tranche participation.',
+      mappedDeals: ['DEAL-NOTES-2026', 'DEAL-OHI-CLOUD']
+    },
+    {
+      id: 'LDR-FO-003',
+      name: 'Heritage Family Capital',
+      lenderType: 'Family Office',
+      relationshipOwner: 'Relationship Manager',
+      priority: 'Medium',
+      stage: 'Introduced',
+      targetCommitment: '$1,000,000',
+      committedAmount: '$0',
+      fundedAmount: '$0',
+      lastTouch: '2026-05-18',
+      nextStep: 'Schedule values-fit briefing and platform demo.',
+      relationshipNotes: 'Interested in cultural infrastructure and education-linked revenue systems.',
+      mappedDeals: ['DEAL-OHI-CLOUD', 'DEAL-FOREST-RESTORE']
+    },
+    {
+      id: 'LDR-BANK-004',
+      name: 'Regional Relationship Bank',
+      lenderType: 'Bank',
+      relationshipOwner: 'Finance Ops',
+      priority: 'Medium',
+      stage: 'Prospecting',
+      targetCommitment: '$750,000',
+      committedAmount: '$0',
+      fundedAmount: '$0',
+      lastTouch: '2026-05-12',
+      nextStep: 'Confirm account package and credit policy fit.',
+      relationshipNotes: 'Potential operating line and treasury relationship once reporting matures.',
+      mappedDeals: ['DEAL-NOTES-2026']
+    },
+    {
+      id: 'LDR-STRAT-005',
+      name: 'Infrastructure Integration Partner',
+      lenderType: 'Strategic Partner',
+      relationshipOwner: 'Partnerships',
+      priority: 'High',
+      stage: 'Diligence',
+      targetCommitment: '$1,200,000',
+      committedAmount: '$200,000',
+      fundedAmount: '$82,000',
+      lastTouch: '2026-05-29',
+      nextStep: 'Map technical milestones to capital release gates.',
+      relationshipNotes: 'Strategic non-dilutive capital tied to API, verification, and cloud infrastructure.',
+      mappedDeals: ['DEAL-OHI-CLOUD']
+    },
+    {
+      id: 'LDR-GRANT-006',
+      name: 'Restoration Program Grant Pipeline',
+      lenderType: 'Grant / Program',
+      relationshipOwner: 'Programs',
+      priority: 'Low',
+      stage: 'Paused',
+      targetCommitment: '$350,000',
+      committedAmount: '$0',
+      fundedAmount: '$0',
+      lastTouch: '2026-04-30',
+      nextStep: 'Reopen after eligibility and fiscal sponsorship review.',
+      relationshipNotes: 'Tracked for future grant alignment; not modeled as repayable capital.',
+      mappedDeals: ['DEAL-FOREST-RESTORE']
+    }
+  ],
+  deals: [
+    {
+      id: 'DEAL-NOTES-2026',
+      name: 'OneGodian Notes 2026 Bridge',
+      capitalNeed: '$1,500,000',
+      fundingStatus: 'Commitment',
+      targetClose: '2026-07-15',
+      mappedLenderIds: ['LDR-PC-002', 'LDR-BANK-004']
+    },
+    {
+      id: 'DEAL-GENESIS-ROAD',
+      name: 'Genesis Road Land Reclamation',
+      capitalNeed: '$900,000',
+      fundingStatus: 'Diligence',
+      targetClose: '2026-08-30',
+      mappedLenderIds: ['LDR-CDFI-001']
+    },
+    {
+      id: 'DEAL-OHI-CLOUD',
+      name: 'OHI Cloud Runtime Expansion',
+      capitalNeed: '$1,850,000',
+      fundingStatus: 'Diligence',
+      targetClose: '2026-09-20',
+      mappedLenderIds: ['LDR-PC-002', 'LDR-FO-003', 'LDR-STRAT-005']
+    },
+    {
+      id: 'DEAL-FOREST-RESTORE',
+      name: 'Turtleback Forest Restoration',
+      capitalNeed: '$650,000',
+      fundingStatus: 'Introduced',
+      targetClose: '2026-10-05',
+      mappedLenderIds: ['LDR-CDFI-001', 'LDR-FO-003', 'LDR-GRANT-006']
+    }
+  ]
+};
+
+export async function getFundingTracker() { return (await safeFetch<FundingTracker>('/api/capital/funding-tracker')) ?? defaultFundingTracker; }


### PR DESCRIPTION
### Motivation
- Provide an internal Funding Tracker workspace to surface lender relationships, capital commitments, funding status, deal-to-lender mappings, and relationship management actions for the Capital module.
- Seed a fallback data model so the UI can render without a live API while integration work continues.

### Description
- Added typed domain models and helpers to `src/lib/capital.ts` including `FundingStage`, `LenderRelationship`, `FundingDeal`, `FundingTracker`, `defaultFundingTracker`, and `getFundingTracker` to support funding-tracker data and API fallbacks.
- Implemented a Funding Tracker page at `src/app/(app)/capital/funding-tracker/page.tsx` that shows totals, a lender database, deal mappings, and relationship-management items using existing UI primitives and `CapitalStatusBadge`.
- Added an API fallback route `src/app/api/capital/funding-tracker/route.ts` that returns `defaultFundingTracker` for server-backed rendering and local dev.
- Updated the Capital landing page (`src/app/(app)/capital/page.tsx`) to include and link the new "Funding Tracker" workspace entry.

### Testing
- Ran a scoped TypeScript check with `npx tsc -p /tmp/tsconfig.funding.json --noEmit --incremental false`, which completed successfully for the funding-tracker files.
- Ran the full repo typecheck with `npm run typecheck`, which failed due to pre-existing unrelated syntax errors elsewhere in the repository and not due to the funding tracker changes.
- Ran the smoke test with `npm run test:smoke`, which failed because the root `/` route returned a `500` in the current app state unrelated to the new funding tracker endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2d9c66d0832dab7354180ac087d5)