### PR TITLE
Implement Algonquian Pipeline CRM WordPress plugin (MVP)

### DIFF
--- a/algonquian-real-estate/README.md
+++ b/algonquian-real-estate/README.md
@@ -8,7 +8,7 @@ This directory contains the modular WordPress plugin architecture for the Algonq
 | --- | --- | --- |
 | `algq-core` | Shared roles, permissions, database tables, REST namespace, settings, activity logging, notifications, licensing, UI primitives, and integration registry. | Scaffolded |
 | `algq-deal-intake` | Lead capture, validation, scoring, tagging, REST endpoints, and import/export workflows. | Scaffolded |
-| `algq-pipeline-crm` | Kanban pipeline, activity history, assignment, and audit trail workflows. | Scaffolded |
+| `algq-pipeline-crm` | Kanban pipeline, activity history, assignment, REST movement endpoints, and audit trail workflows. | Implemented |
 | `algq-mao-engine` | Maximum Allowable Offer calculations, scenario storage, REST endpoints, and shortcodes. | Scaffolded |
 | `algq-command-center` | KPI dashboard, pipeline value, deal counts, funding status, buyer activity, and reporting engine. | Scaffolded |
 | `algq-offer-generator` | LOI, purchase agreement, seller-financing, PDF, and merge-field workflows. | Scaffolded |
@@ -42,7 +42,7 @@ Version 1.0 targets the modules that move a lead from capture to monetization:
 - Deal Intake (`algq-deal-intake`) — seller/property capture, deal IDs, notifications, and admin review.
 - MAO Engine (`algq-mao-engine`) — ARV, rehab, assignment fee, max allowable offer, spread, and risk score.
 - Creative Offer Generator (`algq-offer-generator`) — seller-finance offer UI, amortization, legacy visualization, and document placeholders.
-- Pipeline CRM (`algq-pipeline-crm`) — Kanban stages and activity logging.
+- Pipeline CRM (`algq-pipeline-crm`) — Kanban stages, drag/drop REST movement, assignment, metrics, and activity logging.
 - Buyer Portal (`algq-buyer-portal`) — buyer registration profile, NDA acceptance, downloads, and interest tracking foundations.
 - Digital Product Store (`algq-digital-products`) — WooCommerce-aware product library shortcode and gated download foundations.
 - Product Vault (`algq-product-vault`) — protected product catalog, license-gated downloads, and training asset foundations.
@@ -92,6 +92,7 @@ bash algonquian-real-estate/scripts/build-plugin-zips.sh
 - `[algq_deal_intake]`
 - `[algq_mao_engine]`
 - `[algq_offer_generator]`
+- `[algq_pipeline_board]`
 - `[algq_pipeline_crm]`
 - `[algq_buyer_portal]`
 - `[algq_product_library]`
@@ -105,6 +106,10 @@ bash algonquian-real-estate/scripts/build-plugin-zips.sh
 - `[algq_license_status]`
 - `[algq_command_center]`
 - `[algq_marketplace]`
