### PR TITLE
Enhance Algonquian Deal Intake plugin: attribution, ARV, scoring, REST & CSV

### DIFF
--- a/algonquian-real-estate/plugins/algq-deal-intake/README.md
+++ b/algonquian-real-estate/plugins/algq-deal-intake/README.md
@@ -4,19 +4,23 @@ Production intake module for seller leads and property opportunities.
 
 ## Features
 
-- `[algq_deal_intake]` shortcode with seller, property, lead source, motivation, and tag fields.
-- Central validation engine for shortcode submissions, REST requests, and CSV imports.
-- Seller motivation scoring based on selling timeline, repairs, occupancy, and motivation keywords.
-- Property tagging stored as structured JSON for downstream CRM and underwriting modules.
-- REST API endpoints under `/wp-json/algq/v1/deals`.
+- Standalone WordPress plugin module with the `[algq_deal_intake]` shortcode for seller, property, lead source, motivation, and tag fields.
+- Central validation engine shared by shortcode submissions, REST requests, admin CSV imports, and REST CSV imports.
+- Lead source tracking for shortcode source, UTM campaign, UTM medium, referrer, and landing page attribution.
+- Seller motivation scoring based on selling timeline, repairs, occupancy, price-to-ARV, and motivation keywords.
+- Property tagging stored as structured JSON for downstream CRM and underwriting modules, including auto-tags such as `urgent-timeline`, `heavy-rehab`, and `deep-discount`.
+- REST API endpoints under `/wp-json/algq/v1/deals` for create, list, detail, update, import, and export workflows.
 - Admin CSV import/export workflows for operations teams.
 
 ## REST API
 
 - `POST /wp-json/algq/v1/deals` — public lead creation endpoint.
-- `GET /wp-json/algq/v1/deals` — admin-only list endpoint with optional `status`, `lead_source`, and `limit` query parameters.
+- `GET /wp-json/algq/v1/deals` — admin-only list endpoint with optional `status`, `lead_source`, `min_score`, and `limit` query parameters.
 - `GET /wp-json/algq/v1/deals/{id}` — admin-only deal detail endpoint.
+- `PATCH /wp-json/algq/v1/deals/{id}` — admin-only deal update endpoint that revalidates and rescores the lead.
+- `GET /wp-json/algq/v1/deals/export` — admin-only CSV export response for integrations.
+- `POST /wp-json/algq/v1/deals/import` — admin-only multipart CSV import endpoint using a `file` or `algq_deal_csv` upload field.
 
 ## CSV columns
 
-`deal_id`, `seller_name`, `seller_phone`, `seller_email`, `address`, `asking_price`, `lead_source`, `motivation_score`, `property_tags`, `status`, `created_at`.
+`deal_id`, `seller_name`, `seller_phone`, `seller_email`, `address`, `asking_price`, `estimated_arv`, `lead_source`, `source_campaign`, `source_medium`, `source_referrer`, `source_landing_page`, `motivation_score`, `property_tags`, `status`, `created_at`.

--- a/algonquian-real-estate/plugins/algq-deal-intake/admin/class-algq-deal-intake-admin.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/admin/class-algq-deal-intake-admin.php
@@ -62,7 +62,7 @@ final class ALGQ_Deal_Intake_Admin
 
             <h2><?php esc_html_e('Recent Deals', 'algq-deal-intake'); ?></h2>
             <table class="widefat striped">
-                <thead><tr><th><?php esc_html_e('Deal ID', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Seller', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Phone', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Address', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Source', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Score', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Tags', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Status', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Created', 'algq-deal-intake'); ?></th></tr></thead>
+                <thead><tr><th><?php esc_html_e('Deal ID', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Seller', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Phone', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Address', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Source', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Campaign', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Score', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Tags', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Status', 'algq-deal-intake'); ?></th><th><?php esc_html_e('Created', 'algq-deal-intake'); ?></th></tr></thead>
                 <tbody>
                 <?php foreach ($rows as $row) : ?>
                     <tr>
