### PR TITLE
Add Offer Generator document/signature engines, patterns, plugin UI, Command Center metrics, and CI improvements

### DIFF
--- a/.github/workflows/build-plugin-zips.yml
+++ b/.github/workflows/build-plugin-zips.yml
@@ -17,10 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Lint plugin PHP before packaging
+        run: find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l
       - name: Install zip
         run: sudo apt-get update && sudo apt-get install -y zip
       - name: Build plugin archives
         run: bash algonquian-real-estate/scripts/build-plugin-zips.sh
+      - name: Verify archives exist
+        run: test -n "$(find algonquian-real-estate/dist -name '*.zip' -print -quit)"
       - uses: actions/upload-artifact@v4
         with:
           name: algonquian-real-estate-plugin-zips

--- a/algonquian-real-estate/plugins/algq-command-center/algq-command-center.php
+++ b/algonquian-real-estate/plugins/algq-command-center/algq-command-center.php
@@ -27,6 +27,27 @@ final class ALGQ_Command_Center
         add_action('wp_dashboard_setup', [$this, 'register_dashboard_widget']);
         add_action('admin_menu', [$this, 'register_admin_page']);
         add_shortcode('algq_command_center', [$this, 'render_shortcode']);
+        add_action('rest_api_init', [$this, 'register_rest_routes']);
+    }
+
+
+    public function register_rest_routes(): void
+    {
+        register_rest_route('algq/v1', '/command-center/metrics', [
+            'methods' => 'GET',
+            'callback' => [$this, 'rest_metrics'],
+            'permission_callback' => static function (): bool {
+                return current_user_can('manage_options');
+            },
+        ]);
+    }
+
+    public function rest_metrics(): WP_REST_Response
+    {
+        return new WP_REST_Response([
+            'generated_at' => gmdate('c'),
+            'metrics' => $this->collect_metrics(),
+        ]);
     }
 
     public function register_dashboard_widget(): void
@@ -107,6 +128,8 @@ final class ALGQ_Command_Center
                 <?php $this->render_panel(__('Buyer Activity', 'algq-command-center'), $metrics['buyers']); ?>
             </div>
 
+            <?php $this->render_metrics_dashboard($metrics); ?>
+
             <?php if ($expanded) : ?>
                 <div class="algq-reporting-engine">
                     <h3><?php esc_html_e('Reporting Engine', 'algq-command-center'); ?></h3>
@@ -128,8 +151,28 @@ final class ALGQ_Command_Center
     }
 
     /**
-     * @param array<int,array{label:string,value:string}> $rows
+     * @param array<string,mixed> $metrics
      */
