### PR TITLE
Add Algonquian Marketplace (ARE) plugin scaffold

### DIFF
--- a/algonquian-real-estate/CHANGELOG.md
+++ b/algonquian-real-estate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1 - 2026-05-31
+
+- Added the ARE Marketplace scaffold for wholesale deals, investor access, deal syndication, buyer subscriptions, and premium listings.
+- Documented the marketplace shortcode, REST snapshot, plugin catalog entry, and roadmap epic.
+
 ## 0.1.0 - 2026-05-29
 
 - Created the Algonquian Real Estate repository foundation.

--- a/algonquian-real-estate/README.md
+++ b/algonquian-real-estate/README.md
@@ -16,6 +16,7 @@ This directory contains the modular WordPress plugin architecture for the Algonq
 | `algq-pdf-signature` | PDF rendering, signature workflow, archive, and execution status. | Planned |
 | `algq-document-library` | Institutional document library by entity, lender, acquisition, financial, risk, and property categories. | Planned |
 | `algq-command-center` | KPI dashboard, pipeline value, deal counts, funding status, buyer activity, and reporting. | Planned |
+| `algq-marketplace` | Wholesale deals, investor access, deal syndication, buyer subscriptions, and premium listings. | Scaffolded |
 
 ## Repository Areas
 
@@ -40,6 +41,7 @@ Version 1.0 targets the modules that move a lead from capture to monetization:
 - Buyer Portal (`algq-buyer-portal`) — buyer registration profile, NDA acceptance, downloads, and interest tracking foundations.
 - Digital Product Store (`algq-digital-products`) — WooCommerce-aware product library shortcode and gated download foundations.
 - Admin Command Center (`algq-command-center`) — dashboard widgets for operating metrics.
+- ARE Marketplace (`algq-marketplace`) — wholesale deals, investor access, deal syndication, buyer subscriptions, and premium listings.
 
 ## Repository layout
 
@@ -71,6 +73,7 @@ bash algonquian-real-estate/scripts/build-plugin-zips.sh
 - `[algq_pipeline_crm]`
 - `[algq_buyer_portal]`
 - `[algq_product_library]`
+- `[algq_marketplace]`
 
 ## WPBakery usage
 

--- a/algonquian-real-estate/plugins/algq-marketplace/README.md
+++ b/algonquian-real-estate/plugins/algq-marketplace/README.md
@@ -1,0 +1,23 @@
+# Algonquian Marketplace
+
+The Marketplace module introduces ARE monetization and distribution foundations for buyer-facing deal inventory.
+
+## Capabilities
+
+- Wholesale deals — curated off-market deal rooms and assignment opportunities.
+- Investor access — gated investor and capital partner visibility.
+- Deal syndication — distribution workflows for qualified private channels.
+- Buyer subscriptions — recurring membership tiers for priority deal access.
+- Premium listings — featured inventory placement with enhanced deal context.
+
+## Shortcode
+
+```text
+[algq_marketplace]
+```
+
+## REST endpoint
+
+```text
+GET /wp-json/algq/v1/marketplace
+```