@@ -71,6 +71,7 @@ final class ALGQ_Deal_Intake_Admin
                         <td><?php echo esc_html($row['seller_phone']); ?></td>
                         <td><?php echo esc_html($row['address']); ?></td>
                         <td><?php echo esc_html($row['lead_source']); ?></td>
+                        <td><?php echo esc_html($row['source_campaign'] ?? ''); ?></td>
                         <td><?php echo esc_html((string) $row['motivation_score']); ?></td>
                         <td><?php echo esc_html(implode(', ', $row['property_tags'])); ?></td>
                         <td><?php echo esc_html($row['status']); ?></td>

--- a/algonquian-real-estate/plugins/algq-deal-intake/algq-deal-intake.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/algq-deal-intake.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Algonquian Deal Intake
  * Description: Production seller lead intake, validation, scoring, tagging, REST API, and CSV workflows for Algonquian Real Estate.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author: Algonquian Real Estate
  * Text Domain: algq-deal-intake
  */
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('ALGQ_DEAL_INTAKE_VERSION', '0.2.0');
+define('ALGQ_DEAL_INTAKE_VERSION', '0.3.0');
 define('ALGQ_DEAL_INTAKE_FILE', __FILE__);
 define('ALGQ_DEAL_INTAKE_DIR', plugin_dir_path(__FILE__));
 

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-activator.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-activator.php
@@ -20,8 +20,13 @@ final class ALGQ_Deal_Intake_Activator
             seller_email varchar(191) DEFAULT '',
             address text NOT NULL,
             asking_price decimal(12,2) DEFAULT 0,
+            estimated_arv decimal(12,2) DEFAULT 0,
             condition_notes longtext NULL,
             lead_source varchar(120) DEFAULT 'website',
+            source_campaign varchar(191) DEFAULT '',
+            source_medium varchar(120) DEFAULT '',
+            source_referrer text NULL,
+            source_landing_page text NULL,
             motivation_score tinyint(3) unsigned DEFAULT 0,
             motivation_signals longtext NULL,
             property_tags longtext NULL,
@@ -32,6 +37,7 @@ final class ALGQ_Deal_Intake_Activator
             UNIQUE KEY deal_id (deal_id),
             KEY status (status),
             KEY lead_source (lead_source),
+            KEY source_medium (source_medium),
             KEY motivation_score (motivation_score)
         ) {$charset};";
 

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-csv.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-csv.php
@@ -25,24 +25,39 @@ final class ALGQ_Deal_Intake_CSV
 
         header('Content-Type: text/csv; charset=utf-8');
         header('Content-Disposition: attachment; filename=algq-deals-' . gmdate('Ymd-His') . '.csv');
