### PR TITLE
Add Algonquian Deal Marketplace docs: architecture, deployment, testing, performance, cache, security, integrations, release & changelog policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,158 @@
-# OMOS Architecture
-OMOS.OneGodian.com runs as a Node/Express runtime with static page delivery and JSON API endpoints for health, manifest, and protected processing.
+# Algonquian Deal Marketplace Architecture
 
-ONEGODIAN, LLC is the commercial/IP/software entity. OMOS is a voluntary educational, documentation, runtime-support, protocol, and systems architecture layer.
+## Plugin purpose
+
+The Algonquian Deal Marketplace plugin provides the buyer-facing marketplace layer for the Algonquian Real Estate (ARE) suite. It packages private wholesale deal distribution, investor access, buyer subscriptions, premium listing visibility, NDA acceptance records, buyer interest capture, audit logging, generated WordPress pages, shortcodes, admin screens, and optional suite-integration awareness into a single WordPress plugin.
+
+The plugin is intentionally modular: the marketplace can render a useful readiness view by itself, while optional ARE plugins can deepen deal intake, CRM routing, buyer-portal access, document management, commerce, and operations workflows.
+
+## WordPress architecture
+
+The main plugin file is `algonquian-real-estate/plugins/algq-marketplace/algq-marketplace.php`. It defines plugin constants, loads include files, registers activation and deactivation hooks, and boots the runtime coordinator on `plugins_loaded`.
+
+High-level WordPress hooks:
+
+1. **Activation** provisions capabilities, database tables, the default marketplace page, default options, and permalink rules.
+2. **Deactivation** refreshes rewrite rules without deleting marketplace data.
+3. **Runtime boot** creates the singleton coordinator and registers public, admin, form, asset, integration, and REST hooks.
+4. **`init`** registers public shortcodes.
+5. **`rest_api_init`** registers the public marketplace status endpoint.
+6. **`admin_menu` / `admin_init`** expose the admin screen and settings registration for authorized users.
+7. **`admin_post_*`** handles buyer interest submission for authenticated and unauthenticated requests, with nonce and capability gates.
+
+## Class map
+
+| Class / file | Responsibility |
+| --- | --- |
+| `ALGQ_Deal_Marketplace` / `includes/class-algq-deal-marketplace.php` | Main coordinator. Instantiates services, registers runtime hooks, registers REST route, exposes NDA and audit services. |
+| `ALGQ_Deal_Marketplace_Activator` | Activation workflow: capabilities, tables, generated page, default options, rewrite flush. |
+| `ALGQ_Deal_Marketplace_Deactivator` | Deactivation rewrite refresh. |
+| `ALGQ_Deal_Marketplace_Capabilities` | Capability declarations, install, and removal helpers. |
+| `ALGQ_Deal_Marketplace_Security` | Nonce verification, sanitization helpers, and capability gate helpers. |
+| `ALGQ_Deal_Marketplace_Cache` | Object-cache/transient wrapper for marketplace cache keys. |
+| `ALGQ_Deal_Marketplace_Repository` | Database table names, schema creation, active listing reads, buyer interest writes, NDA acceptance writes, audit log writes, and fallback marketplace modules. |
+| `ALGQ_Deal_Marketplace_Renderer` | Public shortcode markup and admin screen markup. |
+| `ALGQ_Deal_Marketplace_Shortcodes` | Registers `[algq_marketplace]` and `[algq_deal_marketplace]`. |
+| `ALGQ_Deal_Marketplace_Assets` | Registers/enqueues public CSS/JS and admin CSS on plugin screens. |
+| `ALGQ_Deal_Marketplace_Admin` | Registers the Deal Marketplace admin menu, settings, settings sanitization, and admin-page permission gate. |
+| `ALGQ_Deal_Marketplace_Audit_Log` | Writes auditable workflow events through the repository. |
+| `ALGQ_Deal_Marketplace_NDA` | Records NDA acceptance and audit events. |
+| `ALGQ_Deal_Marketplace_Interest` | Processes buyer interest submissions from `admin-post.php`. |
+| `ALGQ_Deal_Marketplace_Integrations` | Detects optional ARE suite plugins, caches integration status, and renders missing-plugin admin notices. |
+| `Algq_Marketplace_Plugin`, `Algq_Marketplace_Activator`, `Algq_Marketplace_Sanitizer` | Legacy compatibility layer for older `algq_marketplace` module consumers. |
+
+## Data flow
+
+### Public marketplace render
+
+1. WordPress renders a page containing `[algq_marketplace]` or `[algq_deal_marketplace]`.
+2. `ALGQ_Deal_Marketplace_Shortcodes` enqueues public assets only when the shortcode is rendered.
+3. `ALGQ_Deal_Marketplace_Renderer::render_marketplace()` checks whether the current user can view the marketplace.
+4. Authorized users receive active listings from `ALGQ_Deal_Marketplace_Repository::get_active_listings()`.
+5. If no active database rows exist, the repository returns default marketplace modules so the screen remains useful during setup.
+6. The renderer escapes all listing output before returning HTML.
+
+### Admin render
+
+1. An authorized user opens **Deal Marketplace** in the WordPress admin.
+2. `ALGQ_Deal_Marketplace_Admin` verifies `algq_manage_deal_marketplace` or `manage_options`.
+3. The renderer loads active listings or fallback modules.
+4. Admin CSS is enqueued only on marketplace admin screens.
+
+### REST status render
+
+1. `GET /wp-json/algq/v1/marketplace` returns plugin name, version, supported shortcodes, default module metadata, and optional integration status.
+2. Integration status is cached to reduce repeated plugin-availability checks.
+
+## Buyer marketplace workflow
+
+1. Administrator activates the plugin and verifies capabilities, generated page, settings, and optional integration notices.
+2. Buyer or investor account receives `algq_view_deal_marketplace`; if interest submission is allowed, it also receives `algq_submit_deal_interest`.
+3. Buyer visits the generated **Deal Marketplace** page at `/deal-marketplace/`.
+4. The shortcode checks marketplace access and renders active listings or readiness modules.
+5. Buyer reviews wholesale deals, investor-access modules, syndication status, subscription options, or premium listing cards.
+6. Buyer submits interest where enabled; submissions are routed through `admin-post.php`, saved to the interests table, audited, and redirected back to the referring page.
+7. Downstream ARE plugins can consume the captured interest for CRM, portal, commerce, document, or command-center workflows.
+
+## NDA workflow
+
+1. A listing or deal room that requires confidentiality should call `ALGQ_Deal_Marketplace_NDA::accept($listing_id, $user_id)` after the buyer explicitly accepts the NDA terms.
+2. The NDA service hashes the request IP using WordPress hashing helpers before persistence.
+3. The repository writes or replaces a unique `(listing_id, user_id)` acceptance record in the NDA table.
+4. The audit log records `nda_accepted` with listing context.
+5. Protected deal details should check for the appropriate acceptance record before rendering sensitive material.
+
+The current NDA service records acceptance. Any template or integration that exposes confidential deal detail must enforce the NDA gate before output and before download generation.
+
+## Buyer interest workflow
+
+1. A buyer submits an interest form to `admin-post.php` with action `algq_deal_marketplace_interest`.
+2. `ALGQ_Deal_Marketplace_Interest` verifies the marketplace nonce using `ALGQ_Deal_Marketplace_Security::NONCE_ACTION` and `NONCE_NAME`.
+3. The same handler verifies `algq_submit_deal_interest`, `algq_manage_deal_marketplace`, or `manage_options`.
+4. Input fields are normalized: listing ID with `absint`, buyer name and message with text sanitization, buyer email with email sanitization, and offer amount as a float when present.
+5. The repository inserts the interest row with status `new` and the current user ID when available.
+6. The audit log records `interest_submitted` against the interest object.
+7. WordPress redirects back to the referrer or home page.
+
+## Generated pages
+
+Activation creates or links the default public page:
+
+| Slug | Title | Content | Option |
+| --- | --- | --- | --- |
+| `deal-marketplace` | Deal Marketplace | `[algq_marketplace]` | `algq_deal_marketplace_page_id` |
+
+Legacy compatibility code also exposes generated page definitions for `are-marketplace` containing `[algq_marketplace]` where older consumers call `algq_marketplace_generated_pages()`.
+
+## Shortcodes
+
+| Shortcode | Purpose |
+| --- | --- |
+| `[algq_marketplace]` | Primary public marketplace shortcode. |
+| `[algq_deal_marketplace]` | Alias for the same renderer. |
+
+Shortcodes should be placed on protected pages when marketplace access is private or member-only.
+
+## Admin screens
+
+| Screen | Slug | Capability | Purpose |
+| --- | --- | --- | --- |
+| Deal Marketplace | `algq-deal-marketplace` | `algq_manage_deal_marketplace` | Shows marketplace modules/listing readiness and operational messaging. |
+
+The plugin also registers the `algq_deal_marketplace_options` setting with a sanitized `access_mode` value of `private`, `members`, or `public`.
+
+## Database tables
+
+All table names use the site `$wpdb->prefix`.
+
+| Table | Purpose | Key columns / indexes |
+| --- | --- | --- |
+| `algq_deal_marketplace_listings` | Marketplace listing inventory. | `id`, `deal_id`, `title`, `status`, `visibility`, `price`, `meta`, `created_at`, `updated_at`; indexes on `status` and `visibility`. |
+| `algq_deal_marketplace_interests` | Buyer interest and offer signals. | `id`, `listing_id`, `user_id`, `buyer_name`, `buyer_email`, `offer_amount`, `message`, `status`, `created_at`; indexes on `listing_id` and `buyer_email`. |
+| `algq_deal_marketplace_ndas` | Per-listing NDA acceptance records. | `id`, `listing_id`, `user_id`, `accepted_at`, `ip_hash`; unique index on `(listing_id, user_id)`. |
+| `algq_deal_marketplace_audit_log` | Workflow audit trail. | `id`, `user_id`, `action`, `object_type`, `object_id`, `context`, `created_at`; indexes on `action` and `(object_type, object_id)`. |
+
+## Capability model
+
+| Capability | Intended holders | Allows |
+| --- | --- | --- |
+| `algq_manage_deal_marketplace` | Administrators and trusted marketplace operators. | Admin screen access, management views, and elevated marketplace operations. |
+| `algq_view_deal_marketplace` | Approved buyers, investors, subscribers, administrators. | Public shortcode marketplace visibility. |
+| `algq_submit_deal_interest` | Approved buyers/investors and administrators. | Buyer interest form submission. |
+| `algq_manage_deal_ndas` | Administrators and compliance/operations users. | NDA management workflows and future NDA administration screens. |
+
+Activation grants all marketplace capabilities to `administrator` and grants view/interest capabilities to `subscriber`. Sites with stricter buyer vetting should remove default subscriber access and assign capabilities through a buyer/investor role, membership plugin, or buyer-portal integration.
+
+## Integration points with the ARE suite
+
+`ALGQ_Deal_Marketplace_Integrations` detects optional ARE plugins by function, class, or active plugin file and caches their status under the marketplace cache group. The marketplace remains operational when these plugins are inactive, but an admin notice lists missing optional integrations.
+
+| Integration | Expected role in the marketplace workflow |
+| --- | --- |
+| `algq-deal-intake` | Supplies inbound deal records that can become marketplace listings. |
+| `algq-pipeline-crm` | Routes buyer interest to acquisition, sales, investor-relations, or follow-up pipelines. |
+| `algq-buyer-portal` | Provides buyer onboarding, saved buy boxes, account-level permissions, and private deal-room access. |
+| `algq-document-library` | Stores NDA templates, diligence files, underwriting summaries, and downloadable documents. |
+| `algq-digital-store` | Supports paid digital access products, document packs, or subscription-like marketplace assets. |
+| `algq-woocommerce-bridge` | Connects buyer subscriptions, paid access, and checkout workflows to WooCommerce. |
+| `algq-command-center` | Centralizes operator dashboards, status monitoring, and executive workflow visibility. |

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,63 @@
+# Algonquian Deal Marketplace Cache Guide
+
+## Cache keys
+
+`ALGQ_Deal_Marketplace_Cache` applies:
+
+- Group: `algq_deal_marketplace`.
+- Prefix: `algq_dm_`.
+
+Current logical keys:
+
+| Logical key | Stored key | Purpose |
+| --- | --- | --- |
+| `integrations` | `algq_dm_integrations` | Optional ARE suite plugin status. |
+| `active_listings` | `algq_dm_active_listings` | Reserved by `flush_marketplace()` for active listing cache support. |
+
+Potential future keys should follow the same naming pattern, for example `listing_{id}`, `buyer_access_{user_id}`, or `nda_{listing_id}_{user_id}`. Include user IDs or listing IDs in keys whenever cached data is permission-sensitive.
+
+## TTLs
+
+| Data | Recommended TTL | Rationale |
+| --- | --- | --- |
+| Integration status | 60 seconds | Admin notices should update quickly after optional plugin activation/deactivation. |
+| Active listing cards | 300 seconds | Listing card data changes less frequently than page views. |
+| Single listing public summary | 300 seconds | Safe for public summary fields when invalidated on listing updates. |
+| Buyer-specific access/NDA state | 60 seconds or request-only | Permission-sensitive and should update quickly. |
+| Admin dashboard summaries | 60-300 seconds | Balance operator freshness with query load. |
+
+The cache wrapper defaults `set()` calls to 300 seconds when no TTL is supplied.
+
+## Invalidation triggers
+
+Call `flush_marketplace()` or delete targeted keys when:
+
+- A listing is created, updated, published, unpublished, archived, or deleted.
+- Listing status changes to or from `active`.
+- Listing visibility changes.
+- Marketplace settings change, especially access mode.
+- Optional ARE suite plugins are activated or deactivated.
+- A buyer role or marketplace capability assignment changes.
+- NDA acceptance changes if cached access gates depend on NDA state.
+- A clear-cache admin action is executed.
+
+Avoid clearing all WordPress transients when marketplace-only keys are sufficient.
+
+## Clear-cache admin action
+
+A clear-cache action should:
+
+1. Require `algq_manage_deal_marketplace` or `manage_options`.
+2. Verify a nonce dedicated to the cache-clear operation.
+3. Call `ALGQ_Deal_Marketplace_Cache::flush_marketplace()`.
+4. Delete any future targeted listing, buyer, or NDA keys.
+5. Record an audit event such as `cache_cleared` with the current user ID.
+6. Redirect back to the marketplace admin screen with a success notice.
+
+Do not expose cache clearing to public routes or unauthenticated AJAX endpoints.
+
+## Object cache/transient fallback
+
+The cache wrapper reads from `wp_cache_get()` first. If no object-cache value is found, it falls back to `get_transient()`. Writes call both `wp_cache_set()` and `set_transient()`. Deletes call both `wp_cache_delete()` and `delete_transient()`.
+
+This design works on hosts without a persistent object cache while still benefiting from Redis/Memcached-backed object caches when present. Because transients may persist in the options table, keep cached values compact and avoid storing confidential buyer-only data unless keys are scoped and invalidated correctly.

