### PR TITLE
Harden marketplace release validation and opt-in uninstall cleanup

### DIFF
--- a/algonquian-real-estate/plugins/algq-marketplace/README.md
+++ b/algonquian-real-estate/plugins/algq-marketplace/README.md
@@ -28,6 +28,12 @@ Activation declares and creates the public ARE Marketplace page when a WordPress
 
 - `are-marketplace` — renders `[algq_marketplace]`
 
+## Release validation
+
+See [`RELEASE_VALIDATION.md`](RELEASE_VALIDATION.md) for the final production-hardening checklist covering PHP lint, PHPUnit smoke testing, activation, generated pages, shortcodes, buyer flows, marketplace listings, deal detail access, NDA gates, interested-buyer submission, admin dashboard, cache clearing, optional suite-plugin inactivity, and uninstall behavior.
+
+Uninstall is non-destructive by default. Marketplace tables and generated options are deleted only when an administrator explicitly enables **Delete marketplace tables and generated options during uninstall** before uninstalling.
+
 ## PHPUnit tests
 
 The plugin includes a safe PHPUnit suite in `tests/` with `phpunit.xml.dist`. The suite is designed to avoid production database access and external network calls.

--- a/algonquian-real-estate/plugins/algq-marketplace/RELEASE_VALIDATION.md
+++ b/algonquian-real-estate/plugins/algq-marketplace/RELEASE_VALIDATION.md
@@ -1,0 +1,42 @@
+# Algonquian Deal Marketplace Release Validation
+
+Use this checklist before packaging or deploying the production plugin. The PHPUnit suite is scaffolded in `tests/` and can run in lightweight shim mode or against a disposable WordPress test suite.
+
+## Automated checks
+
+- Run PHP syntax validation for every plugin PHP file:
+
+  ```bash
+  find algonquian-real-estate/plugins/algq-marketplace -name '*.php' -print0 | xargs -0 -n1 php -l
+  ```
+
+- Run PHPUnit smoke tests when PHPUnit is available:
+
+  ```bash
+  cd algonquian-real-estate/plugins/algq-marketplace
+  phpunit -c phpunit.xml.dist
+  ```
+
+If PHPUnit is unavailable in the execution environment, record that the suite is scaffolded and complete PHP lint plus the manual WordPress smoke validation below before release packaging.
+
+## Manual WordPress smoke validation
+
+Validate on a disposable staging site, not production data:
+
+1. Activate the plugin and confirm no fatal errors.
+2. Confirm automatic marketplace page generation and that generated page IDs are stored.
+3. Confirm `[algq_marketplace]` and `[algq_deal_marketplace]` render public marketplace markup.
+4. Register and log in as a buyer/investor user.
+5. Confirm marketplace listing cards display, including the branded public styling and responsive card polish.
+6. Open a deal detail view and verify the NDA gate appears before restricted details.
+7. Accept the NDA and confirm gated detail access is unlocked only for that buyer/listing combination.
+8. Submit an interested-buyer form and confirm the interest record and audit log are created.
+9. Open the admin dashboard and confirm branded admin styling, KPI cards, settings, and suite-status messaging render.
+10. Trigger the cache clear action and confirm the success notice appears without errors.
+11. Deactivate optional Algonquian suite plugins and confirm marketplace screens avoid fatal errors.
+12. Uninstall with **Delete marketplace tables and generated options during uninstall** unchecked and confirm data is retained.
+13. Only for disposable data, enable the uninstall deletion option and confirm uninstall removes marketplace tables and generated options.
+
+## Release note
+
+Uninstall is non-destructive by default. Destructive cleanup requires an administrator to explicitly enable the uninstall deletion setting before uninstalling the plugin.

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-activator.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-activator.php
@@ -28,6 +28,9 @@ final class ALGQ_Deal_Marketplace_Activator
 
         add_option('algq_deal_marketplace_options', [
             'access_mode' => 'private',
+            'caching_enabled' => '1',
+            'default_cache_ttl' => (string) ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS,
+            'delete_data_on_uninstall' => '0',
         ]);
 
         flush_rewrite_rules();

--- a/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-admin.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/includes/class-algq-deal-marketplace-admin.php
@@ -55,6 +55,7 @@ final class ALGQ_Deal_Marketplace_Admin
                 'access_mode' => 'private',
                 'caching_enabled' => '1',
                 'default_cache_ttl' => (string) ALGQ_Deal_Marketplace_Cache::TTL_LISTINGS,
+                'delete_data_on_uninstall' => '0',
             ],
         ]);
     }