-        $out = fopen('php://output', 'w');
-        fputcsv($out, ['deal_id', 'seller_name', 'seller_phone', 'seller_email', 'address', 'asking_price', 'lead_source', 'motivation_score', 'property_tags', 'status', 'created_at']);
-        foreach ($this->repository->all(200) as $deal) {
+        echo $this->to_string($this->repository->all(200));
+        exit;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $deals
+     */
+    public function to_string(array $deals): string
+    {
+        $out = fopen('php://temp', 'r+');
+        fputcsv($out, $this->headers());
+        foreach ($deals as $deal) {
             fputcsv($out, [
-                $deal['deal_id'],
-                $deal['seller_name'],
-                $deal['seller_phone'],
-                $deal['seller_email'],
-                $deal['address'],
-                $deal['asking_price'],
-                $deal['lead_source'],
-                $deal['motivation_score'],
-                implode('|', $deal['property_tags']),
-                $deal['status'],
-                $deal['created_at'],
+                $deal['deal_id'] ?? '',
+                $deal['seller_name'] ?? '',
+                $deal['seller_phone'] ?? '',
+                $deal['seller_email'] ?? '',
+                $deal['address'] ?? '',
+                $deal['asking_price'] ?? 0,
+                $deal['estimated_arv'] ?? 0,
+                $deal['lead_source'] ?? '',
+                $deal['source_campaign'] ?? '',
+                $deal['source_medium'] ?? '',
+                $deal['source_referrer'] ?? '',
+                $deal['source_landing_page'] ?? '',
+                $deal['motivation_score'] ?? 0,
+                implode('|', $deal['property_tags'] ?? []),
+                $deal['status'] ?? '',
+                $deal['created_at'] ?? '',
             ]);
         }
-        exit;
+        rewind($out);
+        return (string) stream_get_contents($out);
     }
 
     public function import(array $file): array
@@ -95,5 +110,13 @@ final class ALGQ_Deal_Intake_CSV
         fclose($handle);
 
         return ['imported' => $imported, 'errors' => $errors];
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function headers(): array
+    {
+        return ['deal_id', 'seller_name', 'seller_phone', 'seller_email', 'address', 'asking_price', 'estimated_arv', 'lead_source', 'source_campaign', 'source_medium', 'source_referrer', 'source_landing_page', 'motivation_score', 'property_tags', 'status', 'created_at'];
     }
 }

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-plugin.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-plugin.php
@@ -21,7 +21,7 @@ final class ALGQ_Deal_Intake_Plugin
         $this->validator = new ALGQ_Deal_Intake_Validator();
         $this->scorer = new ALGQ_Deal_Intake_Scorer();
         $this->csv = new ALGQ_Deal_Intake_CSV($this->repository, $this->validator, $this->scorer);
-        $this->rest = new ALGQ_Deal_Intake_REST_Controller($this->repository, $this->validator, $this->scorer);
+        $this->rest = new ALGQ_Deal_Intake_REST_Controller($this->repository, $this->validator, $this->scorer, $this->csv);
         $this->admin = new ALGQ_Deal_Intake_Admin($this->repository, $this->csv);
         $this->public = new ALGQ_Deal_Intake_Public($this->repository, $this->validator, $this->scorer);
     }

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-repository.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-repository.php
@@ -31,8 +31,13 @@ final class ALGQ_Deal_Intake_Repository
                 'seller_email' => $data['seller_email'] ?? '',
                 'address' => $data['address'],
                 'asking_price' => $data['asking_price'] ?? 0,
+                'estimated_arv' => $data['estimated_arv'] ?? 0,
                 'condition_notes' => $data['condition_notes'] ?? '',
                 'lead_source' => $data['lead_source'] ?? 'website',
+                'source_campaign' => $data['source_campaign'] ?? '',
+                'source_medium' => $data['source_medium'] ?? '',
+                'source_referrer' => $data['source_referrer'] ?? '',
+                'source_landing_page' => $data['source_landing_page'] ?? '',
                 'motivation_score' => $data['motivation_score'] ?? 0,
                 'motivation_signals' => wp_json_encode($data['motivation_signals'] ?? []),
                 'property_tags' => wp_json_encode($data['property_tags'] ?? []),
@@ -40,10 +45,62 @@ final class ALGQ_Deal_Intake_Repository
                 'created_at' => $data['created_at'] ?? $now,
                 'updated_at' => $now,
             ],
