### PR TITLE
Add marketplace performance caching layer

### DIFF
--- a/algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php
@@ -131,7 +131,13 @@ function algq_deal_marketplace_bootstrap(): void
 }
 
 add_action('plugins_loaded', 'algq_deal_marketplace_bootstrap', 20);
-    return Algq_Marketplace_Plugin::modules();
+
+/**
+ * Determine whether optional Algonquian core services are available.
+ */
+function algq_marketplace_core_available(): bool
+{
+    return function_exists('algq_core') || class_exists('ALGQ_Core');
 }
 
 /**

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-admin.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-admin.php
@@ -13,11 +13,13 @@ final class ALGQ_Deal_Marketplace_Admin
 {
     private ALGQ_Deal_Marketplace_Renderer $renderer;
     private ALGQ_Deal_Marketplace_Security $security;
+    private ALGQ_Deal_Marketplace_Cache $cache;
 
-    public function __construct(ALGQ_Deal_Marketplace_Renderer $renderer, ALGQ_Deal_Marketplace_Security $security)
+    public function __construct(ALGQ_Deal_Marketplace_Renderer $renderer, ALGQ_Deal_Marketplace_Security $security, ALGQ_Deal_Marketplace_Cache $cache)
     {
         $this->renderer = $renderer;
         $this->security = $security;
+        $this->cache = $cache;
     }
 
     public function register_hooks(): void
@@ -28,6 +30,7 @@ final class ALGQ_Deal_Marketplace_Admin
 
         add_action('admin_menu', [$this, 'register_menu']);
         add_action('admin_init', [$this, 'register_settings']);
+        add_action('admin_post_algq_deal_marketplace_clear_cache', [$this, 'handle_clear_cache']);
     }
 
     public function register_menu(): void
@@ -48,7 +51,11 @@ final class ALGQ_Deal_Marketplace_Admin
         register_setting('algq_deal_marketplace', 'algq_deal_marketplace_options', [
             'type' => 'array',
             'sanitize_callback' => [$this, 'sanitize_options'],
-            'default' => [],
+            'default' => [
+                'access_mode' => 'private',
+                'caching_enabled' => '1',
+                'default_cache_ttl' => (string) ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS,
+            ],
         ]);
     }
 
@@ -58,13 +65,41 @@ final class ALGQ_Deal_Marketplace_Admin
      */
     public function sanitize_options($options): array
     {
+        $existing = function_exists('get_option') ? get_option('algq_deal_marketplace_options', []) : [];
+        $existing = is_array($existing) ? $existing : [];
+
         if (!is_array($options)) {
-            return [];
+            $options = [];
+        }
+
+        $ttl = absint($options['default_cache_ttl'] ?? $existing['default_cache_ttl'] ?? ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS);
+
+        if ($ttl < 30) {
+            $ttl = 30;
+        }
+
+        if ($ttl > DAY_IN_SECONDS) {
+            $ttl = DAY_IN_SECONDS;
         }
 
         return [
-            'access_mode' => $this->security->sanitize_allowed($options['access_mode'] ?? '', ['private', 'members', 'public'], 'private'),
+            'access_mode' => $this->security->sanitize_allowed($options['access_mode'] ?? $existing['access_mode'] ?? '', ['private', 'members', 'public'], 'private'),
+            'caching_enabled' => !empty($options['caching_enabled']) ? '1' : '0',
+            'default_cache_ttl' => (string) $ttl,
         ];
+    }
+
+    public function handle_clear_cache(): void
+    {
+        if (!$this->security->can_manage()) {
+            wp_die(esc_html__('You do not have permission to clear marketplace cache.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN), '', ['response' => 403]);
+        }
+
+        check_admin_referer('algq_deal_marketplace_clear_cache');
+        $this->cache->flush_group();
+
+        wp_safe_redirect(add_query_arg('algq_cache_cleared', '1', wp_get_referer() ?: admin_url('admin.php?page=algq-deal-marketplace')));
+        exit;
     }
 
     public function render_page(): void
@@ -73,6 +108,51 @@ final class ALGQ_Deal_Marketplace_Admin
             wp_die(esc_html__('You do not have permission to manage the deal marketplace.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN));
         }
 
+        if (isset($_GET['algq_cache_cleared'])) {
+            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Marketplace cache cleared.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN) . '</p></div>';
+        }
+
         $this->renderer->render_admin_page();
+        $this->render_cache_settings();
+    }
+
+    private function render_cache_settings(): void
+    {
+        $options = get_option('algq_deal_marketplace_options', []);
+        $options = is_array($options) ? $options : [];
+        $enabled = !isset($options['caching_enabled']) || '0' !== (string) $options['caching_enabled'];
+        $ttl = absint($options['default_cache_ttl'] ?? ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS);
+        ?>
+        <div class="wrap algq-marketplace-cache-settings">
+            <h2><?php echo esc_html__('Marketplace cache settings', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></h2>
+            <form method="post" action="options.php">
+                <?php settings_fields('algq_deal_marketplace'); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php echo esc_html__('Enable caching', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></th>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="algq_deal_marketplace_options[caching_enabled]" value="1" <?php checked($enabled); ?> />
+                                <?php echo esc_html__('Cache marketplace listings, dashboards, NDA status, settings, and summary metrics.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?>
+                            </label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="algq-default-cache-ttl"><?php echo esc_html__('Default cache TTL', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></label></th>
+                        <td>
+                            <input id="algq-default-cache-ttl" type="number" min="30" max="86400" step="30" name="algq_deal_marketplace_options[default_cache_ttl]" value="<?php echo esc_attr((string) $ttl); ?>" />
+                            <p class="description"><?php echo esc_html__('Time to keep listing cache entries, in seconds. Dashboard summaries use 120 seconds, settings use 1800 seconds, and NDA status uses 600 seconds.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(__('Save cache settings', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN)); ?>
+            </form>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <input type="hidden" name="action" value="algq_deal_marketplace_clear_cache" />
+                <?php wp_nonce_field('algq_deal_marketplace_clear_cache'); ?>
+                <?php submit_button(__('Clear Marketplace Cache', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN), 'secondary'); ?>
+            </form>
+        </div>
+        <?php
     }
 }

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-cache.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-cache.php
@@ -11,38 +11,308 @@ if (!defined('ABSPATH')) {
 
 final class ALGQ_Deal_Marketplace_Cache
 {
-    private const GROUP = 'algq_deal_marketplace';
-    private const PREFIX = 'algq_dm_';
+    public const GROUP = 'algq_deal_marketplace';
+    public const PREFIX = 'algq_dmp_';
+    public const OPTION_KEYS = 'algq_deal_marketplace_cache_keys';
+    public const OPTION_VERSION = 'algq_deal_marketplace_cache_version';
 
-    public function get(string $key)
+    public const TTL_LISTINGS = 300;
+    public const TTL_DASHBOARD = 120;
+    public const TTL_SETTINGS = 1800;
+    public const TTL_NDA_STATUS = 600;
+
+    /**
+     * Register cache invalidation hooks.
+     */
+    public function register_hooks(): void
     {
-        $cache_key = self::PREFIX . $key;
-        $value = wp_cache_get($cache_key, self::GROUP);
+        add_action('save_post_algq_deal_marketplace', [$this, 'flush_group']);
+        add_action('save_post_algq_marketplace_deal', [$this, 'flush_group']);
+        add_action('save_post_deal', [$this, 'flush_group']);
+        add_action('deleted_post', [$this, 'handle_deleted_post']);
+        add_action('algq_deal_marketplace_interest_submitted', [$this, 'flush_group']);
+        add_action('algq_deal_marketplace_nda_accepted', [$this, 'flush_group']);
+        add_action('update_option_algq_deal_marketplace_options', [$this, 'flush_group']);
+        add_action('plugins_loaded', [$this, 'maybe_flush_on_version_change'], 30);
+    }
 
-        if (false !== $value) {
-            return $value;
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
+    public function get($key, $group = self::GROUP)
+    {
+        if (!$this->is_enabled()) {
+            return false;
         }
 
-        return get_transient($cache_key);
+        $cache_key = $this->build_key($key);
+        $found = false;
+
+        if (function_exists('wp_cache_get')) {
+            $value = wp_cache_get($cache_key, $group, false, $found);
+
+            if ($found || false !== $value) {
+                return $value;
+            }
+        }
+
+        if (function_exists('get_transient')) {
+            return get_transient($cache_key);
+        }
+
+        return false;
     }
 
-    public function set(string $key, $value, int $ttl = 300): bool
+    /**
+     * @param mixed $key
+     * @param mixed $value
+     */
+    public function set($key, $value, $ttl = self::TTL_LISTINGS, $group = self::GROUP): bool
     {
-        $cache_key = self::PREFIX . $key;
-        wp_cache_set($cache_key, $value, self::GROUP, $ttl);
-        return set_transient($cache_key, $value, $ttl);
+        if (!$this->is_enabled()) {
+            return false;
+        }
+
+        $ttl = $this->normalize_ttl($ttl);
+        $cache_key = $this->build_key($key);
+        $stored = false;
+
+        if (function_exists('wp_cache_set')) {
+            $stored = (bool) wp_cache_set($cache_key, $value, $group, $ttl);
+        }
+
+        if (function_exists('set_transient')) {
+            $stored = (bool) set_transient($cache_key, $value, $ttl) || $stored;
+        }
+
+        $this->remember_key($cache_key, $group);
+
+        return $stored;
     }
 
-    public function delete(string $key): void
+    /**
+     * @param mixed $key
+     */
+    public function delete($key, $group = self::GROUP): void
     {
-        $cache_key = self::PREFIX . $key;
-        wp_cache_delete($cache_key, self::GROUP);
-        delete_transient($cache_key);
+        $cache_key = $this->build_key($key);
+
+        if (function_exists('wp_cache_delete')) {
+            wp_cache_delete($cache_key, $group);
+        }
+
+        if (function_exists('delete_transient')) {
+            delete_transient($cache_key);
+        }
+
+        $this->forget_key($cache_key, $group);
     }
 
-    public function flush_marketplace(): void
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
+    public function remember($key, callable $callback, $ttl = self::TTL_LISTINGS, $group = self::GROUP)
     {
-        $this->delete('active_listings');
-        $this->delete('integrations');
+        $cached = $this->get($key, $group);
+
+        if (false !== $cached) {
+            return $cached;
+        }
+
+        $value = $callback();
+        $this->set($key, $value, $ttl, $group);
+
+        return $value;
+    }
+
+    /**
+     * Clear all known marketplace cache keys.
+     */
+    public function flush_group(): void
+    {
+        if (function_exists('wp_cache_flush_group')) {
+            wp_cache_flush_group(self::GROUP);
+        }
+
+        foreach ($this->registered_keys() as $group => $keys) {
+            if (!is_array($keys)) {
+                continue;
+            }
+
+            foreach (array_keys($keys) as $cache_key) {
+                if (function_exists('wp_cache_delete')) {
+                    wp_cache_delete($cache_key, (string) $group);
+                }
+
+                if (function_exists('delete_transient')) {
+                    delete_transient($cache_key);
+                }
+            }
+        }
+
+        if (function_exists('delete_option')) {
+            delete_option(self::OPTION_KEYS);
+        }
+    }
+
+    /**
+     * @param mixed $parts
+     */
+    public function build_key($parts): string
+    {
+        if (is_array($parts)) {
+            $parts = implode('_', array_map(function ($part): string {
+                if (is_scalar($part) || null === $part) {
+                    return (string) $part;
+                }
+
+                return md5($this->encode($part));
+            }, $parts));
+        } elseif (!is_scalar($parts) && null !== $parts) {
+            $parts = md5($this->encode($parts));
+        }
+
+        $key = $this->sanitize_cache_key((string) $parts);
+
+        if (0 === strpos($key, self::PREFIX)) {
+            return $key;
+        }
+
+        return self::PREFIX . $key;
+    }
+
+    public function ttl_for(string $type): int
+    {
+        switch ($type) {
+            case 'settings':
+                return self::TTL_SETTINGS;
+            case 'nda':
+                return self::TTL_NDA_STATUS;
+            case 'dashboard':
+            case 'summary':
+            case 'kpi':
+                return self::TTL_DASHBOARD;
+            case 'listings':
+            case 'featured':
+            default:
+                return $this->default_ttl();
+        }
+    }
+
+    public function is_enabled(): bool
+    {
+        $options = $this->options();
+        return !isset($options['caching_enabled']) || '0' !== (string) $options['caching_enabled'];
+    }
+
+    public function default_ttl(): int
+    {
+        $options = $this->options();
+        return $this->normalize_ttl($options['default_cache_ttl'] ?? self::TTL_LISTINGS);
+    }
+
+    public function handle_deleted_post(int $post_id): void
+    {
+        $post_type = function_exists('get_post_type') ? (string) get_post_type($post_id) : '';
+
+        if (in_array($post_type, ['algq_deal_marketplace', 'algq_marketplace_deal', 'deal'], true)) {
+            $this->flush_group();
+        }
+    }
+
+    public function maybe_flush_on_version_change(): void
+    {
+        if (!function_exists('get_option') || !function_exists('update_option') || !defined('ALGQ_DEAL_MARKETPLACE_VERSION')) {
+            return;
+        }
+
+        $version = (string) get_option(self::OPTION_VERSION, '');
+
+        if (ALGQ_DEAL_MARKETPLACE_VERSION !== $version) {
+            $this->flush_group();
+            update_option(self::OPTION_VERSION, ALGQ_DEAL_MARKETPLACE_VERSION, false);
+        }
+    }
+
+    private function normalize_ttl($ttl): int
+    {
+        $ttl = function_exists('absint') ? absint($ttl) : abs( (int) $ttl );
+        return $ttl > 0 ? $ttl : self::TTL_LISTINGS;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encode($value): string
+    {
+        if (function_exists('wp_json_encode')) {
+            return (string) wp_json_encode($value);
+        }
+
+        return (string) json_encode($value);
+    }
+
+    private function sanitize_cache_key(string $key): string
+    {
+        if (function_exists('sanitize_key')) {
+            return sanitize_key($key);
+        }
+
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower($key)) ?: '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function options(): array
+    {
+        if (!function_exists('get_option')) {
+            return [];
+        }
+
+        $options = get_option('algq_deal_marketplace_options', []);
+        return is_array($options) ? $options : [];
+    }
+
+    /**
+     * @return array<string, array<string, bool>>
+     */
+    private function registered_keys(): array
+    {
+        if (!function_exists('get_option')) {
+            return [];
+        }
+
+        $keys = get_option(self::OPTION_KEYS, []);
+        return is_array($keys) ? $keys : [];
+    }
+
+    private function remember_key(string $cache_key, string $group): void
+    {
+        if (!function_exists('update_option')) {
+            return;
+        }
+
+        $keys = $this->registered_keys();
+        $keys[$group] = isset($keys[$group]) && is_array($keys[$group]) ? $keys[$group] : [];
+        $keys[$group][$cache_key] = true;
+
+        update_option(self::OPTION_KEYS, $keys, false);
+    }
+
+    private function forget_key(string $cache_key, string $group): void
+    {
+        if (!function_exists('update_option')) {
+            return;
+        }
+
+        $keys = $this->registered_keys();
+
+        if (isset($keys[$group][$cache_key])) {
+            unset($keys[$group][$cache_key]);
+            update_option(self::OPTION_KEYS, $keys, false);
+        }
     }
 }

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-interest.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-interest.php
@@ -45,6 +45,7 @@ final class ALGQ_Deal_Marketplace_Interest
         ]);
 
         $this->audit_log->record('interest_submitted', 'interest', $interest_id);
+        do_action('algq_deal_marketplace_interest_submitted', $interest_id, absint($_POST['listing_id'] ?? 0), get_current_user_id());
         wp_safe_redirect(wp_get_referer() ?: home_url('/'));
         exit;
     }

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-nda.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-nda.php
@@ -27,5 +27,6 @@ final class ALGQ_Deal_Marketplace_NDA
 
         $this->repository->record_nda_acceptance($listing_id, $user_id, $ip_hash);
         $this->audit_log->record('nda_accepted', 'listing', $listing_id, ['user_id' => $user_id]);
+        do_action('algq_deal_marketplace_nda_accepted', $listing_id, $user_id);
     }
 }

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-renderer.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-renderer.php
@@ -27,12 +27,29 @@ final class ALGQ_Deal_Marketplace_Renderer
         }
 
         $listings = $this->repository->get_active_listings();
+        $featured_deals = $this->repository->get_featured_deals();
 
         ob_start();
         ?>
         <section class="algq-marketplace" aria-labelledby="algq-marketplace-title">
             <h2 id="algq-marketplace-title"><?php echo esc_html__('ARE Deal Marketplace', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></h2>
             <p><?php echo esc_html__('Wholesale deal distribution, investor access, buyer subscriptions, and premium listing controls for the Algonquian Real Estate platform.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></p>
+            <?php if (!empty($featured_deals)) : ?>
+                <h3><?php echo esc_html__('Featured deals', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></h3>
+                <div class="algq-marketplace-grid algq-marketplace-featured-grid">
+                    <?php foreach ($featured_deals as $listing) : ?>
+                        <article class="algq-marketplace-card algq-marketplace-card-featured">
+                            <h4><?php echo esc_html((string) ($listing['title'] ?? $listing['label'] ?? 'Featured opportunity')); ?></h4>
+                            <?php if (!empty($listing['description'])) : ?>
+                                <p><?php echo esc_html((string) $listing['description']); ?></p>
+                            <?php endif; ?>
+                            <?php if (!empty($listing['status'])) : ?>
+                                <span><?php echo esc_html((string) $listing['status']); ?></span>
+                            <?php endif; ?>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
             <div class="algq-marketplace-grid">
                 <?php foreach ($listings as $listing) : ?>
                     <article class="algq-marketplace-card">
@@ -54,10 +71,19 @@ final class ALGQ_Deal_Marketplace_Renderer
     public function render_admin_page(): void
     {
         $listings = $this->repository->get_active_listings();
+        $summary_cards = $this->repository->get_admin_summary_cards();
         ?>
         <div class="wrap algq-marketplace-admin">
             <h1><?php echo esc_html__('ARE Deal Marketplace', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></h1>
             <p><?php echo esc_html__('Manage enterprise marketplace readiness, buyer access, NDA acceptance, and buyer interest signals.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></p>
+            <div class="algq-marketplace-summary-cards">
+                <?php foreach ($summary_cards as $card) : ?>
+                    <div class="algq-marketplace-summary-card">
+                        <strong><?php echo esc_html((string) ($card['value'] ?? 0)); ?></strong>
+                        <span><?php echo esc_html((string) ($card['label'] ?? 'Metric')); ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
             <h2><?php echo esc_html__('Marketplace modules', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></h2>
             <table class="widefat striped">
                 <thead>

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-repository.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-repository.php
@@ -11,6 +11,13 @@ if (!defined('ABSPATH')) {
 
 final class ALGQ_Deal_Marketplace_Repository
 {
+    private ?ALGQ_Deal_Marketplace_Cache $cache;
+
+    public function __construct(?ALGQ_Deal_Marketplace_Cache $cache = null)
+    {
+        $this->cache = $cache;
+    }
+
     public function listings_table(): string
     {
         global $wpdb;
@@ -102,21 +109,134 @@ final class ALGQ_Deal_Marketplace_Repository
      */
     public function get_active_listings(): array
     {
-        global $wpdb;
+        return $this->remember(['listings', 'active'], function (): array {
+            global $wpdb;
 
-        $rows = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT * FROM {$this->listings_table()} WHERE status = %s ORDER BY updated_at DESC LIMIT 50",
-                'active'
-            ),
-            ARRAY_A
-        );
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$this->listings_table()} WHERE status = %s ORDER BY updated_at DESC LIMIT 50",
+                    'active'
+                ),
+                ARRAY_A
+            );
 
-        if (!is_array($rows) || [] === $rows) {
-            return $this->default_modules();
-        }
+            if (!is_array($rows) || [] === $rows) {
+                return $this->default_modules();
+            }
 
-        return $rows;
+            return $rows;
+        }, ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function get_featured_deals(): array
+    {
+        return $this->remember(['listings', 'featured'], function (): array {
+            global $wpdb;
+
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$this->listings_table()} WHERE status = %s AND (visibility = %s OR meta LIKE %s) ORDER BY updated_at DESC LIMIT 12",
+                    'active',
+                    'featured',
+                    '%"featured":true%'
+                ),
+                ARRAY_A
+            );
+
+            return is_array($rows) ? $rows : [];
+        }, ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_buyer_dashboard_summary(int $user_id): array
+    {
+        return $this->remember(['dashboard', 'buyer', $user_id], function () use ($user_id): array {
+            global $wpdb;
+
+            $interest_count = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(*) FROM {$this->interests_table()} WHERE user_id = %d",
+                    $user_id
+                )
+            );
+            $nda_count = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(*) FROM {$this->nda_table()} WHERE user_id = %d",
+                    $user_id
+                )
+            );
+
+            return [
+                'user_id' => $user_id,
+                'submitted_interest_count' => $interest_count,
+                'accepted_nda_count' => $nda_count,
+            ];
+        }, ALGQ_Deal_Marketplace_Cache::TTL_DASHBOARD);
+    }
+
+    public function has_accepted_nda(int $listing_id, int $user_id): bool
+    {
+        return (bool) $this->remember(['nda', $listing_id, $user_id], function () use ($listing_id, $user_id): bool {
+            global $wpdb;
+
+            return (bool) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$this->nda_table()} WHERE listing_id = %d AND user_id = %d LIMIT 1",
+                    $listing_id,
+                    $user_id
+                )
+            );
+        }, ALGQ_Deal_Marketplace_Cache::TTL_NDA_STATUS);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function get_dashboard_kpi_counts(): array
+    {
+        return $this->remember(['dashboard', 'kpis'], function (): array {
+            global $wpdb;
+
+            return [
+                'active_listings' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->listings_table()} WHERE status = %s", 'active')),
+                'featured_deals' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->listings_table()} WHERE status = %s AND (visibility = %s OR meta LIKE %s)", 'active', 'featured', '%"featured":true%')),
+                'buyer_interests' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->interests_table()}"),
+                'accepted_ndas' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->nda_table()}"),
+            ];
+        }, ALGQ_Deal_Marketplace_Cache::TTL_DASHBOARD);
+    }
+
+    /**
+     * @return array<int, array{label: string, value: int}>
+     */
+    public function get_admin_summary_cards(): array
+    {
+        $counts = $this->get_dashboard_kpi_counts();
+
+        return $this->remember(['admin', 'summary_cards'], static function () use ($counts): array {
+            return [
+                ['label' => 'Active listings', 'value' => $counts['active_listings'] ?? 0],
+                ['label' => 'Featured deals', 'value' => $counts['featured_deals'] ?? 0],
+                ['label' => 'Buyer interests', 'value' => $counts['buyer_interests'] ?? 0],
+                ['label' => 'Accepted NDAs', 'value' => $counts['accepted_ndas'] ?? 0],
+            ];
+        }, ALGQ_Deal_Marketplace_Cache::TTL_DASHBOARD);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_settings(): array
+    {
+        return $this->remember(['settings'], static function (): array {
+            $options = get_option('algq_deal_marketplace_options', []);
+            return is_array($options) ? $options : [];
+        }, ALGQ_Deal_Marketplace_Cache::TTL_SETTINGS);
     }
 
     /**
@@ -151,6 +271,19 @@ final class ALGQ_Deal_Marketplace_Repository
                 'status' => 'Featured inventory',
             ],
         ];
+    }
+
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
+    private function remember($key, callable $callback, int $ttl)
+    {
+        if ($this->cache instanceof ALGQ_Deal_Marketplace_Cache) {
+            return $this->cache->remember($key, $callback, $ttl);
+        }
+
+        return $callback();
     }
 
     /**

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace.php
@@ -29,12 +29,12 @@ final class ALGQ_Deal_Marketplace
     private function __construct()
     {
         $this->cache = new ALGQ_Deal_Marketplace_Cache();
-        $this->repository = new ALGQ_Deal_Marketplace_Repository();
+        $this->repository = new ALGQ_Deal_Marketplace_Repository($this->cache);
         $this->security = new ALGQ_Deal_Marketplace_Security();
         $this->assets = new ALGQ_Deal_Marketplace_Assets();
         $this->renderer = new ALGQ_Deal_Marketplace_Renderer($this->repository, $this->security);
         $this->shortcodes = new ALGQ_Deal_Marketplace_Shortcodes($this->renderer, $this->assets);
-        $this->admin = new ALGQ_Deal_Marketplace_Admin($this->renderer, $this->security);
+        $this->admin = new ALGQ_Deal_Marketplace_Admin($this->renderer, $this->security, $this->cache);
         $this->audit_log = new ALGQ_Deal_Marketplace_Audit_Log($this->repository);
         $this->nda = new ALGQ_Deal_Marketplace_NDA($this->repository, $this->audit_log);
         $this->interest = new ALGQ_Deal_Marketplace_Interest($this->repository, $this->security, $this->audit_log);
@@ -60,6 +60,7 @@ final class ALGQ_Deal_Marketplace
 
         load_plugin_textdomain(ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN, false, dirname(ALGQ_DEAL_MARKETPLACE_BASENAME) . '/languages');
 
+        $this->cache->register_hooks();
         $this->assets->register_hooks();
         $this->admin->register_hooks();
         $this->interest->register_hooks();

--- a/algonquian-real-estate/plugins/algq-marketplace/tests/bootstrap.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/tests/bootstrap.php
@@ -53,6 +53,35 @@ function tests_add_wordpress_shims(): void
         }
     }
 
+
+    if (!function_exists('plugin_basename')) {
+        function plugin_basename($file): string
+        {
+            return basename(dirname($file)) . '/' . basename($file);
+        }
+    }
+
+    if (!function_exists('is_admin')) {
+        function is_admin(): bool
+        {
+            return false;
+        }
+    }
+
+    if (!function_exists('load_plugin_textdomain')) {
+        function load_plugin_textdomain($domain, $deprecated = false, $plugin_rel_path = false): bool
+        {
+            return true;
+        }
+    }
+
+    if (!function_exists('register_deactivation_hook')) {
+        function register_deactivation_hook($file, $callback): void
+        {
+            $GLOBALS['algq_marketplace_deactivation_hooks'][$file] = $callback;
+        }
+    }
+
     if (!function_exists('trailingslashit')) {
         function trailingslashit($value): string
         {


### PR DESCRIPTION
### Motivation
- Improve performance by adding a safe caching layer for marketplace data (listings, featured deals, dashboard summaries, NDA status, settings, and KPI/admin summaries). 
- Provide a unified cache API that uses object cache APIs when available and falls back to transients, with predictable keys and TTLs.
- Allow operators to control caching from the admin UI and ensure cache is invalidated on relevant lifecycle events.

### Description
- Added a new cache service `ALGQ_Deal_Marketplace_Cache` at `includes/class-algq-deal-marketplace-cache.php` implementing `get`, `set`, `delete`, `remember`, `flush_group`, and `build_key` and tracking keys in an option registry; it prefers `wp_cache_*` functions and falls back to transients and supports the `algq_dmp_` key prefix. 
- Introduced typed default TTLs: listings = 300s, dashboard summaries = 120s, settings = 1800s, NDA status = 600s, and a `ttl_for`/`default_ttl` API for type-based TTL resolution. 
- Wired caching into the repository layer so `get_active_listings`, `get_featured_deals`, `get_buyer_dashboard_summary`, `has_accepted_nda`, `get_dashboard_kpi_counts`, `get_admin_summary_cards`, and `get_settings` use `remember(...)` to cache results.
- Added invalidation hooks and integration points: flush on marketplace deal save/delete, on buyer interest submission, NDA acceptance, settings update, and plugin version change; emitted `algq_deal_marketplace_interest_submitted` and `algq_deal_marketplace_nda_accepted` actions where appropriate. 
- Added admin controls in `ALGQ_Deal_Marketplace_Admin` to enable/disable caching, configure default TTL, and a nonce/capability-protected `Clear Marketplace Cache` action that calls the cache `flush_group` method. 
- Updated renderer to display featured deals and admin summary cards (sourced from cached KPI counts), updated plugin bootstrap to instantiate and register cache hooks, and added lightweight test shims so the plugin can boot in the test environment.

### Testing
- Ran PHP lint across plugin files with `php -l` (no syntax errors reported). — succeeded. 
- Executed the plugin test bootstrap with `php tests/bootstrap.php` to validate lightweight shims and plugin bootstrap logic — succeeded. 
- Performed a runtime check that `ALGQ_Deal_Marketplace_Cache` exposes the required methods and that `build_key(['Listings','Active'])` yields the expected prefixed key via a short PHP invocation — succeeded. 
- Attempted to run the full test suite with `phpunit --configuration phpunit.xml.dist`, but `phpunit` is not installed in the environment so the PHPUnit run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9c738058832d8f5bcb171be0eea2)