--- a/docs/changelog-policy.md
+++ b/docs/changelog-policy.md
@@ -1,0 +1,95 @@
+# Algonquian Deal Marketplace Changelog Policy
+
+## Purpose
+
+The changelog provides operators, developers, and compliance reviewers with a readable history of marketplace changes. It should make upgrades predictable by clearly documenting functional changes, security fixes, database changes, integration changes, and operational notes.
+
+## Format
+
+Use a reverse-chronological changelog with one section per released version:
+
+```markdown
+## [1.1.0] - 2026-06-01
+
+### Added
+- New buyer access workflow.
+
+### Changed
+- Updated marketplace listing query strategy.
+
+### Fixed
+- Corrected shortcode access message escaping.
+
+### Security
+- Tightened NDA download capability checks.
+
+### Database
+- Added an index for active listing queries.
+
+### Integrations
+- Added Pipeline CRM handoff metadata.
+
+### Upgrade notes
+- Flush permalinks after activation.
+```
+
+Only include headings that have entries for that release.
+
+## Required entries
+
+Every release should include:
+
+- Version number.
+- Release date in `YYYY-MM-DD` format.
+- Summary of user-facing changes.
+- Security notes, if any.
+- Database migration notes, if any.
+- Integration behavior changes, if any.
+- Manual post-deployment steps, if any.
+
+## Categories
+
+Use these categories consistently:
+
+- **Added** for new features, screens, shortcodes, endpoints, tables, or integrations.
+- **Changed** for behavior changes, UI changes, performance changes, or dependency changes.
+- **Deprecated** for supported functionality scheduled for removal.
+- **Removed** for removed functionality.
+- **Fixed** for bug fixes.
+- **Security** for nonce, capability, escaping, sanitization, access-control, upload/download, or data-protection fixes.
+- **Database** for schema, index, migration, or data-retention changes.
+- **Integrations** for changes involving ARE suite plugins or third-party systems.
+- **Upgrade notes** for required operator actions.
+
+## Security disclosure language
+
+Security entries should be clear without exposing exploit instructions. Include:
+
+- The affected surface, such as shortcode render, admin screen, interest submission, NDA gate, REST route, upload, or download.
+- The type of mitigation, such as nonce check, capability check, escaping, sanitization, prepared query, or stricter file validation.
+- Whether operators must take action.
+
+Avoid publishing payloads, private vulnerability reports, or sensitive buyer/deal data.
+
+## Database and retention notes
+
+Document any change that affects:
+
+- `algq_deal_marketplace_listings`.
+- `algq_deal_marketplace_interests`.
+- `algq_deal_marketplace_ndas`.
+- `algq_deal_marketplace_audit_log`.
+- Generated pages or options.
+- Role/capability grants.
+
+If a release changes retention behavior for NDA, interest, or audit records, call it out under both **Database** and **Upgrade notes**.
+
+## Pre-release changelog review
+
+Before packaging:
+
+- Confirm the changelog version matches the plugin header and constants.
+- Confirm the changelog date matches the intended release date.
+- Confirm all breaking changes and manual steps are visible.
+- Confirm security fixes are documented at the right level of detail.
+- Confirm integration changes name affected optional plugins.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,144 @@
-# Deployment
-1. Set Node >=20.
-2. Populate env from `.env.example`.
-3. Install dependencies and run checks.
-4. Start runtime with `npm start`.
-5. Validate production endpoints.
+# Algonquian Deal Marketplace Deployment Guide
+
+## Pre-deployment checklist
+
+- Confirm target WordPress and PHP versions meet the site baseline for the ARE suite.
+- Confirm `algq-core` is installed and active before installing Deal Marketplace.
+- Confirm the deployment user can install plugins, activate plugins, manage options, and flush permalinks.
+- Back up the WordPress database and `wp-content/plugins` directory.
+- Export existing role/capability assignments if the site uses custom buyer or investor roles.
+- Review the target environment for optional integrations: Deal Intake, Pipeline CRM, Buyer Portal, Document Library, Digital Store, WooCommerce Bridge, and Command Center.
+- Run syntax checks and the PHPUnit smoke suite before packaging.
+- Confirm no production-only secrets or local artifacts are included in the plugin directory.
+
+## Zip packaging
+
+Package the plugin from the ARE plugins directory so the archive root is `algq-marketplace/`:
+
+```bash
+cd algonquian-real-estate/plugins
+zip -r algq-marketplace.zip algq-marketplace \
+  -x '*/.DS_Store' \
+  -x '*/node_modules/*' \
+  -x '*/vendor/*' \
+  -x '*/tests/.phpunit.result.cache'
+```
+
+Validate the archive before upload:
+
+```bash
+unzip -l algq-marketplace.zip | head
+```
+
+The first path entries should begin with `algq-marketplace/`, not `plugins/algq-marketplace/` and not loose plugin files.
+
+## WordPress upload/install steps
+
+1. Sign in to WordPress as an administrator.
+2. Go to **Plugins → Add New → Upload Plugin**.
+3. Upload `algq-marketplace.zip`.
+4. Click **Install Now**.
+5. Confirm WordPress extracts the plugin as `wp-content/plugins/algq-marketplace/`.
+6. Do not activate until `algq-core` is active.
+
+For command-line deployments, copy or unzip the plugin into `wp-content/plugins/algq-marketplace/`, then use WP-CLI activation from the WordPress root:
+
+```bash
+wp plugin activate algq-core
+wp plugin activate algq-marketplace
+```
+
+## Activation steps
+
+Activation runs the plugin activator, which:
+
+1. Installs marketplace capabilities.
+2. Creates marketplace database tables.
+3. Creates or links the default `/deal-marketplace/` page.
+4. Adds default options with private access mode.
+5. Flushes rewrite rules.
+
+After activation, open **Plugins** and verify **Algonquian Deal Marketplace** is active with the expected version.
+
+## Generated page verification
+
+- Open **Pages** and find **Deal Marketplace**.
+- Confirm the slug is `deal-marketplace`.
+- Confirm the page content contains `[algq_marketplace]`.
+- Confirm the page is published unless the deployment plan requires a draft/private status.
+- Visit `/deal-marketplace/` while signed in as an authorized marketplace user.
+- Confirm unauthorized users see the access message instead of listing details.
+
+## Permalink refresh
+
+Activation flushes rewrite rules, but production deployments should still verify permalink health:
+
+1. Go to **Settings → Permalinks**.
+2. Click **Save Changes** without changing the structure.
+3. Revisit `/deal-marketplace/`.
+4. Revisit `/wp-json/algq/v1/marketplace`.
+
+With WP-CLI:
+
+```bash
+wp rewrite flush
+```
+
+## Role/capability verification
+
+Verify the following grants after activation:
+
+- `administrator` has `algq_manage_deal_marketplace`, `algq_view_deal_marketplace`, `algq_submit_deal_interest`, and `algq_manage_deal_ndas`.
+- `subscriber` has `algq_view_deal_marketplace` and `algq_submit_deal_interest` by default.
+- If the site requires vetted buyers only, remove default subscriber access and grant view/submit capabilities to approved buyer or investor roles.
+- Confirm users who manage NDA operations have `algq_manage_deal_ndas`.
+
+WP-CLI examples:
+
+```bash
+wp cap list administrator | grep algq_
+wp cap list subscriber | grep algq_
+```
+
+## Shortcode smoke test
+
+Create a temporary draft page or use the generated page and verify:
+
+- `[algq_marketplace]` renders the marketplace heading for an authorized user.
+- `[algq_deal_marketplace]` renders the same marketplace output.
+- Public CSS and JS enqueue only when the shortcode renders.
+- Unauthorized visitors receive the sign-in/access message.
+- The page does not emit PHP notices, warnings, or fatal errors.
+
+## Admin screen smoke test
+
+- Open **Deal Marketplace** in the WordPress admin.
+- Confirm the screen is visible to an administrator or user with `algq_manage_deal_marketplace`.
+- Confirm a user without management capability cannot open the screen.
+- Confirm marketplace modules/listings render in the admin table.
+- Confirm optional integration notices are informational and do not block normal operation.
+- Confirm the `algq_deal_marketplace_options` setting sanitizes `access_mode` to `private`, `members`, or `public`.
+
+## Rollback plan
+
+1. Confirm database backup is available.
+2. Deactivate **Algonquian Deal Marketplace**.
+3. Replace `wp-content/plugins/algq-marketplace/` with the previous known-good version.
+4. Reactivate the previous version.
+5. Flush permalinks.
+6. Verify generated page, shortcode, admin screen, and REST endpoint.
+7. If a database migration caused the issue, restore the pre-deployment database backup in staging first, then production after approval.
+
+Do not delete marketplace tables during an ordinary rollback unless the rollback plan explicitly includes data restoration.
+
+## Uninstall policy
+
+The plugin deactivation path does not remove marketplace tables, pages, options, audit records, NDA records, or buyer interest records. This protects operational and compliance data.
+
+Uninstall/data deletion should be a separate, explicit administrative decision that includes:
+
+- Exporting buyer interest records.
+- Exporting NDA acceptance records and audit logs.
+- Confirming legal/compliance retention requirements.
+- Removing generated pages only after confirming no active navigation depends on them.
+- Removing custom role/capability grants only after confirming no other ARE module uses them.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,132 @@
+# Algonquian Deal Marketplace Integrations
+
+The Deal Marketplace is designed to run independently while detecting optional Algonquian Real Estate suite plugins. Missing optional plugins generate an informational admin notice for marketplace managers but should not block activation, shortcode rendering, or basic admin visibility.
+
+Integration status is exposed through the marketplace REST status payload and cached briefly under the marketplace cache group.
+
+## Integration principles
+
+- Treat all integrations as optional unless a deployment explicitly requires them.
+- Detect integrations by known class, function, or active plugin file.
+- Never assume an optional plugin is active when rendering public deal information.
+- Keep marketplace access and NDA gates in the marketplace layer even when another plugin owns documents, CRM records, or products.
+- Use audit logs when data crosses workflow boundaries.
+
+## `algq-deal-intake`
+
+Expected role:
+
+- Originates seller/deal intake records.
+- Supplies deal candidates that can become marketplace listings.
+- Provides upstream intake metadata such as property summary, seller context, acquisition strategy, and diligence status.
+
+Recommended integration flow:
+
+1. Intake creates or updates a qualified deal.
+2. Operator approves the deal for marketplace distribution.
+3. Marketplace creates/updates a listing record with a reference to the intake/deal ID.
+4. Marketplace invalidates active listing caches.
+5. Audit log records the publication or update event.
+
+## `algq-pipeline-crm`
+
+Expected role:
+
+- Routes buyer interest to sales, acquisitions, investor-relations, or dispositions pipelines.
+- Tracks follow-up tasks, stages, and owner assignment.
+- Maintains relationship history for buyers and capital partners.
+
+Recommended integration flow:
+
+1. Buyer submits marketplace interest.
+2. Marketplace stores the interest and records `interest_submitted`.
+3. CRM receives the interest payload or polls the interests table.
+4. CRM creates/updates a contact, opportunity, task, or pipeline stage.
+5. Marketplace audit context stores the CRM handoff identifier when available.
+
+## `algq-buyer-portal`
+
+Expected role:
+
+- Manages buyer onboarding, approval state, buy boxes, saved markets, and private account pages.
+- Provides a better role/capability assignment workflow than default subscriber grants.
+- Can surface marketplace listings inside a buyer dashboard.
+
+Recommended integration flow:
+
+1. Buyer completes onboarding in Buyer Portal.
+2. Buyer Portal grants marketplace view/submit capabilities when approved.
+3. Buyer Portal links to `/deal-marketplace/` or embeds the shortcode in a protected dashboard.
+4. Buyer preferences can filter marketplace listing visibility in future repository methods.
+
+## `algq-document-library`
+
+Expected role:
+
+- Stores NDA templates, executed NDA references, diligence documents, underwriting summaries, photos, and downloadable artifacts.
+- Enforces document permissions in coordination with marketplace listing/NDA state.
+
+Recommended integration flow:
+
+1. Marketplace listing references a document collection or folder.
+2. Buyer accepts NDA for the listing.
+3. Document Library checks marketplace NDA state before serving confidential documents.
+4. Document downloads are logged in the document system and/or marketplace audit log.
+
+## `algq-digital-store`
+
+Expected role:
+
+- Provides digital products related to marketplace access, document packs, education products, or paid research assets.
+- Supports monetization that is adjacent to the marketplace but not necessarily WooCommerce-specific.
+
+Recommended integration flow:
+
+1. Operator maps digital products to marketplace access tiers or listing add-ons.
+2. Buyer purchases or receives access.
+3. Digital Store grants entitlement.
+4. Marketplace checks entitlement before rendering premium content if configured.
+
+## `algq-woocommerce-bridge`
+
+Expected role:
+
+- Connects marketplace subscriptions, buyer memberships, paid deal access, and checkout workflows to WooCommerce.
+- Maps WooCommerce order/subscription state to marketplace capabilities or entitlements.
+
+Recommended integration flow:
+
+1. Buyer purchases a subscription or access product through WooCommerce.
+2. WooCommerce Bridge validates payment/subscription state.
+3. Bridge grants marketplace capabilities or buyer-portal entitlement.
+4. Marketplace renders gated content based on capability and NDA state.
+5. Failed/cancelled subscriptions revoke or suspend marketplace access.
+
+## `algq-command-center`
+
+Expected role:
+
+- Centralizes operator dashboards, health checks, deployment status, and cross-plugin workflow visibility.
+- Consumes marketplace REST status and audit signals.
+- Provides executive-level visibility into buyer interest, NDA acceptance, listing status, and optional integration health.
+
+Recommended integration flow:
+
+1. Command Center reads `GET /wp-json/algq/v1/marketplace`.
+2. It displays version, shortcodes, default modules, and integration activity.
+3. It links operators to the marketplace admin screen.
+4. It flags missing optional integrations or stale workflow state.
+
+## Integration status keys
+
+The marketplace status service uses these logical keys:
+
+| Key | Label | Detection hints |
+| --- | --- | --- |
+| `deal_intake` | Deal Intake | Function `algq_deal_intake_core_available` or plugin file. |
+| `pipeline_crm` | Pipeline CRM | Class `ALGQ_Pipeline_CRM` or plugin file. |
+| `buyer_portal` | Buyer Portal | Class `ALGQ_Buyer_Portal` or plugin file. |
+| `document_library` | Document Library | Active plugin file. |
+| `digital_store` | Digital Store | Active plugin file. |
+| `woocommerce_bridge` | WooCommerce Bridge | Class `ALGQ_WooCommerce_Bridge` or plugin file. |
+| `command_center` | Command Center | Active plugin file. |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,61 @@
+# Algonquian Deal Marketplace Performance Guide
+
+## Query strategy
+
+- Keep public marketplace reads focused on active listings.
+- The current active-listing query filters by `status = active`, orders by `updated_at DESC`, and limits results to 50 rows.
+- Use `$wpdb->prepare()` for dynamic SQL conditions.
+- Avoid loading full diligence documents, NDA files, CRM notes, or large metadata blobs in the initial card list.
+- Add pagination or cursor-based loading before increasing the public listing limit.
+- Prefer summary columns for public card rendering and lazy-load detail payloads behind buyer/NDA checks.
+
+## Cache strategy
+
+- Use `ALGQ_Deal_Marketplace_Cache` for marketplace-level cached data.
+- Store data in WordPress object cache first and transients as a persistent fallback.
+- Cache optional integration status because plugin availability checks can involve file loading and active-plugin lookups.
+- Cache active listings when listing volume or traffic justifies it, using invalidation on listing, NDA, interest, and settings changes.
+- Keep buyer-specific, NDA-specific, and capability-specific data out of shared public caches unless the key includes the relevant user/listing context.
+
+## Asset loading
+
+- Public CSS and JavaScript are registered on `wp_enqueue_scripts`.
+- Public assets are enqueued only when `[algq_marketplace]` or `[algq_deal_marketplace]` renders.
+- Admin CSS is enqueued only when the admin hook suffix contains `algq-deal-marketplace`.
+- Version asset URLs with `ALGQ_DEAL_MARKETPLACE_VERSION` to support browser-cache busting on releases.
+- Keep public JavaScript progressive and non-blocking; the marketplace page should remain readable if JavaScript fails.
+
+## Admin table pagination
+
+The current admin screen renders the active listing/module table directly. Before production listing volume grows, add:
+
+- `WP_List_Table` or equivalent pagination for listings, interests, NDA records, and audit logs.
+- Server-side filtering by status, visibility, buyer email, listing ID, and date range.
+- Bounded page sizes such as 20, 50, or 100 rows.
+- Indexed sort columns only.
+- Bulk actions protected by nonces and capabilities.
+
+## Shortcode rendering performance
+
+- Shortcode rendering should perform one bounded listing query for the marketplace card list.
+- Avoid per-card queries in loops; prefetch required data in repository methods.
+- Escape during output but sanitize during input/write to avoid repeated sanitization work on trusted stored fields.
+- Do not call optional integration checks from inside each listing card.
+- If rendering buyer-specific buttons, prefetch buyer capability/NDA state once per request and pass it to the renderer.
+
+## Database indexing expectations
+
+Expected indexes from activation:
+
+- Listings: `status`, `visibility`.
+- Interests: `listing_id`, `buyer_email`.
+- NDAs: unique `(listing_id, user_id)`.
+- Audit log: `action`, `(object_type, object_id)`.
+
+Recommended future indexes as data volume grows:
+
+- Listings: composite `(status, updated_at)` for the active listing query.
+- Listings: composite `(visibility, status)` for gated browsing.
+- Interests: composite `(listing_id, status)` for listing-level review queues.
+- Interests: composite `(buyer_email, created_at)` for buyer activity history.
+- Audit log: composite `(action, created_at)` for operational reporting.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,110 @@
+# Algonquian Deal Marketplace Release Checklist
+
+Use this checklist before packaging and deploying a marketplace release.
+
+## Version bump
+
+- [ ] Update the plugin header version in `algq-marketplace.php`.
+- [ ] Update `ALGQ_DEAL_MARKETPLACE_VERSION`.
+- [ ] Update any legacy compatibility version constants if the release affects legacy consumers.
+- [ ] Confirm asset URLs use the new version for cache busting.
+
+## Changelog update
+
+- [ ] Add an entry following `docs/changelog-policy.md`.
+- [ ] Include user-facing changes, security fixes, database changes, integration changes, and known upgrade notes.
+- [ ] Confirm the changelog date matches the release date.
+
+## Syntax check
+
+Run syntax checks for changed PHP files:
+
+```bash
+find algonquian-real-estate/plugins/algq-marketplace -name '*.php' -print0 | xargs -0 -n1 php -l
+```
+
+- [ ] No PHP syntax errors.
+- [ ] No accidental debug output.
+- [ ] No local-only file paths or secrets.
+
+## PHPUnit smoke test
+
+From the plugin directory:
+
+```bash
+cd algonquian-real-estate/plugins/algq-marketplace
+phpunit -c phpunit.xml.dist
+```
+
+- [ ] Plugin load tests pass.
+- [ ] Capability tests pass.
+- [ ] Shortcode tests pass.
+- [ ] Sanitization tests pass.
+- [ ] Activation/generation tests pass.
+
+## Manual activation test
+
+On staging:
+
+- [ ] `algq-core` is active before marketplace activation.
+- [ ] Activation completes without fatal errors.
+- [ ] Database tables are created.
+- [ ] Default options are created.
+- [ ] Rewrite rules are flushed.
+- [ ] Deactivation and reactivation do not duplicate pages or corrupt data.
+
+## Generated page test
+
+- [ ] `/deal-marketplace/` page exists.
+- [ ] Page content contains `[algq_marketplace]`.
+- [ ] Page renders for authorized marketplace users.
+- [ ] Unauthorized users receive the access-control message.
+- [ ] Permalinks are refreshed after activation.
+
+## Shortcode test
+
+- [ ] `[algq_marketplace]` renders expected markup.
+- [ ] `[algq_deal_marketplace]` renders equivalent markup.
+- [ ] Assets enqueue only on shortcode pages.
+- [ ] No browser console errors.
+- [ ] Output is escaped and does not leak private metadata.
+
+## Admin settings test
+
+- [ ] **Deal Marketplace** admin menu appears for marketplace managers.
+- [ ] Unauthorized users cannot access the admin screen directly.
+- [ ] Admin table renders listings or fallback modules.
+- [ ] `access_mode` accepts only `private`, `members`, or `public`.
+- [ ] Optional integration notice is accurate.
+
+## Cache clear test
+
+- [ ] Clear-cache action exists if included in the release.
+- [ ] Clear-cache action requires management capability.
+- [ ] Clear-cache action verifies a nonce.
+- [ ] Integration cache refreshes after optional plugin activation/deactivation.
+- [ ] Listing cache refreshes after listing updates if listing caching is enabled.
+
+## Uninstall safety review
+
+- [ ] Deactivation does not delete listings, interests, NDAs, audit logs, generated pages, or options.
+- [ ] Any uninstall/delete-data path is explicit and documented.
+- [ ] Legal/compliance retention expectations for NDA and audit records are reviewed.
+- [ ] Rollback plan has been tested on staging.
+
+## Zip packaging
+
+From `algonquian-real-estate/plugins`:
+
+```bash
+zip -r algq-marketplace.zip algq-marketplace \
+  -x '*/.DS_Store' \
+  -x '*/node_modules/*' \
+  -x '*/vendor/*' \
+  -x '*/tests/.phpunit.result.cache'
+```
+
+- [ ] Archive root is `algq-marketplace/`.
+- [ ] Archive excludes local caches and dependency directories not needed for runtime.
+- [ ] Archive installs cleanly through WordPress plugin upload.
+- [ ] Uploaded plugin version matches release notes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,71 @@
+# Algonquian Deal Marketplace Security Guide
+
+## Nonce strategy
+
+- Use `ALGQ_Deal_Marketplace_Security::NONCE_ACTION` for marketplace actions.
+- Use `ALGQ_Deal_Marketplace_Security::NONCE_NAME` as the submitted nonce field name.
+- Verify nonces before processing buyer interest, NDA acceptance, cache clearing, settings changes, or bulk admin actions.
+- Use separate action names for future destructive operations when practical, such as cache clearing, listing deletion, or NDA administration.
+- Nonce failure should return a 403-style response and should not reveal private listing details.
+
+## Capability checks
+
+- Admin screen access requires `algq_manage_deal_marketplace` or `manage_options`.
+- Public marketplace view requires `algq_view_deal_marketplace`, `algq_manage_deal_marketplace`, or `manage_options`.
+- Buyer interest submission requires `algq_submit_deal_interest`, `algq_manage_deal_marketplace`, or `manage_options`.
+- NDA administration should require `algq_manage_deal_ndas` or a stricter management capability.
+- Do not rely on page visibility alone; shortcodes, form handlers, REST callbacks, downloads, and AJAX endpoints must all enforce capabilities.
+
+## Sanitization rules
+
+- Use `sanitize_text_field()` through the security helper for names, statuses, modes, and short messages.
+- Use `sanitize_email()` for buyer email addresses.
+- Use `absint()` for listing IDs, user IDs, and object IDs.
+- Cast offer amounts to numeric values before storage and validate acceptable business ranges in future pricing workflows.
+- Use allowlists for enumerated values such as `access_mode`, `status`, and `visibility`.
+- Use `wp_unslash()` before sanitizing request input.
+
+## Escaping rules
+
+- Escape HTML text with `esc_html()`.
+- Escape attribute values with `esc_attr()`.
+- Escape URLs with `esc_url()`.
+- Escape translated strings after translation unless the string is known safe.
+- Do not echo listing metadata, buyer messages, integration labels, or admin notice content without escaping.
+- Keep rendered marketplace cards free of raw HTML from listing metadata unless sanitized through a strict allowlist.
+
+## Database access rules
+
+- Use `$wpdb->prepare()` for dynamic SELECT queries.
+- Use `$wpdb->insert()` and `$wpdb->replace()` with explicit format arrays for writes.
+- Keep table names generated internally through repository methods; do not accept table names from request input.
+- Store audit context as JSON through `wp_json_encode()`.
+- Avoid storing raw IP addresses. The NDA service stores an IP hash.
+- Do not query or display confidential listing metadata until buyer and NDA gates have passed.
+
+## Buyer access control
+
+- Approved buyer access should be represented with explicit capabilities or a dedicated buyer/investor role.
+- Sites with a public subscriber population should remove default subscriber marketplace access after activation and assign capabilities only to vetted accounts.
+- Buyer Portal integration should be the preferred home for onboarding status, buy-box preferences, and account-level gating.
+- Marketplace access should be checked at render time and at action-handler time.
+
+## NDA gate enforcement
+
+- NDA acceptance must be recorded per listing and user before confidential deal materials are shown.
+- Templates and integrations that render protected details must check the NDA record before output.
+- Download endpoints must enforce the same NDA gate as HTML views.
+- NDA acceptance events should be audited with `nda_accepted`.
+- Changing a listing from non-confidential to confidential should invalidate listing and buyer access caches.
+
+## Upload/download safety if applicable
+
+The current marketplace plugin does not implement direct upload or download endpoints. If document upload/download support is added or delegated to Document Library:
+
+- Require authenticated users and appropriate marketplace/document capabilities.
+- Verify nonces for upload and destructive file actions.
+- Validate MIME type and extension with WordPress file APIs.
+- Store files outside public paths or use signed/permissioned download routes for confidential documents.
+- Scan or reject executable files.
+- Enforce listing-level NDA acceptance before serving diligence files.
+- Log download events for compliance-sensitive materials.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,101 @@
+# Algonquian Deal Marketplace Testing Guide
+
+## PHPUnit setup
+
+The plugin includes `phpunit.xml.dist` and tests under `algonquian-real-estate/plugins/algq-marketplace/tests/`.
+
+From the plugin directory:
+
+```bash
+cd algonquian-real-estate/plugins/algq-marketplace
+phpunit -c phpunit.xml.dist
+```
+
+If PHPUnit is installed through Composer in a parent project, run the local binary instead:
+
+```bash
+../../vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+The test bootstrap supports a lightweight shim mode for safe plugin-load, shortcode, capability, activation, and sanitization tests without connecting to a production database. For full WordPress integration testing, install the WordPress test suite, set `WP_DEVELOP_DIR` and `WP_TESTS_DIR`, and point the test suite only at disposable test data.
+
+## Test suite scope
+
+Automated tests should cover:
+
+- Main plugin file existence and load safety.
+- Required constants and classes.
+- Activation class and generated page definitions.
+- Capability declarations and expected role grants.
+- Shortcode registration and expected render structure.
+- Sanitization helpers for text, keys, URLs, emails, and textarea-style values where present.
+- Legacy compatibility APIs that older ARE consumers may call.
+
+Automated tests in shim mode intentionally should not cover production database writes, live REST dispatch through WordPress core, external network calls, or real role persistence. Use a disposable WordPress test database or staging site for those checks.
+
+## Manual QA checklist
+
+- Activate the plugin on a staging site with `WP_DEBUG` enabled.
+- Confirm activation completes without fatal errors.
+- Confirm generated tables exist with the expected names and indexes.
+- Confirm `/deal-marketplace/` exists and contains the shortcode.
+- Confirm an authorized user can view marketplace cards.
+- Confirm an unauthorized user sees only the access-control message.
+- Confirm the admin screen renders for authorized users.
+- Confirm optional integration notices appear only to marketplace managers.
+- Confirm deactivation does not delete data.
+- Confirm reactivation does not duplicate generated pages.
+
+## Browser QA checklist
+
+Test the generated marketplace page in current Chrome, Safari, Firefox, and Edge where possible:
+
+- Desktop width.
+- Tablet width.
+- Mobile width.
+- Signed-in authorized buyer.
+- Signed-in unauthorized user.
+- Signed-out visitor.
+- High-contrast or reduced-motion browser settings if supported.
+- Browser console free of JavaScript errors.
+- Network panel confirms marketplace assets load successfully only on pages using the shortcode.
+
+## Security checks
+
+- Verify buyer interest submissions require the marketplace nonce.
+- Verify buyer interest submissions require `algq_submit_deal_interest`, marketplace management capability, or `manage_options`.
+- Verify admin screen access requires `algq_manage_deal_marketplace` or `manage_options`.
+- Verify all user-controlled output is escaped with the appropriate WordPress escaping helper.
+- Verify database writes use `$wpdb` format arrays or prepared SQL.
+- Verify NDA acceptance stores hashed IP data rather than raw IP data.
+- Verify confidential deal details are not shown without buyer access and NDA acceptance where applicable.
+- Verify REST output contains status metadata only and does not leak private deal details.
+
+## Shortcode checks
+
+- `[algq_marketplace]` renders the ARE Deal Marketplace section for authorized users.
+- `[algq_deal_marketplace]` renders equivalent output.
+- Shortcodes enqueue `deal-marketplace.css` and `deal-marketplace.js` when rendered.
+- Shortcodes do not enqueue public assets on unrelated pages.
+- Shortcodes escape listing titles, descriptions, and statuses.
+- Shortcodes return a clear access message for unauthorized users.
+
+## Admin checks
+
+- **Deal Marketplace** menu appears for authorized managers.
+- Menu does not appear for unauthorized users.
+- Admin table lists active listings or fallback marketplace modules.
+- Admin CSS loads only on marketplace admin screens.
+- Settings registration accepts only valid `access_mode` values.
+- Optional integration notice lists inactive optional suite plugins.
+
+## Buyer workflow checks
+
+- Approved buyer can access `/deal-marketplace/`.
+- Buyer can view active listing cards or setup modules.
+- Buyer can submit interest when the form/integration is present and the buyer has submit capability.
+- Interest row is written with listing ID, buyer identity, offer amount when present, message, status `new`, and timestamp.
+- Audit log records `interest_submitted`.
+- Buyer is redirected back to the referring page after submission.
+- NDA acceptance records `(listing_id, user_id)`, timestamp, and hashed IP.
+- Audit log records `nda_accepted`.


### PR DESCRIPTION
### Motivation

- Provide comprehensive operator and developer documentation for the Algonquian Deal Marketplace WordPress plugin covering architecture, deployment, testing, performance, caching, security, integrations, release and changelog processes.

### Description

- Added or updated documentation files under `docs/`: `architecture.md`, `deployment.md`, `testing.md`, `performance.md`, `cache.md`, `security.md`, `integrations.md`, `release-checklist.md`, and `changelog-policy.md`.
- `architecture.md` maps plugin purpose, WordPress lifecycle hooks, class map, data flow, buyer marketplace workflow, NDA and interest workflows, generated pages, shortcodes, admin screens, database tables, capability model, and ARE-suite integration points.
- `deployment.md` and `release-checklist.md` provide pre-deploy checks, zip packaging instructions, WP upload/activation steps, generated page verification, permalink refresh, role/capability verification, shortcode/admin smoke tests, rollback guidance, and uninstall policy.
- `testing.md`, `performance.md`, `cache.md`, `security.md`, and `integrations.md` codify PHPUnit setup and scope, query and caching strategies (keys/TTLs/invalidation), asset-loading and pagination guidance, nonce/capability/sanitization/escaping rules, and recommended integration flows for ARE suite modules.

### Testing

- A Node-based file check verified all required docs exist, start with an H1, and include a trailing newline, and that check passed.
- `npm test` (project smoke tests) was run and failed because the smoke test expected a shorter API route list while the runtime returned additional routes (`/api/pages`, `/api/tools`, `/api/artifacts`, `/api/system-health`).
- PHPUnit was not executed in this run; the plugin includes `phpunit.xml.dist` and `docs/testing.md` describes how to run the PHPUnit suite in shim or full WordPress test modes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9cde096c832dbd43299bdcad2f0f)