-            ['%s', '%s', '%s', '%s', '%s', '%f', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s']
+            ['%s', '%s', '%s', '%s', '%s', '%f', '%f', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s']
         );
 
         return false === $inserted ? false : (int) $wpdb->insert_id;
+    }
+
+    public function update(int $id, array $data): ?array
+    {
+        global $wpdb;
+
+        $allowed = [
+            'seller_name' => '%s',
+            'seller_phone' => '%s',
+            'seller_email' => '%s',
+            'address' => '%s',
+            'asking_price' => '%f',
+            'estimated_arv' => '%f',
+            'condition_notes' => '%s',
+            'lead_source' => '%s',
+            'source_campaign' => '%s',
+            'source_medium' => '%s',
+            'source_referrer' => '%s',
+            'source_landing_page' => '%s',
+            'motivation_score' => '%d',
+            'motivation_signals' => '%s',
+            'property_tags' => '%s',
+            'status' => '%s',
+        ];
+        $update = [];
+        $formats = [];
+
+        foreach ($allowed as $field => $format) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+            $value = $data[$field];
+            if (in_array($field, ['motivation_signals', 'property_tags'], true)) {
+                $value = wp_json_encode($value ?: []);
+            }
+            $update[$field] = $value;
+            $formats[] = $format;
+        }
+
+        if ([] === $update) {
+            return $this->find($id);
+        }
+
+        $update['updated_at'] = current_time('mysql');
+        $formats[] = '%s';
+
+        $updated = $wpdb->update(self::table_name(), $update, ['id' => $id], $formats, ['%d']);
+        if (false === $updated) {
+            return null;
+        }
+
+        return $this->find($id);
     }
 
     public function find(int $id): ?array
@@ -71,6 +128,10 @@ final class ALGQ_Deal_Intake_Repository
             $where .= ' AND lead_source = %s';
             $args[] = sanitize_key($filters['lead_source']);
         }
+        if (!empty($filters['min_score'])) {
+            $where .= ' AND motivation_score >= %d';
+            $args[] = (int) $filters['min_score'];
+        }
 
         $sql = 'SELECT * FROM ' . self::table_name() . " {$where} ORDER BY created_at DESC LIMIT %d";
         $args[] = $limit;
@@ -89,6 +150,7 @@ final class ALGQ_Deal_Intake_Repository
     {
         $row['motivation_score'] = (int) ($row['motivation_score'] ?? 0);
         $row['asking_price'] = (float) ($row['asking_price'] ?? 0);
+        $row['estimated_arv'] = (float) ($row['estimated_arv'] ?? 0);
         $row['motivation_signals'] = json_decode((string) ($row['motivation_signals'] ?? '[]'), true) ?: [];
         $row['property_tags'] = json_decode((string) ($row['property_tags'] ?? '[]'), true) ?: [];
         return $row;

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-rest-controller.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-rest-controller.php
@@ -8,12 +8,14 @@ final class ALGQ_Deal_Intake_REST_Controller
     private ALGQ_Deal_Intake_Repository $repository;
     private ALGQ_Deal_Intake_Validator $validator;
     private ALGQ_Deal_Intake_Scorer $scorer;
+    private ALGQ_Deal_Intake_CSV $csv;
 
-    public function __construct(ALGQ_Deal_Intake_Repository $repository, ALGQ_Deal_Intake_Validator $validator, ALGQ_Deal_Intake_Scorer $scorer)
+    public function __construct(ALGQ_Deal_Intake_Repository $repository, ALGQ_Deal_Intake_Validator $validator, ALGQ_Deal_Intake_Scorer $scorer, ALGQ_Deal_Intake_CSV $csv)
     {
         $this->repository = $repository;
         $this->validator = $validator;
         $this->scorer = $scorer;
+        $this->csv = $csv;
     }
 
     public function register_routes(): void
@@ -32,8 +34,27 @@ final class ALGQ_Deal_Intake_REST_Controller
         ]);
 
         register_rest_route('algq/v1', '/deals/(?P<id>\d+)', [
+            [
+                'methods' => WP_REST_Server::READABLE,
+                'callback' => [$this, 'show'],
+                'permission_callback' => [$this, 'can_manage'],
+            ],
+            [
+                'methods' => WP_REST_Server::EDITABLE,
+                'callback' => [$this, 'update'],
+                'permission_callback' => [$this, 'can_manage'],
+            ],
+        ]);
+
+        register_rest_route('algq/v1', '/deals/export', [
             'methods' => WP_REST_Server::READABLE,
-            'callback' => [$this, 'show'],
+            'callback' => [$this, 'export'],
+            'permission_callback' => [$this, 'can_manage'],
+        ]);
+
+        register_rest_route('algq/v1', '/deals/import', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'import'],
             'permission_callback' => [$this, 'can_manage'],
         ]);
     }