+    private function render_metrics_dashboard(array $metrics): void
+    {
+        $cards = array_merge($metrics['pipeline'], $metrics['deals'], $metrics['funding'], $metrics['buyers']);
+        ?>
+        <div class="algq-metrics-dashboard">
+            <h3><?php esc_html_e('Metrics Dashboard', 'algq-command-center'); ?></h3>
+            <div class="algq-metric-bars">
+                <?php foreach ($cards as $index => $card) : ?>
+                    <?php $width = 20 + (($index + 1) * 9 % 70); ?>
+                    <div class="algq-metric-bar-row">
+                        <span><?php echo esc_html($card['label']); ?></span>
+                        <strong><?php echo esc_html($card['value']); ?></strong>
+                        <em style="width: <?php echo esc_attr((string) $width); ?>%"></em>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <?php
+    }
+
     private function render_panel(string $title, array $rows): void
     {
         ?>
@@ -151,7 +194,7 @@ final class ALGQ_Command_Center
     {
         ?>
         <style>
-            .algq-command-center{margin:18px 0;color:#172033}.algq-command-hero{display:flex;gap:16px;justify-content:space-between;align-items:flex-start;padding:20px;border:1px solid #d9e2ef;border-radius:18px;background:linear-gradient(135deg,#f8fbff,#edf4ff)}.algq-command-eyebrow{margin:0 0 6px;font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#45607f}.algq-command-hero h2{margin:0 0 8px;font-size:28px;line-height:1.1}.algq-command-hero p{margin:0;max-width:760px;color:#4b5870}.algq-command-status{display:inline-flex;white-space:nowrap;border-radius:999px;background:#0f766e;color:#fff;padding:7px 12px;font-weight:700;font-size:12px}.algq-kpi-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin:14px 0}.algq-kpi-card,.algq-command-panel,.algq-reporting-engine{border:1px solid #d9e2ef;border-radius:16px;background:#fff;padding:16px;box-shadow:0 10px 24px rgba(20,39,67,.06)}.algq-kpi-card span,.algq-kpi-card small{display:block;color:#64748b}.algq-kpi-card strong{display:block;margin:6px 0;font-size:24px;color:#0f172a}.algq-command-panels{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.algq-command-panel h3,.algq-reporting-engine h3{margin:0 0 12px}.algq-command-panel dl{margin:0}.algq-command-panel dl div{display:flex;justify-content:space-between;gap:14px;padding:9px 0;border-top:1px solid #edf2f7}.algq-command-panel dl div:first-child{border-top:0}.algq-command-panel dt{color:#64748b}.algq-command-panel dd{margin:0;font-weight:700;text-align:right}.algq-reporting-engine{margin-top:14px}.algq-report-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}.algq-report-grid article{border:1px solid #e5edf6;border-radius:12px;padding:12px;background:#f8fafc}.algq-report-grid strong,.algq-report-grid span,.algq-report-grid small{display:block}.algq-report-grid span{margin:5px 0;color:#475569}.algq-report-grid small{color:#64748b}@media (max-width:900px){.algq-kpi-grid,.algq-command-panels,.algq-report-grid{grid-template-columns:1fr}.algq-command-hero{display:block}.algq-command-status{margin-top:12px}}
+            .algq-command-center{margin:18px 0;color:#172033}.algq-command-hero{display:flex;gap:16px;justify-content:space-between;align-items:flex-start;padding:20px;border:1px solid #d9e2ef;border-radius:18px;background:linear-gradient(135deg,#f8fbff,#edf4ff)}.algq-command-eyebrow{margin:0 0 6px;font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#45607f}.algq-command-hero h2{margin:0 0 8px;font-size:28px;line-height:1.1}.algq-command-hero p{margin:0;max-width:760px;color:#4b5870}.algq-command-status{display:inline-flex;white-space:nowrap;border-radius:999px;background:#0f766e;color:#fff;padding:7px 12px;font-weight:700;font-size:12px}.algq-kpi-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin:14px 0}.algq-kpi-card,.algq-command-panel,.algq-reporting-engine{border:1px solid #d9e2ef;border-radius:16px;background:#fff;padding:16px;box-shadow:0 10px 24px rgba(20,39,67,.06)}.algq-kpi-card span,.algq-kpi-card small{display:block;color:#64748b}.algq-kpi-card strong{display:block;margin:6px 0;font-size:24px;color:#0f172a}.algq-command-panels{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.algq-command-panel h3,.algq-reporting-engine h3{margin:0 0 12px}.algq-command-panel dl{margin:0}.algq-command-panel dl div{display:flex;justify-content:space-between;gap:14px;padding:9px 0;border-top:1px solid #edf2f7}.algq-command-panel dl div:first-child{border-top:0}.algq-command-panel dt{color:#64748b}.algq-command-panel dd{margin:0;font-weight:700;text-align:right}.algq-reporting-engine{margin-top:14px}.algq-report-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}.algq-report-grid article{border:1px solid #e5edf6;border-radius:12px;padding:12px;background:#f8fafc}.algq-report-grid strong,.algq-report-grid span,.algq-report-grid small{display:block}.algq-report-grid span{margin:5px 0;color:#475569}.algq-report-grid small{color:#64748b}.algq-metrics-dashboard{margin-top:18px;border:1px solid rgba(180,135,35,.28);border-radius:18px;padding:18px;background:rgba(255,255,255,.72)}.algq-metric-bars{display:grid;gap:10px}.algq-metric-bar-row{position:relative;overflow:hidden;border-radius:12px;background:#fff;padding:12px 14px}.algq-metric-bar-row span,.algq-metric-bar-row strong{position:relative;z-index:1}.algq-metric-bar-row strong{float:right}.algq-metric-bar-row em{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,rgba(180,135,35,.28),rgba(34,197,94,.18))}@media (max-width:900px){.algq-kpi-grid,.algq-command-panels,.algq-report-grid{grid-template-columns:1fr}.algq-command-hero{display:block}.algq-command-status{margin-top:12px}}
         </style>
         <?php
     }

--- a/algonquian-real-estate/plugins/algq-digital-products/algq-digital-products.php
+++ b/algonquian-real-estate/plugins/algq-digital-products/algq-digital-products.php
@@ -1,22 +1,106 @@
 <?php
 /**
  * Plugin Name: Algonquian Digital Products
- * Description: Product library dashboard for contract packs, spreadsheets, calculators, checklists, and training.
- * Version: 0.1.0
+ * Description: Product library dashboard for contract packs, spreadsheets, calculators, checklists, training, and plugin-library access cards.
+ * Version: 0.2.0
  * Author: Algonquian Real Estate
+ * Text Domain: algq-digital-products
  */
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
-add_shortcode('algq_product_library', function (): string {
-    $products = ['Contract Packs', 'Spreadsheets', 'Calculators', 'Checklists', 'Training'];
-    ob_start();
-    echo '<div class="algq-product-library"><h2>Product Library</h2><ul>';
-    foreach ($products as $product) {
-        echo '<li><strong>' . esc_html($product) . '</strong><br><span>WooCommerce secure download, license tracking, and access-control hooks ready for integration.</span></li>';
+final class ALGQ_Digital_Products
+{
+    /**
+     * @return array<int,array<string,string>>
+     */
+    private function library_items(): array
+    {
+        return [
+            ['title' => 'Contract Packs', 'type' => 'Document Pack', 'status' => 'WooCommerce gated', 'description' => 'Purchase, assignment, seller-financing, and due-diligence contract bundles.'],
+            ['title' => 'Spreadsheets', 'type' => 'Financial Tools', 'status' => 'License tracked', 'description' => 'Acquisition models, rehab budgets, cash-flow sheets, and capital tracking workbooks.'],
+            ['title' => 'Calculators', 'type' => 'Interactive Tool', 'status' => 'Member access', 'description' => 'MAO, amortization, seller income, and offer comparison calculators.'],
+            ['title' => 'Checklists', 'type' => 'Operations', 'status' => 'Download ready', 'description' => 'Closing, inspection, lender, onboarding, and asset-management checklists.'],
+            ['title' => 'Training', 'type' => 'Education', 'status' => 'Course mapped', 'description' => 'Wholesale, underwriting, creative finance, buyer management, and automation modules.'],
+        ];
     }
-    echo '</ul></div>';
-    return (string) ob_get_clean();
-});
+
+    public function register(): void
+    {
+        add_shortcode('algq_product_library', [$this, 'render_product_library']);
+        add_shortcode('algq_plugin_library', [$this, 'render_plugin_library']);
+    }
+
+    public function render_product_library(): string
+    {
+        ob_start();
+        $this->render_styles();
+        ?>
+        <section class="algq-library-ui" aria-label="<?php esc_attr_e('Product Library', 'algq-digital-products'); ?>">
+            <div class="algq-library-hero">
+                <p><?php esc_html_e('Plugin Library UI', 'algq-digital-products'); ?></p>
+                <h2><?php esc_html_e('Product Library', 'algq-digital-products'); ?></h2>
+                <span><?php esc_html_e('WooCommerce downloads, licensing, and access-control hooks are ready for integration.', 'algq-digital-products'); ?></span>
+            </div>
+            <div class="algq-library-grid">
+                <?php foreach ($this->library_items() as $item) : ?>
+                    <article class="algq-library-card">
+                        <span><?php echo esc_html($item['type']); ?></span>
+                        <h3><?php echo esc_html($item['title']); ?></h3>
+                        <p><?php echo esc_html($item['description']); ?></p>
+                        <strong><?php echo esc_html($item['status']); ?></strong>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    public function render_plugin_library(): string
+    {
+        $plugins = [
+            ['name' => 'Deal Intake', 'shortcode' => '[algq_deal_intake]', 'status' => 'Lead capture'],
+            ['name' => 'MAO Engine', 'shortcode' => '[algq_mao_engine]', 'status' => 'Underwriting'],
+            ['name' => 'Offer Generator', 'shortcode' => '[algq_offer_generator]', 'status' => 'Documents + PDF'],
+            ['name' => 'PDF & Signature', 'shortcode' => '[algq_signature]', 'status' => 'Execution'],
+            ['name' => 'Command Center', 'shortcode' => '[algq_command_center]', 'status' => 'Metrics'],
+            ['name' => 'Marketplace', 'shortcode' => '[algq_marketplace]', 'status' => 'Distribution'],
+        ];
+
+        ob_start();
+        $this->render_styles();
+        ?>
+        <section class="algq-library-ui algq-plugin-library" aria-label="<?php esc_attr_e('Plugin Library', 'algq-digital-products'); ?>">
+            <div class="algq-library-hero">
+                <p><?php esc_html_e('Module Launcher', 'algq-digital-products'); ?></p>
+                <h2><?php esc_html_e('Plugin Library', 'algq-digital-products'); ?></h2>
+                <span><?php esc_html_e('Central UI for shortcode discovery, module status, and operator handoff.', 'algq-digital-products'); ?></span>
+            </div>
+            <div class="algq-library-grid">
+                <?php foreach ($plugins as $plugin) : ?>
+                    <article class="algq-library-card">
+                        <span><?php echo esc_html($plugin['status']); ?></span>
+                        <h3><?php echo esc_html($plugin['name']); ?></h3>
+                        <code><?php echo esc_html($plugin['shortcode']); ?></code>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    private function render_styles(): void
+    {
+        ?>
+        <style>
+            .algq-library-ui{border:1px solid #d7c9a5;border-radius:22px;padding:24px;background:#fffdf7;color:#1f2937}.algq-library-hero{display:flex;flex-wrap:wrap;align-items:end;justify-content:space-between;gap:12px;margin-bottom:18px}.algq-library-hero p{margin:0;text-transform:uppercase;letter-spacing:.16em;font-size:12px;color:#8a6b1f}.algq-library-hero h2{margin:0;font-size:30px}.algq-library-hero span{max-width:440px}.algq-library-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:14px}.algq-library-card{border:1px solid #eadfbd;border-radius:18px;padding:18px;background:#fff}.algq-library-card span{font-size:12px;text-transform:uppercase;letter-spacing:.12em;color:#7c5d14}.algq-library-card h3{margin:.35rem 0}.algq-library-card strong,.algq-library-card code{display:inline-block;margin-top:10px;border-radius:999px;background:#f7ecd0;padding:6px 10px;color:#5d420d}
+        </style>
+        <?php
+    }
+}
+
+(new ALGQ_Digital_Products())->register();

--- a/algonquian-real-estate/plugins/algq-offer-generator/algq-offer-generator.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/algq-offer-generator.php
@@ -1,31 +1,177 @@
 <?php
 /**
  * Plugin Name: Algonquian Offer Generator
- * Description: Creative offer, amortization, legacy visualization, and printable offer summary tools.
- * Version: 0.1.0
+ * Description: Creative offer, amortization, legacy visualization, merge-field documents, PDF generation, and signature workflow bootstrap tools.
+ * Version: 0.2.0
  * Author: Algonquian Real Estate
+ * Text Domain: algq-offer-generator
  */
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
-require_once __DIR__ . '/includes/class-amortization-engine.php';
+define('ALGQ_OFFER_GENERATOR_VERSION', '0.2.0');
+define('ALGQ_OFFER_GENERATOR_DIR', plugin_dir_path(__FILE__));
+
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-amortization-engine.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-database.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-audit-log.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-merge-engine.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-document-generator.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-pdf-engine.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-signature-engine.php';
+require_once ALGQ_OFFER_GENERATOR_DIR . 'includes/class-connectors.php';
+
+register_activation_hook(__FILE__, ['ALGQ_Offer_Database', 'activate']);
 
 add_action('wp_enqueue_scripts', function (): void {
-    wp_register_style('algq-offer-generator', plugins_url('assets/css/offer-generator.css', __FILE__), [], '0.1.0');
-    wp_register_script('algq-offer-generator', plugins_url('assets/js/offer-generator.js', __FILE__), [], '0.1.0', true);
+    wp_register_style('algq-offer-generator', plugins_url('assets/css/offer-generator.css', __FILE__), [], ALGQ_OFFER_GENERATOR_VERSION);
+    wp_register_script('algq-offer-generator', plugins_url('assets/js/offer-generator.js', __FILE__), [], ALGQ_OFFER_GENERATOR_VERSION, true);
 });
+
+add_action('admin_post_algq_offer_document', 'algq_offer_generator_handle_document');
+
+add_action('init', 'algq_offer_generator_register_patterns');
 
 add_shortcode('algq_offer_generator', function (): string {
     wp_enqueue_style('algq-offer-generator');
     wp_enqueue_script('algq-offer-generator');
     $offer = null;
+    $documents = [];
     if ('POST' === ($_SERVER['REQUEST_METHOD'] ?? '') && isset($_POST['algq_offer_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['algq_offer_nonce'])), 'algq_offer_generate')) {
         $engine = new ALGQ_Amortization_Engine();
         $offer = $engine->schedule((float) ($_POST['price'] ?? 0), (float) ($_POST['rate'] ?? 0), (int) ($_POST['term'] ?? 1));
     }
+
+    if (current_user_can('manage_options')) {
+        $documents = (new ALGQ_Offer_Database())->recent_documents(5);
+    }
+
     ob_start();
     include __DIR__ . '/templates/app.php';
+    algq_offer_generator_render_document_tools($documents);
     return (string) ob_get_clean();
 });
+
+function algq_offer_generator_handle_document(): void
+{
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Insufficient permissions.', 'algq-offer-generator'));
+    }
+
+    check_admin_referer('algq_offer_document');
+
+    $connectors = new ALGQ_Offer_Connectors();
+    $merge = new ALGQ_Offer_Merge_Engine();
+    $generator = new ALGQ_Offer_Document_Generator($merge);
+    $database = new ALGQ_Offer_Database();
+    $audit = new ALGQ_Offer_Audit_Log();
+    $pdf = new ALGQ_Offer_PDF_Engine();
+
+    $deal_id = sanitize_text_field($_POST['deal_id'] ?? '');
+    $payload = array_merge(
+        $connectors->deal_payload($deal_id),
+        [
+            'seller_name' => sanitize_text_field($_POST['seller_name'] ?? ''),
+            'seller_email' => sanitize_email($_POST['seller_email'] ?? ''),
+            'property_address' => sanitize_text_field($_POST['property_address'] ?? ''),
+            'purchase_price' => sanitize_text_field($_POST['purchase_price'] ?? ''),
+            'earnest_money' => sanitize_text_field($_POST['earnest_money'] ?? ''),
+            'closing_date' => sanitize_text_field($_POST['closing_date'] ?? ''),
+            'offer_terms' => sanitize_textarea_field($_POST['offer_terms'] ?? ''),
+        ]
+    );
+
+    $document = $generator->generate(sanitize_key($_POST['document_type'] ?? 'loi'), $payload);
+    $document['deal_id'] = $deal_id;
+    $binary = $pdf->render($document);
+    $document['pdf_checksum'] = $pdf->checksum($binary);
+    $document_id = $database->save_document($document);
+    $audit->record('offer_document', (string) $document_id, 'document_generated', 'Offer document generated.', ['document_type' => $document['document_type']]);
+
+    if (!empty($_POST['request_signature'])) {
+        $saved = $database->find_document($document_id) ?: $document;
+        $signature = (new ALGQ_Offer_Signature_Engine())->request_signature($saved);
+        $saved['id'] = $document_id;
+        $saved['signature_uid'] = $signature['signature_uid'];
+        $saved['status'] = $signature['status'];
+        if (!empty($signature['pdf_checksum'])) {
+            $saved['pdf_checksum'] = $signature['pdf_checksum'];
+        }
+        $database->save_document($saved);
+        $audit->record('offer_document', (string) $document_id, 'signature_requested', 'Signature workflow requested.', $signature);
+    }
+
+    wp_safe_redirect(add_query_arg(['algq_offer_document' => $document_id], wp_get_referer() ?: home_url('/')));
+    exit;
+}
+
+function algq_offer_generator_render_document_tools(array $documents): void
+{
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    ?>
+    <section class="algq-offer-document-tools">
+        <h2><?php esc_html_e('Document Generator', 'algq-offer-generator'); ?></h2>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+            <?php wp_nonce_field('algq_offer_document'); ?>
+            <input type="hidden" name="action" value="algq_offer_document" />
+            <p><label><?php esc_html_e('Deal ID', 'algq-offer-generator'); ?><br /><input name="deal_id" /></label></p>
+            <p><label><?php esc_html_e('Document Type', 'algq-offer-generator'); ?><br />
+                <select name="document_type">
+                    <option value="loi"><?php esc_html_e('LOI', 'algq-offer-generator'); ?></option>
+                    <option value="purchase_agreement"><?php esc_html_e('Purchase Agreement', 'algq-offer-generator'); ?></option>
+                    <option value="seller_financing"><?php esc_html_e('Seller Financing', 'algq-offer-generator'); ?></option>
+                    <option value="assignment_contract"><?php esc_html_e('Assignment Contract', 'algq-offer-generator'); ?></option>
+                </select></label></p>
+            <p><label><?php esc_html_e('Seller Name', 'algq-offer-generator'); ?><br /><input name="seller_name" /></label></p>
+            <p><label><?php esc_html_e('Seller Email', 'algq-offer-generator'); ?><br /><input type="email" name="seller_email" /></label></p>
+            <p><label><?php esc_html_e('Property Address', 'algq-offer-generator'); ?><br /><input name="property_address" /></label></p>
+            <p><label><?php esc_html_e('Purchase Price', 'algq-offer-generator'); ?><br /><input name="purchase_price" /></label></p>
+            <p><label><?php esc_html_e('Earnest Money', 'algq-offer-generator'); ?><br /><input name="earnest_money" /></label></p>
+            <p><label><?php esc_html_e('Closing Date', 'algq-offer-generator'); ?><br /><input name="closing_date" /></label></p>
+            <p><label><?php esc_html_e('Offer Terms', 'algq-offer-generator'); ?><br /><textarea name="offer_terms" rows="4"></textarea></label></p>
+            <p><label><input type="checkbox" name="request_signature" value="1" /> <?php esc_html_e('Send to signature engine after generation', 'algq-offer-generator'); ?></label></p>
+            <p><button type="submit"><?php esc_html_e('Generate Document', 'algq-offer-generator'); ?></button></p>
+        </form>
+        <?php if (!empty($documents)) : ?>
+            <h3><?php esc_html_e('Recent Documents', 'algq-offer-generator'); ?></h3>
+            <ul>
+                <?php foreach ($documents as $document) : ?>
+                    <li><strong><?php echo esc_html($document['title']); ?></strong> — <?php echo esc_html($document['status']); ?> <code><?php echo esc_html($document['document_uid']); ?></code></li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </section>
+    <?php
+}
+
+function algq_offer_generator_register_patterns(): void
+{
+    if (!function_exists('register_block_pattern')) {
+        return;
+    }
+
+    if (function_exists('register_block_pattern_category')) {
+        register_block_pattern_category('algq-real-estate', ['label' => __('Algonquian Real Estate', 'algq-offer-generator')]);
+    }
+
+    register_block_pattern('algq-real-estate/offer-command-center', [
+        'title' => __('Offer Generator Command Center', 'algq-offer-generator'),
+        'description' => __('Embed the offer generator with operational context and document workflow links.', 'algq-offer-generator'),
+        'categories' => ['algq-real-estate', 'call-to-action'],
+        'viewportWidth' => 1200,
+        'content' => '<!-- wp:group {"className":"algq-pattern-offer-command"} --><div class="wp-block-group algq-pattern-offer-command"><!-- wp:heading --><h2>Offer Generator Command Center</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Create offer summaries, LOIs, seller-financing sheets, PDFs, and signature-ready documents.</p><!-- /wp:paragraph --><!-- wp:shortcode -->[algq_offer_generator]<!-- /wp:shortcode --></div><!-- /wp:group -->',
+    ]);
+
+    register_block_pattern('algq-real-estate/navigation-overlay', [
+        'title' => __('Navigation Overlay Template', 'algq-offer-generator'),
+        'description' => __('Responsive overlay navigation for Algonquian operating modules.', 'algq-offer-generator'),
+        'categories' => ['algq-real-estate', 'header'],
+        'blockTypes' => ['core/template-part/header'],
+        'viewportWidth' => 1200,
+        'content' => '<!-- wp:group {"className":"algq-navigation-overlay"} --><div class="wp-block-group algq-navigation-overlay"><!-- wp:heading {"level":3} --><h3>Algonquian Real Estate</h3><!-- /wp:heading --><!-- wp:navigation --><!-- wp:navigation-link {"label":"Deals","url":"/deals"} /--><!-- wp:navigation-link {"label":"Offers","url":"/offers"} /--><!-- wp:navigation-link {"label":"Documents","url":"/documents"} /--><!-- wp:navigation-link {"label":"Command Center","url":"/command-center"} /--><!-- /wp:navigation --></div><!-- /wp:group -->',
+    ]);
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/assets/css/offer-generator.css
+++ b/algonquian-real-estate/plugins/algq-offer-generator/assets/css/offer-generator.css
@@ -1,3 +1,32 @@
 .algq-offer-generator { border: 1px solid #d7dee8; border-radius: 12px; padding: 1rem; max-width: 760px; }
 .algq-offer-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
 .algq-offer-card { background: #f8fafc; border-radius: 10px; padding: 1rem; }
+
+.algq-offer-document-tools {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid #d7c9a5;
+  border-radius: 16px;
+  background: #fffdf7;
+}
+
+.algq-offer-document-tools form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.algq-offer-document-tools input,
+.algq-offer-document-tools select,
+.algq-offer-document-tools textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.algq-navigation-overlay,
+.algq-pattern-offer-command {
+  border-radius: 20px;
+  padding: 24px;
+  background: linear-gradient(135deg, #111827, #3b2f12);
+  color: #fff7df;
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-audit-log.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-audit-log.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Audit_Log
+{
+    public function record(string $object_type, string $object_id, string $event_type, string $message = '', array $metadata = []): void
+    {
+        global $wpdb;
+
+        $user = wp_get_current_user();
+        $actor = $user && $user->exists() ? $user->user_login : 'system';
+
+        $wpdb->insert(
+            ALGQ_Offer_Database::audit_table(),
+            [
+                'object_type' => sanitize_key($object_type),
+                'object_id' => sanitize_text_field($object_id),
+                'event_type' => sanitize_key($event_type),
+                'actor' => sanitize_text_field($actor),
+                'message' => sanitize_textarea_field($message),
+                'metadata' => wp_json_encode($metadata),
+                'created_at' => current_time('mysql'),
+            ],
+            ['%s', '%s', '%s', '%s', '%s', '%s', '%s']
+        );
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function for_object(string $object_type, string $object_id, int $limit = 25): array
+    {
+        global $wpdb;
+        $limit = max(1, min(100, $limit));
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                'SELECT * FROM ' . ALGQ_Offer_Database::audit_table() . ' WHERE object_type = %s AND object_id = %s ORDER BY created_at DESC LIMIT %d',
+                sanitize_key($object_type),
+                sanitize_text_field($object_id),
+                $limit
+            ),
+            ARRAY_A
+        );
+
+        return array_map(static function (array $row): array {
+            $row['metadata'] = json_decode((string) ($row['metadata'] ?? '{}'), true) ?: [];
+            return $row;
+        }, $rows ?: []);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-connectors.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-connectors.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Connectors
+{
+    public function deal_payload(string $deal_id): array
+    {
+        global $wpdb;
+
+        $deal_id = sanitize_text_field($deal_id);
+        if ('' === $deal_id || !$this->table_exists('algq_deals')) {
+            return [];
+        }
+
+        $table = $wpdb->prefix . 'algq_deals';
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE deal_uid = %s OR id = %d", $deal_id, (int) $deal_id), ARRAY_A);
+        if (!$row) {
+            return [];
+        }
+
+        return [
+            'seller_name' => $row['seller_name'] ?? '',
+            'seller_email' => $row['seller_email'] ?? '',
+            'property_address' => $row['property_address'] ?? '',
+            'purchase_price' => isset($row['asking_price']) ? '$' . number_format((float) $row['asking_price'], 2) : '',
+            'deal_id' => $row['deal_uid'] ?? (string) ($row['id'] ?? ''),
+        ];
+    }
+
+    public function table_exists(string $table): bool
+    {
+        global $wpdb;
+        $full = $wpdb->prefix . sanitize_key($table);
+        return (string) $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $full)) === $full;
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-database.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-database.php
@@ -1,0 +1,130 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Database
+{
+    public const DOCUMENTS_TABLE = 'algq_offer_documents';
+    public const AUDIT_TABLE = 'algq_offer_audit_log';
+
+    public static function documents_table(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . self::DOCUMENTS_TABLE;
+    }
+
+    public static function audit_table(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . self::AUDIT_TABLE;
+    }
+
+    public static function activate(): void
+    {
+        global $wpdb;
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+        $documents = self::documents_table();
+        $audit = self::audit_table();
+
+        dbDelta("CREATE TABLE {$documents} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            document_uid varchar(48) NOT NULL,
+            deal_id varchar(64) DEFAULT '',
+            document_type varchar(80) NOT NULL DEFAULT 'loi',
+            title varchar(191) NOT NULL,
+            status varchar(40) NOT NULL DEFAULT 'draft',
+            merge_payload longtext NULL,
+            rendered_html longtext NULL,
+            pdf_checksum varchar(128) DEFAULT '',
+            signature_uid varchar(80) DEFAULT '',
+            created_by bigint(20) unsigned DEFAULT 0,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY document_uid (document_uid),
+            KEY deal_id (deal_id),
+            KEY document_type (document_type),
+            KEY status (status)
+        ) {$charset};");
+
+        dbDelta("CREATE TABLE {$audit} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            object_type varchar(80) NOT NULL,
+            object_id varchar(80) NOT NULL,
+            event_type varchar(100) NOT NULL,
+            actor varchar(191) DEFAULT '',
+            message text NULL,
+            metadata longtext NULL,
+            created_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY object_lookup (object_type, object_id),
+            KEY event_type (event_type),
+            KEY created_at (created_at)
+        ) {$charset};");
+    }
+
+    public function save_document(array $record): int
+    {
+        global $wpdb;
+
+        $now = current_time('mysql');
+        $uid = sanitize_text_field($record['document_uid'] ?? $this->generate_uid());
+        $payload = wp_json_encode($record['merge_payload'] ?? []);
+        $data = [
+            'document_uid' => $uid,
+            'deal_id' => sanitize_text_field($record['deal_id'] ?? ''),
+            'document_type' => sanitize_key($record['document_type'] ?? 'loi'),
+            'title' => sanitize_text_field($record['title'] ?? 'Untitled Offer Document'),
+            'status' => sanitize_key($record['status'] ?? 'draft'),
+            'merge_payload' => $payload,
+            'rendered_html' => wp_kses_post($record['rendered_html'] ?? ''),
+            'pdf_checksum' => sanitize_text_field($record['pdf_checksum'] ?? ''),
+            'signature_uid' => sanitize_text_field($record['signature_uid'] ?? ''),
+            'created_by' => (int) ($record['created_by'] ?? get_current_user_id()),
+            'updated_at' => $now,
+        ];
+
+        if (!empty($record['id'])) {
+            $wpdb->update(self::documents_table(), $data, ['id' => (int) $record['id']]);
+            return (int) $record['id'];
+        }
+
+        $data['created_at'] = $now;
+        $wpdb->insert(self::documents_table(), $data);
+        return (int) $wpdb->insert_id;
+    }
+
+    public function find_document(int $id): ?array
+    {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . self::documents_table() . ' WHERE id = %d', $id), ARRAY_A);
+        return $row ? $this->hydrate($row) : null;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function recent_documents(int $limit = 20): array
+    {
+        global $wpdb;
+        $limit = max(1, min(100, $limit));
+        $rows = $wpdb->get_results($wpdb->prepare('SELECT * FROM ' . self::documents_table() . ' ORDER BY updated_at DESC LIMIT %d', $limit), ARRAY_A);
+        return array_map([$this, 'hydrate'], $rows ?: []);
+    }
+
+    private function generate_uid(): string
+    {
+        return 'OFFER-' . gmdate('Ymd') . '-' . strtoupper(wp_generate_password(8, false, false));
+    }
+
+    private function hydrate(array $row): array
+    {
+        $row['id'] = (int) ($row['id'] ?? 0);
+        $row['merge_payload'] = json_decode((string) ($row['merge_payload'] ?? '{}'), true) ?: [];
+        return $row;
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-document-generator.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-document-generator.php
@@ -1,0 +1,47 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Document_Generator
+{
+    private ALGQ_Offer_Merge_Engine $merge_engine;
+
+    /** @var array<string,string> */
+    private array $templates = [
+        'loi' => '<h1>Letter of Intent</h1><p>{{buyer_name}} offers to purchase {{property_address}} from {{seller_name}} for {{purchase_price}}.</p><p>Earnest money: {{earnest_money}}. Closing date: {{closing_date}}.</p><p>{{offer_terms}}</p><p>Generated: {{generated_date}}</p>',
+        'purchase_agreement' => '<h1>Purchase Agreement Summary</h1><p>Buyer: {{buyer_name}}</p><p>Seller: {{seller_name}}</p><p>Property: {{property_address}}</p><p>Purchase price: {{purchase_price}}</p><p>Terms: {{offer_terms}}</p>',
+        'seller_financing' => '<h1>Seller Financing Sheet</h1><p>{{seller_name}} financing terms for {{property_address}}.</p><p>Price: {{purchase_price}}</p><p>{{offer_terms}}</p>',
+        'assignment_contract' => '<h1>Assignment Contract Summary</h1><p>Contract rights for {{property_address}} are prepared for assignment review.</p><p>{{offer_terms}}</p>',
+    ];
+
+    public function __construct(ALGQ_Offer_Merge_Engine $merge_engine)
+    {
+        $this->merge_engine = $merge_engine;
+    }
+
+    public function generate(string $document_type, array $payload): array
+    {
+        $document_type = sanitize_key($document_type);
+        $template = $this->templates[$document_type] ?? $this->templates['loi'];
+        $merged = $this->merge_engine->merge($template, $payload);
+
+        return [
+            'document_type' => $document_type,
+            'title' => $this->title_for($document_type),
+            'merge_payload' => $this->merge_engine->normalize($payload),
+            'rendered_html' => '<article class="algq-offer-document">' . wp_kses_post($merged) . '</article>',
+        ];
+    }
+
+    private function title_for(string $document_type): string
+    {
+        $titles = [
+            'loi' => __('Letter of Intent', 'algq-offer-generator'),
+            'purchase_agreement' => __('Purchase Agreement', 'algq-offer-generator'),
+            'seller_financing' => __('Seller Financing Sheet', 'algq-offer-generator'),
+            'assignment_contract' => __('Assignment Contract', 'algq-offer-generator'),
+        ];
+        return $titles[$document_type] ?? __('Offer Document', 'algq-offer-generator');
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-merge-engine.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-merge-engine.php
@@ -1,0 +1,64 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Merge_Engine
+{
+    /** @var array<string,string> */
+    private array $defaults = [
+        'seller_name' => 'Seller',
+        'buyer_name' => 'Algonquian Real Estate',
+        'property_address' => 'Property address pending',
+        'purchase_price' => '$0',
+        'earnest_money' => '$1,000',
+        'closing_date' => 'TBD',
+        'offer_terms' => 'Offer terms pending final review.',
+        'generated_date' => '',
+    ];
+
+    /**
+     * @return array<string,string>
+     */
+    public function normalize(array $input): array
+    {
+        $values = $this->defaults;
+        $values['generated_date'] = gmdate('Y-m-d');
+
+        foreach ($input as $key => $value) {
+            $key = sanitize_key((string) $key);
+            if ('' === $key) {
+                continue;
+            }
+            $values[$key] = is_scalar($value) ? sanitize_textarea_field((string) $value) : wp_json_encode($value);
+        }
+
+        return $values;
+    }
+
+    public function merge(string $template, array $payload): string
+    {
+        $payload = $this->normalize($payload);
+        foreach ($payload as $key => $value) {
+            $template = str_replace('{{' . $key . '}}', $value, $template);
+        }
+        return $template;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function field_labels(): array
+    {
+        return [
+            'seller_name' => __('Seller Name', 'algq-offer-generator'),
+            'buyer_name' => __('Buyer Name', 'algq-offer-generator'),
+            'property_address' => __('Property Address', 'algq-offer-generator'),
+            'purchase_price' => __('Purchase Price', 'algq-offer-generator'),
+            'earnest_money' => __('Earnest Money', 'algq-offer-generator'),
+            'closing_date' => __('Closing Date', 'algq-offer-generator'),
+            'offer_terms' => __('Offer Terms', 'algq-offer-generator'),
+            'generated_date' => __('Generated Date', 'algq-offer-generator'),
+        ];
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-pdf-engine.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-pdf-engine.php
@@ -1,0 +1,62 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_PDF_Engine
+{
+    public function render(array $document): string
+    {
+        if (class_exists('ALGQ_PDF_Signature_Renderer')) {
+            $renderer = new ALGQ_PDF_Signature_Renderer();
+            return $renderer->render_pdf_binary([
+                'title' => $document['title'] ?? 'Offer Document',
+                'document_uid' => $document['document_uid'] ?? '',
+                'document_type' => $document['document_type'] ?? 'offer',
+                'recipient_name' => $document['merge_payload']['seller_name'] ?? '',
+                'recipient_email' => $document['merge_payload']['seller_email'] ?? '',
+                'source_payload' => $document['merge_payload'] ?? [],
+                'status' => $document['status'] ?? 'draft',
+                'execution_status' => 'not_started',
+            ]);
+        }
+
+        return $this->fallback_pdf($document);
+    }
+
+    public function checksum(string $binary): string
+    {
+        return hash('sha256', $binary);
+    }
+
+    private function fallback_pdf(array $document): string
+    {
+        $title = wp_strip_all_tags((string) ($document['title'] ?? 'Offer Document'));
+        $body = wp_strip_all_tags((string) ($document['rendered_html'] ?? ''));
+        $content = "BT\n/F1 12 Tf\n72 740 Td\n(" . $this->escape($title) . ") Tj\n0 -24 Td\n(" . $this->escape(substr($body, 0, 900)) . ") Tj\nET\n";
+        $objects = [
+            '<< /Type /Catalog /Pages 2 0 R >>',
+            '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+            '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+            '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+            '<< /Length ' . strlen($content) . " >>\nstream\n" . $content . "endstream",
+        ];
+        $pdf = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $number => $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= ($number + 1) . " 0 obj\n" . $object . "\nendobj\n";
+        }
+        $xref = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n0000000000 65535 f \n";
+        for ($i = 1; $i <= count($objects); $i++) {
+            $pdf .= sprintf('%010d 00000 n ', $offsets[$i]) . "\n";
+        }
+        return $pdf . "trailer\n<< /Size " . (count($objects) + 1) . " /Root 1 0 R >>\nstartxref\n{$xref}\n%%EOF";
+    }
+
+    private function escape(string $text): string
+    {
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-offer-generator/includes/class-signature-engine.php
+++ b/algonquian-real-estate/plugins/algq-offer-generator/includes/class-signature-engine.php
@@ -1,0 +1,45 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Offer_Signature_Engine
+{
+    public function request_signature(array $document): array
+    {
+        if (class_exists('ALGQ_PDF_Signature_Repository') && class_exists('ALGQ_PDF_Signature_Renderer')) {
+            $repository = new ALGQ_PDF_Signature_Repository();
+            $renderer = new ALGQ_PDF_Signature_Renderer();
+            $payload = $document['merge_payload'] ?? [];
+            $id = $repository->create_document([
+                'title' => $document['title'] ?? 'Offer Document',
+                'document_type' => $document['document_type'] ?? 'offer',
+                'related_deal_id' => $document['deal_id'] ?? '',
+                'recipient_name' => $payload['seller_name'] ?? 'Seller',
+                'recipient_email' => $payload['seller_email'] ?? '',
+                'status' => 'sent',
+                'payload' => $payload,
+            ], (string) ($document['rendered_html'] ?? ''));
+
+            if ($id) {
+                $created = $repository->find((int) $id);
+                if ($created) {
+                    $pdf = $renderer->render_pdf_binary($created);
+                    return [
+                        'signature_id' => (int) $id,
+                        'signature_uid' => (string) $created['document_uid'],
+                        'pdf_checksum' => $renderer->checksum($pdf),
+                        'status' => 'sent',
+                    ];
+                }
+            }
+        }
+
+        return [
+            'signature_id' => 0,
+            'signature_uid' => 'LOCAL-' . strtoupper(wp_generate_password(10, false, false)),
+            'pdf_checksum' => '',
+            'status' => 'queued',
+        ];
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a foundation for generating offer documents (LOI, purchase agreements, seller-financing, assignment), persist them, produce checksummed PDFs, record audit events, and optionally hand off to the existing PDF signature engine. 
- Expose operational entry points for editors via WordPress Pattern API and a Navigation Overlay so the Offer Generator can be placed in site layouts. 
- Surface executive metrics via the Command Center REST endpoint and visual metrics dashboard for admin monitoring. 
- Harden plugin packaging CI to lint PHP before building archives and verify results.

### Description
- Added an Offer Generator integration including `class-database.php` and `class-audit-log.php` to store offer documents and audit events, and activation table creation via `dbDelta` (paths under `algq-offer-generator/includes/`).
- Implemented merge/document/PDF/signature/connectors engines as `class-merge-engine.php`, `class-document-generator.php`, `class-pdf-engine.php`, `class-signature-engine.php`, and `class-connectors.php` to normalize merge fields, produce HTML/PDF, checksum PDFs, and optionally request signatures using the `algq-pdf-signature` plugin when available.
- Bootstrapped the Offer Generator plugin (`algq-offer-generator.php`) with admin-post handling to generate documents, a document tools UI for administrators, recent-document listing, and registration of two block patterns using the WordPress Pattern API: `offer-command-center` and `navigation-overlay`.
- Extended the Digital Products plugin with a `Plugin Library UI` and new shortcodes (`algq_product_library`, `algq_plugin_library`) for product and module discovery.
- Added a metrics REST route and small visual metrics dashboard to the Command Center plugin at `algq/v1/command-center/metrics` and rendered an in-admin metrics bar dashboard (`algq-command-center` changes).
- Updated styling for the Offer Generator and new pattern surfaces and added CSS under `algq-offer-generator/assets/css/offer-generator.css`.
- Hardened `.github/workflows/build-plugin-zips.yml` to run PHP setup and syntax linting (`shivammathur/setup-php@v2` + `php -l`) and verify that plugin archives were produced before uploading.

### Testing
- Ran PHP syntax checks across the plugin tree with `find algonquian-real-estate/plugins -name '*.php' -print0 | xargs -0 -n1 php -l`, which reported no syntax errors.
- Executed the packaging script `bash algonquian-real-estate/scripts/build-plugin-zips.sh` to build plugin archives, and the script produced archives in `algonquian-real-estate/dist/` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3b393400832da4211e9ae4e22bf8)