+
+## REST endpoint summary
+
+Pipeline CRM exposes `/wp-json/algq/v1/pipeline/deals`, `/wp-json/algq/v1/pipeline/deals/{id}`, `/wp-json/algq/v1/pipeline/deals/{id}/stage`, `/wp-json/algq/v1/pipeline/activity`, and `/wp-json/algq/v1/pipeline/metrics` for deal listing, detail, stage movement, activity, and metrics workflows.
 
 ## WPBakery usage
 

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/README.md
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/README.md
@@ -1,0 +1,103 @@
+# Algonquian Pipeline CRM
+
+Algonquian Pipeline CRM (`algq-pipeline-crm`) is the acquisition lifecycle CRM for the Algonquian Real Estate platform. It manages deals from lead capture through underwriting, offers, contract, buyer assignment, and close.
+
+## Installation
+
+1. Copy `algq-pipeline-crm` into `wp-content/plugins/`.
+2. Activate **Algonquian Pipeline CRM** from **Plugins** in WordPress Admin.
+3. On activation the plugin creates/updates its database tables, seeds default stages, and grants pipeline capabilities to administrators.
+4. Visit **Algonquian Pipeline CRM → Board** to view the Kanban pipeline.
+
+## Shortcodes
+
+- `[algq_pipeline_board]` — renders the Kanban board for users with `algq_view_pipeline`.
+- `[algq_pipeline_crm]` — backward-compatible alias for the same board.
+
+Shortcode output is buffered and never echoed directly from the shortcode callback.
+
+## REST Routes
+
+All routes are registered under `/wp-json/algq/v1/pipeline` and require the WordPress REST nonce (`X-WP-Nonce`) plus the relevant pipeline capability.
+
+| Route | Methods | Capability | Purpose |
+| --- | --- | --- | --- |
+| `/deals` | `GET` | `algq_view_pipeline` | List pipeline deals. |
+| `/deals` | `POST` | `algq_edit_deals` or `algq_manage_pipeline` | Create a deal and log `deal_created`. |
+| `/deals/(?P<id>\d+)` | `GET` | `algq_view_pipeline` | Retrieve a single deal. |
+| `/deals/(?P<id>\d+)` | `PUT/PATCH/POST` | `algq_edit_deals` or `algq_manage_pipeline` | Update editable deal fields. |
+| `/deals/(?P<id>\d+)/stage` | `POST` | `algq_edit_deals` or `algq_manage_pipeline` | Move a deal to a new stage and log `stage_changed`. |
+| `/activity` | `GET` | `algq_view_pipeline` | List recent activity. |
+| `/metrics` | `GET` | `algq_view_pipeline` | Return total, open, closed, and per-stage counts. |
+
+## Database Tables
+
+The plugin creates the following tables with `dbDelta` on activation:
+
+- `{$wpdb->prefix}algq_pipeline_deals`
+- `{$wpdb->prefix}algq_pipeline_stages`
+- `{$wpdb->prefix}algq_pipeline_activity`
+- `{$wpdb->prefix}algq_pipeline_notes`
+- `{$wpdb->prefix}algq_pipeline_assignments`
+
+## Default Stages
+
+| Key | Label |
+| --- | --- |
+| `lead_captured` | Lead Captured |
+| `underwriting` | Underwriting |
+| `offer_sent` | Offer Sent |
+| `under_contract` | Under Contract |
+| `buyer_assigned` | Buyer Assigned |
+| `closed` | Closed |
+
+## Capabilities
+
+The following custom capabilities are created for administrators on activation:
+
+- `algq_view_pipeline`
+- `algq_manage_pipeline`
+- `algq_edit_deals`
+- `algq_assign_deals`
+- `algq_close_deals`
+
+## Activity Logging
+
+The activity table records important lifecycle events, including:
+
+- Deal created
+- Stage changed
+- Assigned user changed
+- Note added
+- Offer generated
+- Underwriting updated
+- Buyer assigned
+- Deal closed
+
+## Integration Hooks
+
+### Actions Fired
+
+- `do_action('algq_pipeline_deal_created', $deal_id, $deal)`
+- `do_action('algq_pipeline_stage_changed', $deal_id, $old_stage, $new_stage)`
+- `do_action('algq_pipeline_deal_closed', $deal_id)`
+
+### Actions Listened For
+
+- `algq_deal_intake_created`
+- `algq_mao_underwriting_saved`
+- `algq_offer_generated`
+- `algq_buyer_assigned`
+- `algq_funding_status_updated`
+
+## Testing Instructions
+
+From the repository root run:
+
+```bash
+find algonquian-real-estate/plugins/algq-pipeline-crm -name '*.php' -print0 | xargs -0 -n1 php -l
+npm run check
+bash algonquian-real-estate/scripts/build-plugin-zips.sh
+```
+
+`npm run check` depends on the JavaScript application dependencies at the repository root. The plugin zip build writes packages to `algonquian-real-estate/deployment/plugin-zips/`.

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/activity.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/activity.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Activity view.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap algq-pipeline-wrap">
+    <h1><?php esc_html_e('Pipeline Activity', 'algq-pipeline-crm'); ?></h1>
+    <table class="widefat striped">
+        <thead><tr><th><?php esc_html_e('Time', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Deal', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Type', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Note', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Change', 'algq-pipeline-crm'); ?></th></tr></thead>
+        <tbody>
+        <?php foreach ($activity as $item) : ?>
+            <tr>
+                <td><?php echo esc_html((string) $item['created_at']); ?></td>
+                <td>#<?php echo esc_html((string) $item['deal_id']); ?></td>
+                <td><code><?php echo esc_html((string) $item['activity_type']); ?></code></td>
+                <td><?php echo esc_html((string) $item['activity_note']); ?></td>
+                <td><?php echo esc_html(trim((string) $item['old_value'] . ' → ' . (string) $item['new_value'], ' →')); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        <?php if ([] === $activity) : ?>
+            <tr><td colspan="5"><?php esc_html_e('No activity has been logged yet.', 'algq-pipeline-crm'); ?></td></tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/board.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/board.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Pipeline board view.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="algq-pipeline-board" data-algq-pipeline-board>
+    <?php foreach ($stages as $stage) : ?>
+        <?php
+        $stage_key = (string) $stage['stage_key'];
+        $stage_deals = $grouped_deals[$stage_key] ?? [];
+        ?>
+        <section class="algq-pipeline-column" data-stage-key="<?php echo esc_attr($stage_key); ?>">
+            <header class="algq-pipeline-column__header">
+                <h2><?php echo esc_html((string) $stage['stage_label']); ?></h2>
+                <span class="algq-pipeline-count" data-stage-count><?php echo esc_html((string) count($stage_deals)); ?></span>
+            </header>
+            <div class="algq-pipeline-dropzone" data-stage-key="<?php echo esc_attr($stage_key); ?>">
+                <?php foreach ($stage_deals as $deal) : ?>
+                    <article class="algq-pipeline-card" draggable="true" data-deal-id="<?php echo esc_attr((string) $deal['id']); ?>">
+                        <div class="algq-pipeline-card__topline">
+                            <strong><?php echo esc_html(sprintf(__('Deal #%d', 'algq-pipeline-crm'), absint($deal['id']))); ?></strong>
+                            <span class="algq-pipeline-priority algq-pipeline-priority--<?php echo esc_attr((string) $deal['priority']); ?>"><?php echo esc_html(ucfirst((string) $deal['priority'])); ?></span>
+                        </div>
+                        <h3><?php echo esc_html((string) $deal['property_address']); ?></h3>
+                        <dl class="algq-pipeline-card__meta">
+                            <div><dt><?php esc_html_e('Seller', 'algq-pipeline-crm'); ?></dt><dd><?php echo esc_html((string) $deal['seller_name']); ?></dd></div>
+                            <div><dt><?php esc_html_e('Assigned', 'algq-pipeline-crm'); ?></dt><dd><?php echo esc_html($this->get_assigned_user_name($deal)); ?></dd></div>
+                            <div><dt><?php esc_html_e('Days in stage', 'algq-pipeline-crm'); ?></dt><dd><?php echo esc_html((string) $this->get_days_in_stage($deal)); ?></dd></div>
+                            <div><dt><?php esc_html_e('Asking', 'algq-pipeline-crm'); ?></dt><dd><?php echo esc_html($this->format_money($deal['asking_price'])); ?></dd></div>
+                            <?php if ('' !== (string) $deal['estimated_arv'] && null !== $deal['estimated_arv']) : ?>
+                                <div><dt><?php esc_html_e('ARV', 'algq-pipeline-crm'); ?></dt><dd><?php echo esc_html($this->format_money($deal['estimated_arv'])); ?></dd></div>
+                            <?php endif; ?>
+                        </dl>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+    <?php endforeach; ?>
+</div>

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/deal-detail.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/deal-detail.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Deal detail view.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap algq-pipeline-wrap">
+    <h1><?php esc_html_e('Deal Detail', 'algq-pipeline-crm'); ?></h1>
+    <?php if (!$deal) : ?>
+        <p><?php esc_html_e('Deal not found.', 'algq-pipeline-crm'); ?></p>
+    <?php else : ?>
+        <table class="widefat striped algq-pipeline-detail-table">
+            <tbody>
+                <tr><th><?php esc_html_e('Deal ID', 'algq-pipeline-crm'); ?></th><td>#<?php echo esc_html((string) $deal['id']); ?></td></tr>
+                <tr><th><?php esc_html_e('Property Address', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['property_address']); ?></td></tr>
+                <tr><th><?php esc_html_e('Seller', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['seller_name']); ?></td></tr>
+                <tr><th><?php esc_html_e('Stage', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['stage_key']); ?></td></tr>
+                <tr><th><?php esc_html_e('Priority', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['priority']); ?></td></tr>
+                <tr><th><?php esc_html_e('Asking Price', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html($this->board->format_money($deal['asking_price'])); ?></td></tr>
+                <tr><th><?php esc_html_e('Estimated ARV', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html($this->board->format_money($deal['estimated_arv'])); ?></td></tr>
+                <tr><th><?php esc_html_e('Created', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['created_at']); ?></td></tr>
+                <tr><th><?php esc_html_e('Updated', 'algq-pipeline-crm'); ?></th><td><?php echo esc_html((string) $deal['updated_at']); ?></td></tr>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</div>

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/settings.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/admin/views/settings.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Settings view.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap algq-pipeline-wrap">
+    <h1><?php esc_html_e('Pipeline Settings', 'algq-pipeline-crm'); ?></h1>
+    <p><?php esc_html_e('Default acquisition stages are managed automatically for this MVP.', 'algq-pipeline-crm'); ?></p>
+    <h2><?php esc_html_e('Default Stages', 'algq-pipeline-crm'); ?></h2>
+    <table class="widefat striped">
+        <thead><tr><th><?php esc_html_e('Key', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Label', 'algq-pipeline-crm'); ?></th><th><?php esc_html_e('Order', 'algq-pipeline-crm'); ?></th></tr></thead>
+        <tbody>
+        <?php foreach ($stages as $stage) : ?>
+            <tr><td><code><?php echo esc_html((string) $stage['stage_key']); ?></code></td><td><?php echo esc_html((string) $stage['stage_label']); ?></td><td><?php echo esc_html((string) $stage['stage_order']); ?></td></tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/algq-pipeline-crm.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/algq-pipeline-crm.php
@@ -1,100 +1,32 @@
 <?php
 /**
  * Plugin Name: Algonquian Pipeline CRM
- * Description: Deal Kanban board, stage movement foundation, and activity logging.
- * Version: 0.1.0
- * Author: Algonquian Real Estate
- * Requires Plugins: algq-core
+ * Description: Production-ready acquisition lifecycle CRM for managing deals from lead capture through close.
+ * Version: 1.0.0
+ * Author: Onegodian
+ * Text Domain: algq-pipeline-crm
  */
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
+define('ALGQ_PIPELINE_CRM_VERSION', '1.0.0');
+define('ALGQ_PIPELINE_CRM_FILE', __FILE__);
+define('ALGQ_PIPELINE_CRM_DIR', plugin_dir_path(__FILE__));
+define('ALGQ_PIPELINE_CRM_URL', plugin_dir_url(__FILE__));
 
-function algq_pipeline_crm_core_available(): bool
-{
-    if (function_exists('algq_core')) {
-        return true;
-    }
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-database.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-activity.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-activator.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-board.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-rest-controller.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-admin.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-integrations.php';
+require_once ALGQ_PIPELINE_CRM_DIR . 'includes/class-algq-pipeline-crm.php';
 
-    add_action('admin_notices', static function (): void {
-        echo '<div class="notice notice-error"><p>' . esc_html__('Algonquian Pipeline CRM requires the Algonquian Core plugin to be active.', 'algq-pipeline-crm') . '</p></div>';
-    });
+register_activation_hook(__FILE__, ['ALGQ_Pipeline_Activator', 'activate']);
 
-    return false;
-}
-
-final class ALGQ_Pipeline_CRM
-{
-    private const ACTIVITY_TABLE = 'algq_activity_log';
-    private const STAGES = ['Lead Captured', 'Underwriting', 'Offer Sent', 'Under Contract', 'Buyer Assigned', 'Closed'];
-
-    public function __construct()
-    {
-        add_shortcode('algq_pipeline_crm', [$this, 'render_board']);
-        add_action('wp_ajax_algq_move_deal_stage', [$this, 'move_stage']);
-    }
-
-    public static function activate(): void
-    {
-        global $wpdb;
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta("CREATE TABLE {$wpdb->prefix}" . self::ACTIVITY_TABLE . " (
-            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-            deal_id varchar(32) NOT NULL,
-            activity_type varchar(64) NOT NULL,
-            activity_note text NOT NULL,
-            created_at datetime NOT NULL,
-            PRIMARY KEY (id),
-            KEY deal_id (deal_id)
-        ) {$wpdb->get_charset_collate()};");
-    }
-
-    public function render_board(): string
-    {
-        ob_start();
-        echo '<div class="algq-kanban">';
-        foreach (self::STAGES as $stage) {
-            echo '<section class="algq-kanban-stage" data-stage="' . esc_attr($stage) . '"><h3>' . esc_html($stage) . '</h3><p>Drag-and-drop deal cards will appear here.</p></section>';
-        }
-        echo '</div>';
-        return (string) ob_get_clean();
-    }
-
-    public function move_stage(): void
-    {
-        check_ajax_referer('algq_pipeline_move', 'nonce');
-        $deal_id = sanitize_text_field(wp_unslash($_POST['deal_id'] ?? ''));
-        $stage = sanitize_text_field(wp_unslash($_POST['stage'] ?? ''));
-        if (!in_array($stage, self::STAGES, true)) {
-            wp_send_json_error(['message' => 'Invalid stage'], 400);
-        }
-        $this->log_activity($deal_id, 'stage_moved', 'Moved to ' . $stage);
-        wp_send_json_success(['stage' => $stage]);
-    }
-
-    private function log_activity(string $deal_id, string $type, string $note): void
-    {
-        if (function_exists('algq_core')) {
-            algq_core()->activity()->log($type, $note, [
-                'object_type' => 'deal',
-                'object_id' => $deal_id,
-                'deal_id' => $deal_id,
-            ]);
-            return;
-        }
-
-        global $wpdb;
-        $wpdb->insert($wpdb->prefix . self::ACTIVITY_TABLE, ['deal_id' => $deal_id, 'activity_type' => $type, 'activity_note' => $note, 'created_at' => current_time('mysql')], ['%s', '%s', '%s', '%s']);
-    }
-}
-
-register_activation_hook(__FILE__, ['ALGQ_Pipeline_CRM', 'activate']);
 add_action('plugins_loaded', static function (): void {
-    if (!algq_pipeline_crm_core_available()) {
-        return;
-    }
-
-    new ALGQ_Pipeline_CRM();
+    ALGQ_Pipeline_CRM::instance()->run();
 });

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/assets/css/pipeline-crm.css
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/assets/css/pipeline-crm.css
@@ -1,0 +1,128 @@
+.algq-pipeline-wrap {
+  max-width: 100%;
+}
+
+.algq-pipeline-board {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(240px, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+  overflow-x: auto;
+  padding-bottom: 16px;
+}
+
+.algq-pipeline-column {
+  background: #f6f7f7;
+  border: 1px solid #dcdcde;
+  border-radius: 10px;
+  min-width: 240px;
+}
+
+.algq-pipeline-column__header {
+  align-items: center;
+  border-bottom: 1px solid #dcdcde;
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 14px;
+}
+
+.algq-pipeline-column__header h2 {
+  font-size: 15px;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.algq-pipeline-count {
+  background: #1d2327;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-block;
+  font-size: 12px;
+  min-width: 24px;
+  padding: 3px 8px;
+  text-align: center;
+}
+
+.algq-pipeline-dropzone {
+  min-height: 180px;
+  padding: 12px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.algq-pipeline-dropzone.is-drag-over {
+  background: #e7f5ff;
+}
+
+.algq-pipeline-card {
+  background: #fff;
+  border: 1px solid #c3c4c7;
+  border-left: 4px solid #2271b1;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  cursor: grab;
+  margin-bottom: 12px;
+  padding: 12px;
+}
+
+.algq-pipeline-card.is-dragging {
+  opacity: 0.5;
+}
+
+.algq-pipeline-card h3 {
+  font-size: 14px;
+  margin: 8px 0 10px;
+}
+
+.algq-pipeline-card__topline {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.algq-pipeline-priority {
+  background: #f0f0f1;
+  border-radius: 999px;
+  font-size: 11px;
+  padding: 2px 7px;
+}
+
+.algq-pipeline-priority--high,
+.algq-pipeline-priority--urgent {
+  background: #d63638;
+  color: #fff;
+}
+
+.algq-pipeline-card__meta {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.algq-pipeline-card__meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.algq-pipeline-card__meta dt {
+  color: #646970;
+  font-size: 12px;
+}
+
+.algq-pipeline-card__meta dd {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0;
+  text-align: right;
+}
+
+.algq-pipeline-detail-table th {
+  width: 200px;
+}
+
+@media (max-width: 1200px) {
+  .algq-pipeline-board {
+    grid-template-columns: repeat(3, minmax(240px, 1fr));
+  }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/assets/js/pipeline-crm.js
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/assets/js/pipeline-crm.js
@@ -1,0 +1,110 @@
+(function () {
+  'use strict';
+
+  function closestCard(target) {
+    return target && target.closest ? target.closest('.algq-pipeline-card') : null;
+  }
+
+  function updateCounts(board) {
+    board.querySelectorAll('.algq-pipeline-column').forEach(function (column) {
+      var count = column.querySelectorAll('.algq-pipeline-card').length;
+      var counter = column.querySelector('[data-stage-count]');
+      if (counter) {
+        counter.textContent = String(count);
+      }
+    });
+  }
+
+  function postStageChange(dealId, stageKey) {
+    return fetch(algqPipelineCRM.restUrl + '/deals/' + encodeURIComponent(dealId) + '/stage', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': algqPipelineCRM.nonce
+      },
+      body: JSON.stringify({ stage_key: stageKey })
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error('Stage update failed');
+      }
+      return response.json();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof algqPipelineCRM === 'undefined') {
+      return;
+    }
+
+    document.querySelectorAll('[data-algq-pipeline-board]').forEach(function (board) {
+      var draggedCard = null;
+      var sourceZone = null;
+
+      board.addEventListener('dragstart', function (event) {
+        var card = closestCard(event.target);
+        if (!card || !algqPipelineCRM.canEdit) {
+          event.preventDefault();
+          return;
+        }
+
+        draggedCard = card;
+        sourceZone = card.closest('.algq-pipeline-dropzone');
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', card.dataset.dealId);
+        card.classList.add('is-dragging');
+      });
+
+      board.addEventListener('dragend', function () {
+        if (draggedCard) {
+          draggedCard.classList.remove('is-dragging');
+        }
+        board.querySelectorAll('.is-drag-over').forEach(function (zone) {
+          zone.classList.remove('is-drag-over');
+        });
+        draggedCard = null;
+        sourceZone = null;
+      });
+
+      board.addEventListener('dragover', function (event) {
+        var zone = event.target.closest('.algq-pipeline-dropzone');
+        if (!zone || !draggedCard || !algqPipelineCRM.canEdit) {
+          return;
+        }
+        event.preventDefault();
+        zone.classList.add('is-drag-over');
+      });
+
+      board.addEventListener('dragleave', function (event) {
+        var zone = event.target.closest('.algq-pipeline-dropzone');
+        if (zone) {
+          zone.classList.remove('is-drag-over');
+        }
+      });
+
+      board.addEventListener('drop', function (event) {
+        var zone = event.target.closest('.algq-pipeline-dropzone');
+        if (!zone || !draggedCard || !algqPipelineCRM.canEdit) {
+          return;
+        }
+
+        event.preventDefault();
+        zone.classList.remove('is-drag-over');
+
+        var dealId = draggedCard.dataset.dealId;
+        var newStage = zone.dataset.stageKey;
+        var originalZone = sourceZone;
+        zone.appendChild(draggedCard);
+        updateCounts(board);
+
+        postStageChange(dealId, newStage).catch(function () {
+          if (originalZone) {
+            originalZone.appendChild(draggedCard);
+            updateCounts(board);
+          }
+          window.alert(algqPipelineCRM.messages.moveFailed);
+        });
+      });
+    });
+  });
+}());

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-activator.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-activator.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Activation routines for Pipeline CRM.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Activator
+{
+    public static function activate(): void
+    {
+        $database = new ALGQ_Pipeline_Database();
+        $database->create_tables();
+        $database->seed_default_stages();
+        self::add_capabilities();
+        update_option('algq_pipeline_crm_version', ALGQ_PIPELINE_CRM_VERSION);
+    }
+
+    private static function add_capabilities(): void
+    {
+        $capabilities = [
+            'algq_view_pipeline',
+            'algq_manage_pipeline',
+            'algq_edit_deals',
+            'algq_assign_deals',
+            'algq_close_deals',
+        ];
+
+        $roles = ['administrator'];
+        foreach ($roles as $role_name) {
+            $role = get_role($role_name);
+            if (!$role) {
+                continue;
+            }
+
+            foreach ($capabilities as $capability) {
+                $role->add_cap($capability);
+            }
+        }
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-activity.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-activity.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Activity logging for Pipeline CRM.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Activity
+{
+    private ALGQ_Pipeline_Database $database;
+
+    public function __construct(ALGQ_Pipeline_Database $database)
+    {
+        $this->database = $database;
+    }
+
+    public function log(int $deal_id, string $type, string $note, string $old_value = '', string $new_value = '', array $metadata = []): int
+    {
+        global $wpdb;
+
+        $type = sanitize_key($type);
+        $note = sanitize_textarea_field($note);
+        $old_value = sanitize_text_field($old_value);
+        $new_value = sanitize_text_field($new_value);
+        $metadata_json = [] === $metadata ? null : wp_json_encode($metadata);
+
+        $inserted = $wpdb->insert(
+            $this->database->get_table_name(ALGQ_Pipeline_Database::ACTIVITY_TABLE),
+            [
+                'deal_id' => absint($deal_id),
+                'activity_type' => $type,
+                'activity_note' => $note,
+                'actor_user_id' => get_current_user_id(),
+                'old_value' => $old_value,
+                'new_value' => $new_value,
+                'metadata' => $metadata_json,
+                'created_at' => current_time('mysql'),
+            ],
+            ['%d', '%s', '%s', '%d', '%s', '%s', '%s', '%s']
+        );
+
+        return false === $inserted ? 0 : (int) $wpdb->insert_id;
+    }
+
+    public function note_added(int $deal_id, string $note): int
+    {
+        return $this->log($deal_id, 'note_added', $note);
+    }
+
+    public function assigned_user_changed(int $deal_id, int $old_user_id, int $new_user_id): int
+    {
+        return $this->log($deal_id, 'assigned_user_changed', __('Assigned user changed.', 'algq-pipeline-crm'), (string) $old_user_id, (string) $new_user_id);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-admin.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-admin.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Admin UI for Pipeline CRM.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Admin
+{
+    private ALGQ_Pipeline_Database $database;
+    private ALGQ_Pipeline_Board $board;
+    private string $hook_suffix = '';
+
+    public function __construct(ALGQ_Pipeline_Database $database, ALGQ_Pipeline_Board $board)
+    {
+        $this->database = $database;
+        $this->board = $board;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('admin_menu', [$this, 'register_admin_menu']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+    }
+
+    public function register_admin_menu(): void
+    {
+        $this->hook_suffix = add_menu_page(
+            __('Algonquian Pipeline CRM', 'algq-pipeline-crm'),
+            __('Algonquian Pipeline CRM', 'algq-pipeline-crm'),
+            'algq_view_pipeline',
+            'algq-pipeline-crm',
+            [$this, 'render_board_page'],
+            'dashicons-networking',
+            26
+        );
+
+        add_submenu_page('algq-pipeline-crm', __('Board', 'algq-pipeline-crm'), __('Board', 'algq-pipeline-crm'), 'algq_view_pipeline', 'algq-pipeline-crm', [$this, 'render_board_page']);
+        add_submenu_page('algq-pipeline-crm', __('Deals', 'algq-pipeline-crm'), __('Deals', 'algq-pipeline-crm'), 'algq_view_pipeline', 'algq-pipeline-deals', [$this, 'render_deals_page']);
+        add_submenu_page('algq-pipeline-crm', __('Activity', 'algq-pipeline-crm'), __('Activity', 'algq-pipeline-crm'), 'algq_view_pipeline', 'algq-pipeline-activity', [$this, 'render_activity_page']);
+        add_submenu_page('algq-pipeline-crm', __('Settings', 'algq-pipeline-crm'), __('Settings', 'algq-pipeline-crm'), 'algq_manage_pipeline', 'algq-pipeline-settings', [$this, 'render_settings_page']);
+    }
+
+    public function enqueue_assets(string $hook): void
+    {
+        if (false === strpos($hook, 'algq-pipeline')) {
+            return;
+        }
+
+        wp_enqueue_style('algq-pipeline-crm', ALGQ_PIPELINE_CRM_URL . 'assets/css/pipeline-crm.css', [], ALGQ_PIPELINE_CRM_VERSION);
+        wp_enqueue_script('algq-pipeline-crm', ALGQ_PIPELINE_CRM_URL . 'assets/js/pipeline-crm.js', [], ALGQ_PIPELINE_CRM_VERSION, true);
+        wp_localize_script('algq-pipeline-crm', 'algqPipelineCRM', [
+            'restUrl' => esc_url_raw(rest_url('algq/v1/pipeline')),
+            'nonce' => wp_create_nonce('wp_rest'),
+            'canEdit' => current_user_can('algq_edit_deals') || current_user_can('algq_manage_pipeline'),
+            'messages' => [
+                'moveFailed' => __('Unable to move deal. Please refresh and try again.', 'algq-pipeline-crm'),
+            ],
+        ]);
+    }
+
+    public function render_board_page(): void
+    {
+        if (!current_user_can('algq_view_pipeline')) {
+            wp_die(esc_html__('You do not have permission to view this page.', 'algq-pipeline-crm'));
+        }
+
+        echo '<div class="wrap algq-pipeline-wrap"><h1>' . esc_html__('Algonquian Pipeline CRM', 'algq-pipeline-crm') . '</h1>';
+        $this->board->render(true);
+        echo '</div>';
+    }
+
+    public function render_deals_page(): void
+    {
+        if (!current_user_can('algq_view_pipeline')) {
+            wp_die(esc_html__('You do not have permission to view this page.', 'algq-pipeline-crm'));
+        }
+
+        $deal_id = isset($_GET['deal_id']) ? absint($_GET['deal_id']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ($deal_id > 0) {
+            $deal = $this->database->get_deal($deal_id);
+            include ALGQ_PIPELINE_CRM_DIR . 'admin/views/deal-detail.php';
+            return;
+        }
+
+        $deals = $this->database->get_deals(['limit' => 300]);
+        echo '<div class="wrap algq-pipeline-wrap"><h1>' . esc_html__('Pipeline Deals', 'algq-pipeline-crm') . '</h1>';
+        echo '<table class="widefat striped"><thead><tr><th>' . esc_html__('Deal ID', 'algq-pipeline-crm') . '</th><th>' . esc_html__('Property', 'algq-pipeline-crm') . '</th><th>' . esc_html__('Seller', 'algq-pipeline-crm') . '</th><th>' . esc_html__('Stage', 'algq-pipeline-crm') . '</th><th>' . esc_html__('Priority', 'algq-pipeline-crm') . '</th><th>' . esc_html__('Updated', 'algq-pipeline-crm') . '</th></tr></thead><tbody>';
+        foreach ($deals as $deal) {
+            $url = add_query_arg(['page' => 'algq-pipeline-deals', 'deal_id' => absint($deal['id'])], admin_url('admin.php'));
+            echo '<tr><td><a href="' . esc_url($url) . '">#' . esc_html((string) $deal['id']) . '</a></td><td>' . esc_html((string) $deal['property_address']) . '</td><td>' . esc_html((string) $deal['seller_name']) . '</td><td>' . esc_html((string) $deal['stage_key']) . '</td><td>' . esc_html((string) $deal['priority']) . '</td><td>' . esc_html((string) $deal['updated_at']) . '</td></tr>';
+        }
+        if ([] === $deals) {
+            echo '<tr><td colspan="6">' . esc_html__('No deals found yet.', 'algq-pipeline-crm') . '</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function render_activity_page(): void
+    {
+        if (!current_user_can('algq_view_pipeline')) {
+            wp_die(esc_html__('You do not have permission to view this page.', 'algq-pipeline-crm'));
+        }
+
+        $activity = $this->database->get_activity(['limit' => 200]);
+        include ALGQ_PIPELINE_CRM_DIR . 'admin/views/activity.php';
+    }
+
+    public function render_settings_page(): void
+    {
+        if (!current_user_can('algq_manage_pipeline')) {
+            wp_die(esc_html__('You do not have permission to view this page.', 'algq-pipeline-crm'));
+        }
+
+        $stages = $this->database->get_stages();
+        include ALGQ_PIPELINE_CRM_DIR . 'admin/views/settings.php';
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-board.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-board.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Kanban board renderer.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Board
+{
+    private ALGQ_Pipeline_Database $database;
+
+    public function __construct(ALGQ_Pipeline_Database $database)
+    {
+        $this->database = $database;
+    }
+
+    public function render(bool $echo = true): string
+    {
+        $this->enqueue_assets();
+        $stages = $this->database->get_stages();
+        $deals = $this->database->get_deals(['limit' => 500]);
+        $grouped_deals = [];
+
+        foreach ($deals as $deal) {
+            $grouped_deals[(string) $deal['stage_key']][] = $deal;
+        }
+
+        ob_start();
+        include ALGQ_PIPELINE_CRM_DIR . 'admin/views/board.php';
+        $html = (string) ob_get_clean();
+
+        if ($echo) {
+            echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- View escapes dynamic values.
+        }
+
+        return $html;
+    }
+
+    public function get_days_in_stage(array $deal): int
+    {
+        $changed_at = !empty($deal['stage_changed_at']) ? strtotime((string) $deal['stage_changed_at']) : false;
+        if (!$changed_at) {
+            return 0;
+        }
+
+        return max(0, (int) floor((current_time('timestamp') - $changed_at) / DAY_IN_SECONDS));
+    }
+
+    public function get_assigned_user_name(array $deal): string
+    {
+        $user_id = isset($deal['assigned_user_id']) ? absint($deal['assigned_user_id']) : 0;
+        if ($user_id < 1) {
+            return __('Unassigned', 'algq-pipeline-crm');
+        }
+
+        $user = get_userdata($user_id);
+        return $user ? $user->display_name : __('Unknown user', 'algq-pipeline-crm');
+    }
+
+    public function format_money($value): string
+    {
+        if (null === $value || '' === $value) {
+            return '—';
+        }
+
+        return '$' . number_format_i18n((float) $value, 0);
+    }
+
+    private function enqueue_assets(): void
+    {
+        wp_enqueue_style('algq-pipeline-crm', ALGQ_PIPELINE_CRM_URL . 'assets/css/pipeline-crm.css', [], ALGQ_PIPELINE_CRM_VERSION);
+        wp_enqueue_script('algq-pipeline-crm', ALGQ_PIPELINE_CRM_URL . 'assets/js/pipeline-crm.js', [], ALGQ_PIPELINE_CRM_VERSION, true);
+        wp_localize_script('algq-pipeline-crm', 'algqPipelineCRM', [
+            'restUrl' => esc_url_raw(rest_url('algq/v1/pipeline')),
+            'nonce' => wp_create_nonce('wp_rest'),
+            'canEdit' => current_user_can('algq_edit_deals') || current_user_can('algq_manage_pipeline'),
+            'messages' => [
+                'moveFailed' => __('Unable to move deal. Please refresh and try again.', 'algq-pipeline-crm'),
+            ],
+        ]);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-crm.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-crm.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Main Pipeline CRM plugin class.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class ALGQ_Pipeline_CRM
+{
+    private static ?ALGQ_Pipeline_CRM $instance = null;
+    private ALGQ_Pipeline_Database $database;
+    private ALGQ_Pipeline_Activity $activity;
+    private ALGQ_Pipeline_Board $board;
+    private ALGQ_Pipeline_REST_Controller $rest_controller;
+    private ALGQ_Pipeline_Admin $admin;
+    private ALGQ_Pipeline_Integrations $integrations;
+
+    private function __construct()
+    {
+        $this->database = new ALGQ_Pipeline_Database();
+        $this->activity = new ALGQ_Pipeline_Activity($this->database);
+        $this->board = new ALGQ_Pipeline_Board($this->database);
+        $this->rest_controller = new ALGQ_Pipeline_REST_Controller($this->database, $this->activity);
+        $this->admin = new ALGQ_Pipeline_Admin($this->database, $this->board);
+        $this->integrations = new ALGQ_Pipeline_Integrations($this->database, $this->activity);
+    }
+
+    public static function instance(): ALGQ_Pipeline_CRM
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function run(): void
+    {
+        add_action('init', [$this, 'register_shortcodes']);
+        add_action('rest_api_init', [$this->rest_controller, 'register_routes']);
+        $this->admin->register_hooks();
+        $this->integrations->register_hooks();
+    }
+
+    public function register_shortcodes(): void
+    {
+        add_shortcode('algq_pipeline_board', [$this, 'render_board_shortcode']);
+        add_shortcode('algq_pipeline_crm', [$this, 'render_board_shortcode']);
+    }
+
+    public function render_board_shortcode(): string
+    {
+        if (!current_user_can('algq_view_pipeline')) {
+            return '<p class="algq-pipeline-message">' . esc_html__('You do not have permission to view the pipeline board.', 'algq-pipeline-crm') . '</p>';
+        }
+
+        ob_start();
+        $this->board->render(false);
+        return (string) ob_get_clean();
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-database.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-database.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Database access layer for Algonquian Pipeline CRM.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Database
+{
+    public const DEALS_TABLE = 'algq_pipeline_deals';
+    public const STAGES_TABLE = 'algq_pipeline_stages';
+    public const ACTIVITY_TABLE = 'algq_pipeline_activity';
+    public const NOTES_TABLE = 'algq_pipeline_notes';
+    public const ASSIGNMENTS_TABLE = 'algq_pipeline_assignments';
+
+    public const DEFAULT_STAGES = [
+        'lead_captured' => 'Lead Captured',
+        'underwriting' => 'Underwriting',
+        'offer_sent' => 'Offer Sent',
+        'under_contract' => 'Under Contract',
+        'buyer_assigned' => 'Buyer Assigned',
+        'closed' => 'Closed',
+    ];
+
+    public function get_table_name(string $table): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . $table;
+    }
+
+    public function create_tables(): void
+    {
+        global $wpdb;
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset_collate = $wpdb->get_charset_collate();
+        $deals = $this->get_table_name(self::DEALS_TABLE);
+        $stages = $this->get_table_name(self::STAGES_TABLE);
+        $activity = $this->get_table_name(self::ACTIVITY_TABLE);
+        $notes = $this->get_table_name(self::NOTES_TABLE);
+        $assignments = $this->get_table_name(self::ASSIGNMENTS_TABLE);
+
+        dbDelta("CREATE TABLE {$stages} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            stage_key varchar(64) NOT NULL,
+            stage_label varchar(191) NOT NULL,
+            stage_order int(11) NOT NULL DEFAULT 0,
+            is_closed tinyint(1) NOT NULL DEFAULT 0,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY stage_key (stage_key),
+            KEY stage_order (stage_order)
+        ) {$charset_collate};");
+
+        dbDelta("CREATE TABLE {$deals} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            external_id varchar(64) DEFAULT '',
+            stage_key varchar(64) NOT NULL DEFAULT 'lead_captured',
+            property_address text NOT NULL,
+            seller_name varchar(191) NOT NULL DEFAULT '',
+            seller_email varchar(191) DEFAULT '',
+            seller_phone varchar(64) DEFAULT '',
+            priority varchar(32) NOT NULL DEFAULT 'normal',
+            assigned_user_id bigint(20) unsigned DEFAULT 0,
+            asking_price decimal(14,2) DEFAULT NULL,
+            estimated_arv decimal(14,2) DEFAULT NULL,
+            status varchar(32) NOT NULL DEFAULT 'open',
+            source varchar(64) DEFAULT '',
+            created_by bigint(20) unsigned DEFAULT 0,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            stage_changed_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY stage_key (stage_key),
+            KEY assigned_user_id (assigned_user_id),
+            KEY status (status),
+            KEY external_id (external_id)
+        ) {$charset_collate};");
+
+        dbDelta("CREATE TABLE {$activity} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            deal_id bigint(20) unsigned NOT NULL DEFAULT 0,
+            activity_type varchar(64) NOT NULL,
+            activity_note text NOT NULL,
+            actor_user_id bigint(20) unsigned DEFAULT 0,
+            old_value varchar(191) DEFAULT '',
+            new_value varchar(191) DEFAULT '',
+            metadata longtext DEFAULT NULL,
+            created_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY deal_id (deal_id),
+            KEY activity_type (activity_type),
+            KEY created_at (created_at)
+        ) {$charset_collate};");
+
+        dbDelta("CREATE TABLE {$notes} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            deal_id bigint(20) unsigned NOT NULL,
+            note text NOT NULL,
+            created_by bigint(20) unsigned DEFAULT 0,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY deal_id (deal_id),
+            KEY created_by (created_by)
+        ) {$charset_collate};");
+
+        dbDelta("CREATE TABLE {$assignments} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            deal_id bigint(20) unsigned NOT NULL,
+            assigned_user_id bigint(20) unsigned NOT NULL,
+            assigned_by bigint(20) unsigned DEFAULT 0,
+            assigned_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY deal_id (deal_id),
+            KEY assigned_user_id (assigned_user_id)
+        ) {$charset_collate};");
+    }
+
+    public function seed_default_stages(): void
+    {
+        global $wpdb;
+
+        $order = 10;
+        $now = current_time('mysql');
+        $table = $this->get_table_name(self::STAGES_TABLE);
+
+        foreach (self::DEFAULT_STAGES as $key => $label) {
+            $existing_id = (int) $wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE stage_key = %s", $key));
+            $data = [
+                'stage_key' => $key,
+                'stage_label' => $label,
+                'stage_order' => $order,
+                'is_closed' => 'closed' === $key ? 1 : 0,
+                'updated_at' => $now,
+            ];
+
+            if ($existing_id > 0) {
+                $wpdb->update($table, $data, ['id' => $existing_id], ['%s', '%s', '%d', '%d', '%s'], ['%d']);
+            } else {
+                $data['created_at'] = $now;
+                $wpdb->insert($table, $data, ['%s', '%s', '%d', '%d', '%s', '%s']);
+            }
+
+            $order += 10;
+        }
+    }
+
+    public function get_stages(): array
+    {
+        global $wpdb;
+        $table = $this->get_table_name(self::STAGES_TABLE);
+        $stages = $wpdb->get_results("SELECT * FROM {$table} ORDER BY stage_order ASC, id ASC", ARRAY_A);
+
+        if (!is_array($stages) || [] === $stages) {
+            return $this->fallback_stages();
+        }
+
+        return $stages;
+    }
+
+    public function get_stage_keys(): array
+    {
+        return wp_list_pluck($this->get_stages(), 'stage_key');
+    }
+
+    public function get_deals(array $args = []): array
+    {
+        global $wpdb;
+        $table = $this->get_table_name(self::DEALS_TABLE);
+        $where = 'WHERE 1=1';
+        $values = [];
+
+        if (!empty($args['stage_key'])) {
+            $where .= ' AND stage_key = %s';
+            $values[] = sanitize_key((string) $args['stage_key']);
+        }
+
+        if (!empty($args['status'])) {
+            $where .= ' AND status = %s';
+            $values[] = sanitize_key((string) $args['status']);
+        }
+
+        $limit = isset($args['limit']) ? max(1, min(500, absint($args['limit']))) : 200;
+        $sql = "SELECT * FROM {$table} {$where} ORDER BY updated_at DESC LIMIT %d";
+        $values[] = $limit;
+
+        return $wpdb->get_results($wpdb->prepare($sql, $values), ARRAY_A) ?: [];
+    }
+
+    public function get_deal(int $deal_id): ?array
+    {
+        global $wpdb;
+        $table = $this->get_table_name(self::DEALS_TABLE);
+        $deal = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id = %d", $deal_id), ARRAY_A);
+        return is_array($deal) ? $deal : null;
+    }
+
+    public function create_deal(array $data): int
+    {
+        global $wpdb;
+        $table = $this->get_table_name(self::DEALS_TABLE);
+        $now = current_time('mysql');
+        $stage_key = !empty($data['stage_key']) ? sanitize_key((string) $data['stage_key']) : 'lead_captured';
+
+        if (!in_array($stage_key, $this->get_stage_keys(), true)) {
+            $stage_key = 'lead_captured';
+        }
+
+        $inserted = $wpdb->insert(
+            $table,
+            [
+                'external_id' => isset($data['external_id']) ? sanitize_text_field((string) $data['external_id']) : '',
+                'stage_key' => $stage_key,
+                'property_address' => isset($data['property_address']) ? sanitize_textarea_field((string) $data['property_address']) : '',
+                'seller_name' => isset($data['seller_name']) ? sanitize_text_field((string) $data['seller_name']) : '',
+                'seller_email' => isset($data['seller_email']) ? sanitize_email((string) $data['seller_email']) : '',
+                'seller_phone' => isset($data['seller_phone']) ? sanitize_text_field((string) $data['seller_phone']) : '',
+                'priority' => isset($data['priority']) ? sanitize_key((string) $data['priority']) : 'normal',
+                'assigned_user_id' => isset($data['assigned_user_id']) ? absint($data['assigned_user_id']) : 0,
+                'asking_price' => $this->nullable_decimal($data['asking_price'] ?? null),
+                'estimated_arv' => $this->nullable_decimal($data['estimated_arv'] ?? null),
+                'status' => isset($data['status']) ? sanitize_key((string) $data['status']) : 'open',
+                'source' => isset($data['source']) ? sanitize_key((string) $data['source']) : '',
+                'created_by' => get_current_user_id(),
+                'created_at' => $now,
+                'updated_at' => $now,
+                'stage_changed_at' => $now,
+            ],
+            ['%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%f', '%f', '%s', '%s', '%d', '%s', '%s', '%s']
+        );
+
+        return false === $inserted ? 0 : (int) $wpdb->insert_id;
+    }
+
+    public function update_deal(int $deal_id, array $data): bool
+    {
+        global $wpdb;
+        $allowed = ['property_address', 'seller_name', 'seller_email', 'seller_phone', 'priority', 'assigned_user_id', 'asking_price', 'estimated_arv', 'status', 'source'];
+        $update = [];
+        $formats = [];
+
+        foreach ($allowed as $field) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+
+            if ('assigned_user_id' === $field) {
+                $update[$field] = absint($data[$field]);
+                $formats[] = '%d';
+            } elseif (in_array($field, ['asking_price', 'estimated_arv'], true)) {
+                $update[$field] = $this->nullable_decimal($data[$field]);
+                $formats[] = '%f';
+            } elseif ('property_address' === $field) {
+                $update[$field] = sanitize_textarea_field((string) $data[$field]);
+                $formats[] = '%s';
+            } elseif ('seller_email' === $field) {
+                $update[$field] = sanitize_email((string) $data[$field]);
+                $formats[] = '%s';
+            } elseif (in_array($field, ['priority', 'status', 'source'], true)) {
+                $update[$field] = sanitize_key((string) $data[$field]);
+                $formats[] = '%s';
+            } else {
+                $update[$field] = sanitize_text_field((string) $data[$field]);
+                $formats[] = '%s';
+            }
+        }
+
+        if ([] === $update) {
+            return true;
+        }
+
+        $update['updated_at'] = current_time('mysql');
+        $formats[] = '%s';
+
+        return false !== $wpdb->update($this->get_table_name(self::DEALS_TABLE), $update, ['id' => $deal_id], $formats, ['%d']);
+    }
+
+    public function update_deal_stage(int $deal_id, string $stage_key): bool
+    {
+        global $wpdb;
+        if (!in_array($stage_key, $this->get_stage_keys(), true)) {
+            return false;
+        }
+
+        $status = 'closed' === $stage_key ? 'closed' : 'open';
+        return false !== $wpdb->update(
+            $this->get_table_name(self::DEALS_TABLE),
+            ['stage_key' => $stage_key, 'status' => $status, 'updated_at' => current_time('mysql'), 'stage_changed_at' => current_time('mysql')],
+            ['id' => $deal_id],
+            ['%s', '%s', '%s', '%s'],
+            ['%d']
+        );
+    }
+
+    public function get_activity(array $args = []): array
+    {
+        global $wpdb;
+        $table = $this->get_table_name(self::ACTIVITY_TABLE);
+        $where = 'WHERE 1=1';
+        $values = [];
+
+        if (!empty($args['deal_id'])) {
+            $where .= ' AND deal_id = %d';
+            $values[] = absint($args['deal_id']);
+        }
+
+        $limit = isset($args['limit']) ? max(1, min(500, absint($args['limit']))) : 100;
+        $values[] = $limit;
+        return $wpdb->get_results($wpdb->prepare("SELECT * FROM {$table} {$where} ORDER BY created_at DESC, id DESC LIMIT %d", $values), ARRAY_A) ?: [];
+    }
+
+    public function get_metrics(): array
+    {
+        global $wpdb;
+        $deals = $this->get_table_name(self::DEALS_TABLE);
+        $stages = $this->get_stages();
+        $metrics = [
+            'total_deals' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$deals}"),
+            'open_deals' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$deals} WHERE status = 'open'"),
+            'closed_deals' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$deals} WHERE status = 'closed'"),
+            'stage_counts' => [],
+        ];
+
+        foreach ($stages as $stage) {
+            $key = (string) $stage['stage_key'];
+            $metrics['stage_counts'][$key] = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$deals} WHERE stage_key = %s", $key));
+        }
+
+        return $metrics;
+    }
+
+    private function fallback_stages(): array
+    {
+        $stages = [];
+        $order = 10;
+        foreach (self::DEFAULT_STAGES as $key => $label) {
+            $stages[] = [
+                'id' => 0,
+                'stage_key' => $key,
+                'stage_label' => $label,
+                'stage_order' => $order,
+                'is_closed' => 'closed' === $key ? 1 : 0,
+            ];
+            $order += 10;
+        }
+        return $stages;
+    }
+
+    private function nullable_decimal($value)
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+        return (float) preg_replace('/[^0-9.\-]/', '', (string) $value);
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-integrations.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-integrations.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Integration hooks for adjacent Algonquian plugins.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_Integrations
+{
+    private ALGQ_Pipeline_Database $database;
+    private ALGQ_Pipeline_Activity $activity;
+
+    public function __construct(ALGQ_Pipeline_Database $database, ALGQ_Pipeline_Activity $activity)
+    {
+        $this->database = $database;
+        $this->activity = $activity;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('algq_deal_intake_created', [$this, 'handle_intake_created'], 10, 2);
+        add_action('algq_mao_underwriting_saved', [$this, 'handle_underwriting_saved'], 10, 2);
+        add_action('algq_offer_generated', [$this, 'handle_offer_generated'], 10, 2);
+        add_action('algq_buyer_assigned', [$this, 'handle_buyer_assigned'], 10, 2);
+        add_action('algq_funding_status_updated', [$this, 'handle_funding_status_updated'], 10, 2);
+    }
+
+    public function handle_intake_created($external_id, $payload = []): void
+    {
+        $data = is_array($payload) ? $payload : [];
+        $data['external_id'] = (string) $external_id;
+        $data['stage_key'] = 'lead_captured';
+        $data['source'] = 'deal_intake';
+        $deal_id = $this->database->create_deal($data);
+
+        if ($deal_id > 0) {
+            $deal = $this->database->get_deal($deal_id);
+            $this->activity->log($deal_id, 'deal_created', __('Deal created from intake.', 'algq-pipeline-crm'));
+            do_action('algq_pipeline_deal_created', $deal_id, $deal);
+        }
+    }
+
+    public function handle_underwriting_saved($deal_id, $payload = []): void
+    {
+        $deal_id = absint($deal_id);
+        if ($deal_id < 1) {
+            return;
+        }
+
+        if (is_array($payload) && isset($payload['estimated_arv'])) {
+            $this->database->update_deal($deal_id, ['estimated_arv' => $payload['estimated_arv']]);
+        }
+        $this->activity->log($deal_id, 'underwriting_updated', __('Underwriting updated.', 'algq-pipeline-crm'));
+    }
+
+    public function handle_offer_generated($deal_id): void
+    {
+        $deal_id = absint($deal_id);
+        if ($deal_id > 0) {
+            $this->activity->log($deal_id, 'offer_generated', __('Offer generated.', 'algq-pipeline-crm'));
+        }
+    }
+
+    public function handle_buyer_assigned($deal_id, $buyer_id = 0): void
+    {
+        $deal_id = absint($deal_id);
+        if ($deal_id > 0) {
+            $this->activity->log($deal_id, 'buyer_assigned', __('Buyer assigned.', 'algq-pipeline-crm'), '', (string) absint($buyer_id));
+        }
+    }
+
+    public function handle_funding_status_updated($deal_id, $status = ''): void
+    {
+        $deal_id = absint($deal_id);
+        if ($deal_id > 0) {
+            $this->activity->log($deal_id, 'funding_status_updated', __('Funding status updated.', 'algq-pipeline-crm'), '', sanitize_text_field((string) $status));
+        }
+    }
+}

--- a/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-rest-controller.php
+++ b/algonquian-real-estate/plugins/algq-pipeline-crm/includes/class-algq-pipeline-rest-controller.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * REST API controller for Pipeline CRM.
+ *
+ * @package Algonquian_Pipeline_CRM
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALGQ_Pipeline_REST_Controller extends WP_REST_Controller
+{
+    protected $namespace = 'algq/v1';
+    protected $rest_base = 'pipeline';
+    private ALGQ_Pipeline_Database $database;
+    private ALGQ_Pipeline_Activity $activity;
+
+    public function __construct(ALGQ_Pipeline_Database $database, ALGQ_Pipeline_Activity $activity)
+    {
+        $this->database = $database;
+        $this->activity = $activity;
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route($this->namespace, '/' . $this->rest_base . '/deals', [
+            [
+                'methods' => WP_REST_Server::READABLE,
+                'callback' => [$this, 'get_deals'],
+                'permission_callback' => [$this, 'can_view'],
+            ],
+            [
+                'methods' => WP_REST_Server::CREATABLE,
+                'callback' => [$this, 'create_deal'],
+                'permission_callback' => [$this, 'can_edit'],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/' . $this->rest_base . '/deals/(?P<id>\d+)', [
+            [
+                'methods' => WP_REST_Server::READABLE,
+                'callback' => [$this, 'get_deal'],
+                'permission_callback' => [$this, 'can_view'],
+                'args' => ['id' => ['sanitize_callback' => 'absint']],
+            ],
+            [
+                'methods' => WP_REST_Server::EDITABLE,
+                'callback' => [$this, 'update_deal'],
+                'permission_callback' => [$this, 'can_edit'],
+                'args' => ['id' => ['sanitize_callback' => 'absint']],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/' . $this->rest_base . '/deals/(?P<id>\d+)/stage', [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'update_stage'],
+            'permission_callback' => [$this, 'can_edit'],
+            'args' => ['id' => ['sanitize_callback' => 'absint']],
+        ]);
+
+        register_rest_route($this->namespace, '/' . $this->rest_base . '/activity', [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'get_activity'],
+            'permission_callback' => [$this, 'can_view'],
+        ]);
+
+        register_rest_route($this->namespace, '/' . $this->rest_base . '/metrics', [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'get_metrics'],
+            'permission_callback' => [$this, 'can_view'],
+        ]);
+    }
+
+    public function can_view(): bool
+    {
+        return current_user_can('algq_view_pipeline');
+    }
+
+    public function can_edit(): bool
+    {
+        return current_user_can('algq_edit_deals') || current_user_can('algq_manage_pipeline');
+    }
+
+    public function get_deals(WP_REST_Request $request): WP_REST_Response
+    {
+        $args = [
+            'stage_key' => sanitize_key((string) $request->get_param('stage_key')),
+            'status' => sanitize_key((string) $request->get_param('status')),
+            'limit' => absint($request->get_param('limit') ?: 200),
+        ];
+
+        return rest_ensure_response($this->database->get_deals(array_filter($args)));
+    }
+
+    public function create_deal(WP_REST_Request $request)
+    {
+        $deal_id = $this->database->create_deal($this->sanitize_deal_payload($request));
+        if ($deal_id < 1) {
+            return new WP_Error('algq_pipeline_create_failed', __('Unable to create deal.', 'algq-pipeline-crm'), ['status' => 500]);
+        }
+
+        $deal = $this->database->get_deal($deal_id);
+        $this->activity->log($deal_id, 'deal_created', __('Deal created.', 'algq-pipeline-crm'));
+        do_action('algq_pipeline_deal_created', $deal_id, $deal);
+
+        return rest_ensure_response($deal)->set_status(201);
+    }
+
+    public function get_deal(WP_REST_Request $request)
+    {
+        $deal = $this->database->get_deal(absint($request['id']));
+        if (!$deal) {
+            return new WP_Error('algq_pipeline_not_found', __('Deal not found.', 'algq-pipeline-crm'), ['status' => 404]);
+        }
+
+        return rest_ensure_response($deal);
+    }
+
+    public function update_deal(WP_REST_Request $request)
+    {
+        $deal_id = absint($request['id']);
+        $old_deal = $this->database->get_deal($deal_id);
+        if (!$old_deal) {
+            return new WP_Error('algq_pipeline_not_found', __('Deal not found.', 'algq-pipeline-crm'), ['status' => 404]);
+        }
+
+        $payload = $this->sanitize_deal_payload($request);
+        if (array_key_exists('assigned_user_id', $payload) && !current_user_can('algq_assign_deals') && !current_user_can('algq_manage_pipeline')) {
+            return new WP_Error('algq_pipeline_assign_forbidden', __('You do not have permission to assign deals.', 'algq-pipeline-crm'), ['status' => 403]);
+        }
+
+        $updated = $this->database->update_deal($deal_id, $payload);
+        if (!$updated) {
+            return new WP_Error('algq_pipeline_update_failed', __('Unable to update deal.', 'algq-pipeline-crm'), ['status' => 500]);
+        }
+
+        if (array_key_exists('assigned_user_id', $payload) && (int) $old_deal['assigned_user_id'] !== (int) $payload['assigned_user_id']) {
+            $this->activity->assigned_user_changed($deal_id, (int) $old_deal['assigned_user_id'], (int) $payload['assigned_user_id']);
+        }
+
+        return rest_ensure_response($this->database->get_deal($deal_id));
+    }
+
+    public function update_stage(WP_REST_Request $request)
+    {
+        $deal_id = absint($request['id']);
+        $new_stage = sanitize_key((string) $request->get_param('stage_key'));
+        $deal = $this->database->get_deal($deal_id);
+
+        if (!$deal) {
+            return new WP_Error('algq_pipeline_not_found', __('Deal not found.', 'algq-pipeline-crm'), ['status' => 404]);
+        }
+
+        if (!in_array($new_stage, $this->database->get_stage_keys(), true)) {
+            return new WP_Error('algq_pipeline_invalid_stage', __('Invalid stage.', 'algq-pipeline-crm'), ['status' => 400]);
+        }
+
+        if ('closed' === $new_stage && !current_user_can('algq_close_deals') && !current_user_can('algq_manage_pipeline')) {
+            return new WP_Error('algq_pipeline_close_forbidden', __('You do not have permission to close deals.', 'algq-pipeline-crm'), ['status' => 403]);
+        }
+
+        $old_stage = (string) $deal['stage_key'];
+        if ($old_stage === $new_stage) {
+            return rest_ensure_response($deal);
+        }
+
+        $updated = $this->database->update_deal_stage($deal_id, $new_stage);
+        if (!$updated) {
+            return new WP_Error('algq_pipeline_stage_failed', __('Unable to update deal stage.', 'algq-pipeline-crm'), ['status' => 500]);
+        }
+
+        $this->activity->log($deal_id, 'stage_changed', __('Stage changed.', 'algq-pipeline-crm'), $old_stage, $new_stage);
+        do_action('algq_pipeline_stage_changed', $deal_id, $old_stage, $new_stage);
+
+        if ('closed' === $new_stage) {
+            $this->activity->log($deal_id, 'deal_closed', __('Deal closed.', 'algq-pipeline-crm'), $old_stage, $new_stage);
+            do_action('algq_pipeline_deal_closed', $deal_id);
+        }
+
+        return rest_ensure_response($this->database->get_deal($deal_id));
+    }
+
+    public function get_activity(WP_REST_Request $request): WP_REST_Response
+    {
+        return rest_ensure_response($this->database->get_activity([
+            'deal_id' => absint($request->get_param('deal_id')),
+            'limit' => absint($request->get_param('limit') ?: 100),
+        ]));
+    }
+
+    public function get_metrics(): WP_REST_Response
+    {
+        return rest_ensure_response($this->database->get_metrics());
+    }
+
+    private function sanitize_deal_payload(WP_REST_Request $request): array
+    {
+        $payload = $request->get_json_params();
+        if (!is_array($payload)) {
+            $payload = $request->get_params();
+        }
+
+        $sanitized = [];
+        $text_fields = ['external_id', 'seller_name', 'seller_phone'];
+        foreach ($text_fields as $field) {
+            if (array_key_exists($field, $payload)) {
+                $sanitized[$field] = sanitize_text_field((string) $payload[$field]);
+            }
+        }
+
+        if (array_key_exists('property_address', $payload)) {
+            $sanitized['property_address'] = sanitize_textarea_field((string) $payload['property_address']);
+        }
+
+        if (array_key_exists('seller_email', $payload)) {
+            $sanitized['seller_email'] = sanitize_email((string) $payload['seller_email']);
+        }
+
+        foreach (['stage_key', 'priority', 'status', 'source'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $sanitized[$field] = sanitize_key((string) $payload[$field]);
+            }
+        }
+
+        foreach (['assigned_user_id'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $sanitized[$field] = absint($payload[$field]);
+            }
+        }
+
+        foreach (['asking_price', 'estimated_arv'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $sanitized[$field] = '' === $payload[$field] ? null : (float) preg_replace('/[^0-9.\-]/', '', (string) $payload[$field]);
+            }
+        }
+
+        return $sanitized;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a production-ready MVP of the Algonquian Pipeline CRM to manage the acquisition lifecycle from lead capture through close. 
- Deliver an admin Kanban board with drag/drop stage movement, REST endpoints, activity logging, and integration hooks for adjacent modules. 
- Establish database schema, default stages, and minimal RBAC so the pipeline can be safely used and extended by other plugins. 

### Description
- Add plugin bootstrap `algq-pipeline-crm.php`, plugin constants, and a core plugin class `includes/class-algq-pipeline-crm.php` that wires shortcodes, REST routes, admin hooks, and integrations. 
- Implement database layer `includes/class-algq-pipeline-database.php` and activator `includes/class-algq-pipeline-activator.php` to create/update tables with `dbDelta` and seed default stages (`lead_captured`, `underwriting`, `offer_sent`, `under_contract`, `buyer_assigned`, `closed`). 
- Add REST controller `includes/class-algq-pipeline-rest-controller.php` exposing `/wp-json/algq/v1/pipeline/deals`, `/deals/{id}`, `/deals/{id}/stage`, `/activity`, and `/metrics` with capability checks, input sanitization, and activity logging; fire/listen integration actions (`algq_pipeline_deal_created`, `algq_pipeline_stage_changed`, `algq_pipeline_deal_closed` and listeners for intake/MAO/offer/buyer/funding events). 
- Implement admin UI and views (`includes/class-algq-pipeline-admin.php` and `admin/views/*`) plus Kanban renderer `includes/class-algq-pipeline-board.php`, assets (`assets/css/pipeline-crm.css`, `assets/js/pipeline-crm.js`) that implement HTML/CSS board, draggable cards, optimistic UI movement, REST stage updates using `X-WP-Nonce`, rollback on failure, and stage counts. 
- Create activity helper `includes/class-algq-pipeline-activity.php`, integrations helper `includes/class-algq-pipeline-integrations.php`, and add shortcode `[algq_pipeline_board]` (alias `[algq_pipeline_crm]`) which returns buffered HTML and is restricted by `algq_view_pipeline`. 
- Add capability creation (`algq_view_pipeline`, `algq_manage_pipeline`, `algq_edit_deals`, `algq_assign_deals`, `algq_close_deals`) on activation, ensure inputs are sanitized and outputs escaped, and document plugin in `README.md` and update top-level README plugin catalog and REST endpoint summary. 

### Testing
- Ran PHP lint across plugin PHP files with `find algonquian-real-estate/plugins/algq-pipeline-crm -name '*.php' -print0 | xargs -0 -n1 php -l`, which completed with no syntax errors. (Succeeded.)
- Ran repository JS check with `npm run check` (executes `node --check server.js`) which completed without errors. (Succeeded.)
- Built plugin zips with `bash algonquian-real-estate/scripts/build-plugin-zips.sh`, which produced `dist/algq-pipeline-crm.zip` alongside other plugin packages. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c750681d4832dbb04d673d0e89aea)