@@ -43,6 +64,7 @@ final class ALGQ_Deal_Intake_REST_Controller
         return rest_ensure_response($this->repository->all((int) ($request->get_param('limit') ?: 50), [
             'status' => $request->get_param('status'),
             'lead_source' => $request->get_param('lead_source'),
+            'min_score' => $request->get_param('min_score'),
         ]));
     }
 
@@ -74,6 +96,48 @@ final class ALGQ_Deal_Intake_REST_Controller
         }
 
         return new WP_REST_Response($this->repository->find($id), 201);
+    }
+
+    public function update(WP_REST_Request $request)
+    {
+        if (!$this->repository->find((int) $request['id'])) {
+            return new WP_Error('algq_deal_not_found', __('Deal not found.', 'algq-deal-intake'), ['status' => 404]);
+        }
+
+        $payload = array_merge($this->repository->find((int) $request['id']) ?: [], $request->get_json_params() ?: $request->get_params());
+        $validation = $this->validator->validate($payload);
+        if (!$validation['valid']) {
+            return new WP_Error('algq_deal_invalid', __('Deal intake validation failed.', 'algq-deal-intake'), ['status' => 400, 'errors' => $validation['errors']]);
+        }
+
+        $scored = $this->scorer->score($validation['data']);
+        $deal = $this->repository->update((int) $request['id'], array_merge($validation['data'], [
+            'motivation_score' => $scored['score'],
+            'motivation_signals' => $scored['signals'],
+            'property_tags' => $scored['tags'],
+        ]));
+
+        if (!$deal) {
+            return new WP_Error('algq_deal_update_failed', __('Deal could not be updated.', 'algq-deal-intake'), ['status' => 500]);
+        }
+
+        return rest_ensure_response($deal);
+    }
+
+    public function export(): WP_REST_Response
+    {
+        return rest_ensure_response([
+            'filename' => 'algq-deals-' . gmdate('Ymd-His') . '.csv',
+            'content_type' => 'text/csv',
+            'csv' => $this->csv->to_string($this->repository->all(200)),
+        ]);
+    }
+
+    public function import(WP_REST_Request $request): WP_REST_Response
+    {
+        $files = $request->get_file_params();
+        $result = $this->csv->import($files['file'] ?? $files['algq_deal_csv'] ?? []);
+        return rest_ensure_response($result);
     }
 
     public function can_manage(): bool

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-scorer.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-scorer.php
@@ -15,23 +15,46 @@ final class ALGQ_Deal_Intake_Scorer
         $tags = $data['property_tags'] ?? [];
 
         $timeline = $data['timeline'] ?? 'unknown';
-        $timeline_scores = ['asap' => 35, '30_days' => 25, '90_days' => 12, 'unknown' => 0];
+        $timeline_scores = ['asap' => 35, '30_days' => 25, '90_days' => 12, '6_months' => 5, 'unknown' => 0];
         $score += $timeline_scores[$timeline] ?? 0;
         $signals['timeline'] = $timeline;
+        if ('asap' === $timeline) {
+            $tags[] = 'urgent-timeline';
+        }
 
         $repairs = $data['repairs_needed'] ?? 'unknown';
         $repair_scores = ['major' => 20, 'cosmetic' => 10, 'none' => 0, 'unknown' => 0];
         $score += $repair_scores[$repairs] ?? 0;
         $signals['repairs_needed'] = $repairs;