--- a/algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Plugin Name: Algonquian Marketplace
+ * Description: Marketplace foundations for wholesale deals, investor access, syndication, buyer subscriptions, and premium listings.
+ * Version: 0.1.0
+ * Author: Algonquian Real Estate
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Return the marketplace module definitions used by the public shortcode and REST snapshot.
+ *
+ * @return array<int, array{label: string, description: string, status: string}>
+ */
+function algq_marketplace_modules(): array
+{
+    return [
+        [
+            'label' => 'Wholesale deals',
+            'description' => 'Curated off-market assignment opportunities with deal highlights, pricing guidance, and diligence checkpoints.',
+            'status' => 'Deal room ready',
+        ],
+        [
+            'label' => 'Investor access',
+            'description' => 'Permissioned access tiers for vetted investors, capital partners, and acquisition collaborators.',
+            'status' => 'Access gated',
+        ],
+        [
+            'label' => 'Deal syndication',
+            'description' => 'Distribution workflows for sending qualified listings to buyer lists, investor circles, and private partner channels.',
+            'status' => 'Distribution mapped',
+        ],
+        [
+            'label' => 'Buyer subscriptions',
+            'description' => 'Recurring buyer membership tiers for priority deal alerts, downloads, market preferences, and saved buy boxes.',
+            'status' => 'Subscription-ready',
+        ],
+        [
+            'label' => 'Premium listings',
+            'description' => 'Featured placement for high-value opportunities with enhanced media, underwriting summaries, and urgency indicators.',
+            'status' => 'Featured inventory',
+        ],
+    ];
+}
+
+add_shortcode('algq_marketplace', function (): string {
+    ob_start();
+    ?>
+    <section class="algq-marketplace" aria-labelledby="algq-marketplace-title">
+        <h2 id="algq-marketplace-title">ARE Marketplace</h2>
+        <p>Wholesale deal distribution, investor access, buyer subscriptions, and premium listing controls for the Algonquian Real Estate platform.</p>
+        <div class="algq-marketplace-grid">
+            <?php foreach (algq_marketplace_modules() as $module) : ?>
+                <article class="algq-marketplace-card">
+                    <h3><?php echo esc_html($module['label']); ?></h3>
+                    <p><?php echo esc_html($module['description']); ?></p>
+                    <span><?php echo esc_html($module['status']); ?></span>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </section>
+    <?php
+    return (string) ob_get_clean();
+});
+
+add_action('rest_api_init', function (): void {
+    register_rest_route('algq/v1', '/marketplace', [
+        'methods' => 'GET',
+        'permission_callback' => '__return_true',
+        'callback' => function (): WP_REST_Response {
+            return new WP_REST_Response([
+                'name' => 'ARE Marketplace',
+                'shortcode' => '[algq_marketplace]',
+                'modules' => algq_marketplace_modules(),
+            ]);
+        },
+    ]);
+});

--- a/algonquian-real-estate/roadmap/backlog.md
+++ b/algonquian-real-estate/roadmap/backlog.md
@@ -70,3 +70,11 @@
 - **ARE-120**: Build subscription tiers: Investor, Buyer, Pro, Enterprise.
 - **ARE-121**: Build recurring billing with WooCommerce Subscriptions and Stripe.
 - **ARE-122**: Create SaaS licensing for Single Site, Agency, and Enterprise.
+
+
+## Epic 14 — ARE Marketplace
+
+- **ARE-130**: Build marketplace foundations for wholesale deal rooms, investor access rules, and private deal visibility.
+- **ARE-131**: Add deal syndication workflows for buyer lists, investor channels, and partner distribution.
+- **ARE-132**: Build buyer subscription tiers for priority deal alerts, downloads, and saved buy-box preferences.
+- **ARE-133**: Add premium listing controls for featured placement, enhanced underwriting summaries, and upgraded deal media.


### PR DESCRIPTION
### Motivation
- Provide a marketplace foundation for the Algonquian Real Estate suite to support wholesale deals, investor access, deal syndication, buyer subscriptions, and premium listings. 
- Expose a simple public UI and snapshot API so other platform pieces can discover and render marketplace capabilities.

### Description
- Add a new plugin `algq-marketplace` with `algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php` implementing `algq_marketplace_modules()`, the `[algq_marketplace]` shortcode, and a public REST snapshot at `algq/v1/marketplace`.
- Add `algonquian-real-estate/plugins/algq-marketplace/README.md` documenting the shortcode and REST endpoint and listing marketplace capabilities. 
- Update the top-level plugin catalog and shortcode list in `algonquian-real-estate/README.md` to include `algq-marketplace` and add an ARE Marketplace epic and related tasks to `algonquian-real-estate/roadmap/backlog.md`.
- Add a changelog entry in `algonquian-real-estate/CHANGELOG.md` noting the new scaffold. 

### Testing
- Ran `php -l algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php` and the file reported no syntax errors (success). 
- Ran `bash algonquian-real-estate/scripts/build-plugin-zips.sh` which built plugin ZIPs including `algq-marketplace.zip` (success). 
- Ran `find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l` to validate PHP syntax across plugins and received no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2e147274832daf55681447671597)