@@ -86,6 +87,7 @@ final class ALGQ_Deal_Marketplace_Admin
             'access_mode' => $this->security->sanitize_allowed($options['access_mode'] ?? $existing['access_mode'] ?? '', ['private', 'members', 'public'], 'private'),
             'caching_enabled' => !empty($options['caching_enabled']) ? '1' : '0',
             'default_cache_ttl' => (string) $ttl,
+            'delete_data_on_uninstall' => !empty($options['delete_data_on_uninstall']) ? '1' : '0',
         ];
     }
 
@@ -142,6 +144,15 @@ final class ALGQ_Deal_Marketplace_Admin
                         <td>
                             <input id="algq-default-cache-ttl" type="number" min="30" max="86400" step="30" name="algq_deal_marketplace_options[default_cache_ttl]" value="<?php echo esc_attr((string) $ttl); ?>" />
                             <p class="description"><?php echo esc_html__('Time to keep listing cache entries, in seconds. Dashboard summaries use 120 seconds, settings use 1800 seconds, and NDA status uses 600 seconds.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php echo esc_html__('Uninstall behavior', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?></th>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="algq_deal_marketplace_options[delete_data_on_uninstall]" value="1" <?php checked(!empty($options['delete_data_on_uninstall']) && '1' === (string) $options['delete_data_on_uninstall']); ?> />
+                                <?php echo esc_html__('Delete marketplace tables and generated options during uninstall. Leave unchecked for non-destructive release-safe uninstalls.', ALGQ_DEAL_MARKETPLACE_TEXT_DOMAIN); ?>
+                            </label>
                         </td>
                     </tr>
                 </table>

--- a/algonquian-real-estate/plugins/algq-marketplace/uninstall.php
+++ b/algonquian-real-estate/plugins/algq-marketplace/uninstall.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Uninstall handler for Algonquian Deal Marketplace.
+ *
+ * The plugin is intentionally non-destructive by default. Marketplace tables,
+ * generated page references, and settings are removed only when the
+ * delete-data-on-uninstall option has been explicitly enabled by an admin.
+ *
+ * @package Algonquian_Deal_Marketplace
+ */
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+$algq_deal_marketplace_options = get_option('algq_deal_marketplace_options', []);
+
+if (!is_array($algq_deal_marketplace_options) || '1' !== (string) ($algq_deal_marketplace_options['delete_data_on_uninstall'] ?? '0')) {
+    return;
+}
+
+global $wpdb;
+
+$algq_deal_marketplace_tables = [
+    $wpdb->prefix . 'algq_deal_marketplace_listings',
+    $wpdb->prefix . 'algq_deal_marketplace_interests',
+    $wpdb->prefix . 'algq_deal_marketplace_ndas',
+    $wpdb->prefix . 'algq_deal_marketplace_audit_log',
+];
+
+foreach ($algq_deal_marketplace_tables as $algq_deal_marketplace_table) {
+    $wpdb->query('DROP TABLE IF EXISTS ' . esc_sql($algq_deal_marketplace_table));
+}
+
+delete_option('algq_deal_marketplace_options');
+delete_option('algq_deal_marketplace_page_id');
+delete_option('algq_marketplace_page_id');


### PR DESCRIPTION
### Motivation

- Final production-hardening pass to add a formal release-validation runbook and surface uninstall safety for the Algonquian Deal Marketplace plugin.
- Ensure fresh installs default to non-destructive behavior while giving administrators an explicit opt-in for destructive uninstall cleanup.

### Description

- Add `RELEASE_VALIDATION.md` with an automated and manual checklist covering PHP lint, PHPUnit smoke tests, activation/page generation, shortcodes, buyer flows, NDA gates, interested-buyer submission, admin dashboards, cache clearing, optional suite-plugin inactivity, and uninstall checks.
- Link the release validation guidance from the plugin `README.md` and document the default non-destructive uninstall behavior.
- Add an explicit `uninstall.php` that only drops marketplace tables and deletes options when the admin option `delete_data_on_uninstall` is set to `1`.
- Expose the `delete_data_on_uninstall` option in admin settings and activation defaults by updating the activator defaults and the admin settings/sanitizer to persist and validate the opt-in flag.

### Testing

- Ran PHP syntax checks with `find ... -name '*.php' -print0 | xargs -0 -n1 php -l` and confirmed no syntax errors for all plugin PHP files.
- Executed the lightweight test bootstrap with `php -r "require 'algonquian-real-estate/plugins/algq-marketplace/tests/bootstrap.php'; ..."` and confirmed the shortcode is registered (output: `shortcode registered`).
- Attempted to run PHPUnit with `phpunit -c phpunit.xml.dist` but PHPUnit was not available in the execution environment; the scaffold remains present at `algonquian-real-estate/plugins/algq-marketplace/phpunit.xml.dist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dadd370e4832d9275982d100de0ac)