+        if ('major' === $repairs) {
+            $tags[] = 'heavy-rehab';
+        } elseif ('cosmetic' === $repairs) {
+            $tags[] = 'cosmetic-rehab';
+        }
 
         $occupancy = $data['occupancy'] ?? 'unknown';
         if (in_array($occupancy, ['vacant', 'tenant'], true)) {
             $score += 10;
+            $tags[] = 'tenant' === $occupancy ? 'tenant-occupied' : 'vacant';
         }
         $signals['occupancy'] = $occupancy;
 
+        $asking_price = (float) ($data['asking_price'] ?? 0);
+        $estimated_arv = (float) ($data['estimated_arv'] ?? 0);
+        if ($asking_price > 0 && $estimated_arv > 0) {
+            $price_to_arv = round(($asking_price / $estimated_arv) * 100, 2);
+            $signals['price_to_arv_percent'] = $price_to_arv;
+            if ($price_to_arv <= 65) {
+                $score += 12;
+                $tags[] = 'deep-discount';
+            } elseif ($price_to_arv <= 75) {
+                $score += 6;
+                $tags[] = 'margin-watch';
+            }
+        }
+
         $reason = strtolower((string) ($data['motivation_reason'] ?? ''));
-        $keywords = ['probate', 'foreclosure', 'divorce', 'tax', 'relocation', 'inherited', 'tired landlord', 'vacant'];
+        $keywords = ['probate', 'foreclosure', 'divorce', 'tax', 'relocation', 'inherited', 'tired landlord', 'vacant', 'code violation', 'behind payments', 'estate'];
         $matched = [];
         foreach ($keywords as $keyword) {
             if (false !== strpos($reason, $keyword)) {

--- a/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-validator.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/includes/class-algq-deal-intake-validator.php
@@ -5,6 +5,11 @@ if (!defined('ABSPATH')) {
 
 final class ALGQ_Deal_Intake_Validator
 {
+    private const ALLOWED_STATUSES = ['new', 'qualified', 'nurture', 'underwriting', 'rejected', 'contracted', 'closed'];
+    private const ALLOWED_TIMELINES = ['asap', '30_days', '90_days', '6_months', 'unknown'];
+    private const ALLOWED_OCCUPANCIES = ['owner', 'tenant', 'vacant', 'unknown'];
+    private const ALLOWED_REPAIRS = ['none', 'cosmetic', 'major', 'unknown'];
+
     /**
      * @return array{valid:bool,errors:array<string,string>,data:array<string,mixed>}
      */
@@ -16,8 +21,13 @@ final class ALGQ_Deal_Intake_Validator
             'seller_email' => sanitize_email(wp_unslash($input['seller_email'] ?? '')),
             'address' => sanitize_textarea_field(wp_unslash($input['address'] ?? '')),
             'asking_price' => $this->sanitize_money($input['asking_price'] ?? 0),
+            'estimated_arv' => $this->sanitize_money($input['estimated_arv'] ?? 0),
             'condition_notes' => sanitize_textarea_field(wp_unslash($input['condition_notes'] ?? '')),
             'lead_source' => sanitize_key(wp_unslash($input['lead_source'] ?? 'website')),
+            'source_campaign' => sanitize_text_field(wp_unslash($input['source_campaign'] ?? '')),
+            'source_medium' => sanitize_key(wp_unslash($input['source_medium'] ?? '')),
+            'source_referrer' => esc_url_raw(wp_unslash($input['source_referrer'] ?? '')),
+            'source_landing_page' => esc_url_raw(wp_unslash($input['source_landing_page'] ?? '')),
             'timeline' => sanitize_key(wp_unslash($input['timeline'] ?? 'unknown')),
             'motivation_reason' => sanitize_text_field(wp_unslash($input['motivation_reason'] ?? '')),
             'occupancy' => sanitize_key(wp_unslash($input['occupancy'] ?? 'unknown')),
@@ -42,11 +52,17 @@ final class ALGQ_Deal_Intake_Validator
         if ($data['asking_price'] < 0) {
             $errors['asking_price'] = __('Asking price cannot be negative.', 'algq-deal-intake');
         }
-
-        $allowed_statuses = ['new', 'qualified', 'nurture', 'underwriting', 'rejected'];
-        if (!in_array($data['status'], $allowed_statuses, true)) {
-            $data['status'] = 'new';
+        if ($data['estimated_arv'] < 0) {
+            $errors['estimated_arv'] = __('Estimated ARV cannot be negative.', 'algq-deal-intake');
         }
+        if ('' === $data['lead_source']) {
+            $data['lead_source'] = 'website';
+        }
+
+        $this->coerce_to_allowed($data, 'timeline', self::ALLOWED_TIMELINES, 'unknown');
+        $this->coerce_to_allowed($data, 'occupancy', self::ALLOWED_OCCUPANCIES, 'unknown');
+        $this->coerce_to_allowed($data, 'repairs_needed', self::ALLOWED_REPAIRS, 'unknown');
+        $this->coerce_to_allowed($data, 'status', self::ALLOWED_STATUSES, 'new');
 
         return [
             'valid' => [] === $errors,
@@ -76,5 +92,16 @@ final class ALGQ_Deal_Intake_Validator
         $tags = array_map(static fn($tag): string => sanitize_key(trim((string) wp_unslash($tag))), $value);
         $tags = array_filter($tags, static fn($tag): bool => '' !== $tag);
         return array_values(array_unique($tags));
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @param array<int,string> $allowed
+     */
+    private function coerce_to_allowed(array &$data, string $field, array $allowed, string $fallback): void
+    {
+        if (!in_array($data[$field], $allowed, true)) {
+            $data[$field] = $fallback;
+        }
     }
 }

--- a/algonquian-real-estate/plugins/algq-deal-intake/public/class-algq-deal-intake-public.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/public/class-algq-deal-intake-public.php
@@ -53,6 +53,8 @@ final class ALGQ_Deal_Intake_Public
 
         $payload = $_POST;
         $payload['lead_source'] = $payload['lead_source'] ?? $fallback_source;
+        $payload['source_referrer'] = $payload['source_referrer'] ?? ($_SERVER['HTTP_REFERER'] ?? '');
+        $payload['source_landing_page'] = $payload['source_landing_page'] ?? home_url(wp_unslash($_SERVER['REQUEST_URI'] ?? ''));
         $validation = $this->validator->validate($payload);
         if (!$validation['valid']) {
             $items = '';

--- a/algonquian-real-estate/plugins/algq-deal-intake/templates/intake-form.php
+++ b/algonquian-real-estate/plugins/algq-deal-intake/templates/intake-form.php
@@ -7,6 +7,10 @@ if (!defined('ABSPATH')) {
     <?php wp_nonce_field('algq_deal_intake_submit', 'algq_deal_intake_nonce'); ?>
     <input type="text" name="algq_website" value="" class="algq-honeypot" tabindex="-1" autocomplete="off" />
     <input type="hidden" name="lead_source" value="<?php echo esc_attr($atts['source'] ?? 'website'); ?>" />
+    <input type="hidden" name="source_campaign" value="<?php echo esc_attr(sanitize_text_field(wp_unslash($_GET['utm_campaign'] ?? ''))); ?>" />
+    <input type="hidden" name="source_medium" value="<?php echo esc_attr(sanitize_key(wp_unslash($_GET['utm_medium'] ?? ''))); ?>" />
+    <input type="hidden" name="source_referrer" value="<?php echo esc_url($_SERVER['HTTP_REFERER'] ?? ''); ?>" />
+    <input type="hidden" name="source_landing_page" value="<?php echo esc_url(home_url(wp_unslash($_SERVER['REQUEST_URI'] ?? ''))); ?>" />
     <?php echo wp_kses_post($message); ?>
 
     <div class="algq-grid">
@@ -14,6 +18,7 @@ if (!defined('ABSPATH')) {
         <p><label><?php esc_html_e('Seller Phone', 'algq-deal-intake'); ?> <input required name="seller_phone" type="tel" /></label></p>
         <p><label><?php esc_html_e('Seller Email', 'algq-deal-intake'); ?> <input name="seller_email" type="email" /></label></p>
         <p><label><?php esc_html_e('Asking Price', 'algq-deal-intake'); ?> <input name="asking_price" type="number" min="0" step="0.01" /></label></p>
+        <p><label><?php esc_html_e('Estimated ARV', 'algq-deal-intake'); ?> <input name="estimated_arv" type="number" min="0" step="0.01" /></label></p>
     </div>
 
     <p><label><?php esc_html_e('Property Address', 'algq-deal-intake'); ?> <textarea required name="address"></textarea></label></p>
@@ -26,6 +31,7 @@ if (!defined('ABSPATH')) {
                 <option value="asap"><?php esc_html_e('ASAP', 'algq-deal-intake'); ?></option>
                 <option value="30_days"><?php esc_html_e('Within 30 days', 'algq-deal-intake'); ?></option>
                 <option value="90_days"><?php esc_html_e('Within 90 days', 'algq-deal-intake'); ?></option>
+                <option value="6_months"><?php esc_html_e('Within 6 months', 'algq-deal-intake'); ?></option>
             </select>
         </label></p>
         <p><label><?php esc_html_e('Occupancy', 'algq-deal-intake'); ?>


### PR DESCRIPTION
### Motivation
- Convert the deal intake form into a standalone WordPress plugin module with production-ready fields and workflows. 
- Add robust validation, lead source attribution, seller motivation scoring, and property tagging so intake can be used safely by REST, shortcode, and CSV workflows. 
- Provide operational APIs and CSV import/export to enable integrations and admin operations. 

### Description
- Expanded the validation engine in `class-algq-deal-intake-validator.php` to sanitize and coerce new fields (`estimated_arv`, UTM/attribution fields, timelines, occupancies, repairs, and an allow-list of `status` values). 
- Extended scoring logic in `class-algq-deal-intake-scorer.php` to include `6_months` timeline, rehab/occupancy auto-tags, price-to-ARV signals and tags (`deep-discount`, `margin-watch`), and additional motivation keywords that produce tags like `urgent-timeline` and `heavy-rehab`. 
- Added repository support for new columns and update operations in `class-algq-deal-intake-repository.php`, and updated activation schema in `class-algq-deal-intake-activator.php` to create the new database columns (ARV and attribution fields). 
- Added REST endpoints and workflows in `class-algq-deal-intake-rest-controller.php` for deal `PATCH` (update), `GET /deals/export` (CSV export), and `POST /deals/import` (CSV import), plus list filtering by `min_score`. 
- Enhanced CSV handling in `class-algq-deal-intake-csv.php` to emit the expanded headers and provide a `to_string` helper for integrations, and updated the admin UI and shortcode template (`templates/intake-form.php`, `public/class-algq-deal-intake-public.php`, `admin/class-algq-deal-intake-admin.php`) to capture/display attribution and `estimated_arv` and the new `6_months` timeline option. 
- Bumped plugin version to `0.3.0` and updated `README.md` to document new fields, endpoints, and CSV contract. 

### Testing
- Ran PHP lint across plugin files with `find ... -name '*.php' -print0 | xargs -0 -n1 php -l`, which reported no syntax errors. 
- Ran the repository JavaScript/Node checks with `npm run check` (executed `node --check server.js`), which completed without errors. 
- Ran the smoke test with `npm run test:smoke` (script `node scripts/smoke-test.mjs`), which failed due to an unrelated existing route assertion: the `/` smoke route returned HTTP `500` instead of expected `200`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2d5ffb6c832d95309ef488d9f500)