### PR TITLE
Document Algonquian real estate repository structure

### DIFF
--- a/algonquian-real-estate/README.md
+++ b/algonquian-real-estate/README.md
@@ -45,13 +45,22 @@ Version 1.0 targets the modules that move a lead from capture to monetization:
 
 ```text
 algonquian-real-estate/
-├── assets/      # Shared images, screenshots, and static assets
-├── docs/        # Architecture and implementation documentation
 ├── plugins/     # WordPress plugins, one module per directory
-├── roadmap/     # Epic/task backlog and release plans
-├── scripts/     # Build and maintenance scripts
-├── templates/   # Shared template snippets
-└── tests/       # Test scaffolding and fixtures
+│   ├── algq-deal-intake
+│   ├── algq-pipeline-crm
+│   ├── algq-mao-engine
+│   ├── algq-offer-generator
+│   ├── algq-buyer-portal
+│   ├── algq-funding-tracker
+│   ├── algq-automation-engine
+│   ├── algq-pdf-signature
+│   ├── algq-document-library
+│   └── algq-command-center
+├── docs/        # Architecture and implementation documentation
+├── wpbakery/    # Page-builder snippets, shortcode wrappers, and layout exports
+├── assets/      # Shared images, screenshots, and static assets
+├── licensing/   # Licensing, entitlement, and productization materials
+└── deployment/  # Packaging, release, hosting, and deployment runbooks
 ```
 
 ## Local validation

--- a/algonquian-real-estate/deployment/README.md
+++ b/algonquian-real-estate/deployment/README.md
@@ -1,0 +1,5 @@
+# Deployment
+
+This directory stores packaging, release, hosting, and deployment runbooks for the Algonquian Real Estate plugin suite.
+
+Use this area for deployment checklists, release procedures, archive-build instructions, and environment-specific rollout notes.

--- a/algonquian-real-estate/licensing/README.md
+++ b/algonquian-real-estate/licensing/README.md
@@ -1,0 +1,5 @@
+# Licensing
+
+This directory stores licensing, productization, entitlement, and commercial packaging notes for the Algonquian Real Estate plugin suite.
+
+Use this area for module packaging plans, license-tier documentation, and materials that support distribution of independently installable plugins.

--- a/algonquian-real-estate/wpbakery/README.md
+++ b/algonquian-real-estate/wpbakery/README.md
@@ -1,0 +1,5 @@
+# WPBakery Assets
+
+This directory stores WPBakery-ready snippets, shortcode wrappers, layout exports, and builder-specific implementation notes for the Algonquian Real Estate plugin suite.
+
+Use this area for page-builder artifacts that should remain separate from plugin source code, shared documentation, and deployment automation.


### PR DESCRIPTION
### Motivation

- Clarify and codify the Algonquian Real Estate repository layout so maintainers can see the intended plugin/module tree and operational areas at a glance.
- Provide placeholders for WPBakery assets, licensing, and deployment materials to reserve those areas and give contributors guidance on their purpose.

### Description

- Updated `algonquian-real-estate/README.md` to expand the repository layout block with an explicit plugin list and the new top-level directories (`wpbakery`, `licensing`, `deployment`).
- Added `algonquian-real-estate/wpbakery/README.md` as a WPBakery assets placeholder describing page-builder snippets and layout exports.
- Added `algonquian-real-estate/licensing/README.md` and `algonquian-real-estate/deployment/README.md` as placeholders for licensing/productization notes and deployment/runbook guidance respectively.
- This is a documentation-only change with no runtime code modifications.

### Testing

- Ran `git diff --check` to validate whitespace and patch issues and it completed with no errors.
- Ran `npm run check` (which executes `node --check server.js`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2eef9708832d8099fff01ca62d2a)