### PR TITLE
feat: ONEGODIAN Capital Portal — global navigation, mobile UI, and pages

### DIFF
--- a/src/app/(app)/docs/page.tsx
+++ b/src/app/(app)/docs/page.tsx
@@ -36,22 +36,5 @@ export default function DocsPage() {
         ))}
       </section>
     </main>
-import { CardGrid, InfoCard, OmosPage } from '@/app/components/omos-docs-ui';
-
-const docs = [
-  ['Getting started', 'Read the protocol, confirm the compliance boundary, request an API key, then test POST /api/process with a small source payload.'],
-  ['Runtime architecture', 'Public pages document the node; API routes expose health, manifest, readiness, stats, and processing; operators verify status before release.'],
-  ['Protocol', 'The human, semantic, agent, interface, and compliance layers define how content becomes repeatable system output.'],
-  ['Algorithm', 'Observe, Distill, Align, Select, Execute, and Verify provide the runtime model for implementation and review.'],
-  ['Auth', 'Use x-omos-key for authenticated endpoints. Store keys server-side and never expose them in browser bundles.'],
-  ['Errors', 'Unauthorized, invalid input, plan limit, rate limit, and server errors should include a requestId for operator review.'],
-  ['Deployment notes', 'Deploy only documented and repeatable features. Check health, manifest, and status routes after each release.']
-];
-
-export default function DocsPage() {
-  return (
-    <OmosPage eyebrow="Docs" title="Developer and operator documentation." description="This documentation hub explains how OMOS is structured, how to integrate with the runtime, and how to label operational status safely.">
-      <CardGrid>{docs.map(([title, detail], i) => <InfoCard key={title} title={title} accent={i % 3 === 0 ? 'gold' : i % 3 === 1 ? 'cyan' : 'green'}><p>{detail}</p></InfoCard>)}</CardGrid>
-    </OmosPage>
   );
 }

--- a/src/app/(app)/records/page.tsx
+++ b/src/app/(app)/records/page.tsx
@@ -1,1 +1,12 @@
-export default function Page(){return <main><h1 className="text-3xl font-bold">Records</h1><p className="mt-3">Public/member-facing records index.</p></main>}
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from '../../components/CapitalPage';
+
+const records = ['Contributor Records', 'Instrument References', 'Disclosure Acknowledgements', 'Certificate References', 'Payment References', 'Verification Logs'];
+
+export default function RecordsPage() {
+  return (
+    <CapitalPage title="Records" subtitle="The Records page organizes contributor records, instrument references, disclosure acknowledgements, certificate references, payment references, and verification logs for controlled internal review.">
+      <NoticePanel>Private records should require authentication before display.</NoticePanel>
+      <CapitalCardGrid>{records.map((record) => <CapitalCard key={record} title={record}><p>Controlled recordkeeping category for authenticated internal review.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
+  );
+}

--- a/src/app/(app)/verification/page.tsx
+++ b/src/app/(app)/verification/page.tsx
@@ -1,5 +1,20 @@
-import { redirect } from 'next/navigation';
+import { CapitalPage, NoticePanel } from '../../components/CapitalPage';
 
-export default function VerificationRedirectPage() {
-  redirect('/verify');
+const fields = ['Certificate ID', 'Contributor Record ID', 'Disclosure Acknowledgement ID', 'OBP-1 Reference', 'Instrument Code'];
+
+export default function VerificationPage() {
+  return (
+    <CapitalPage title="Verification" subtitle="Use this page to verify certificate references, contribution record IDs, disclosure acknowledgement IDs, and OBP-1 references.">
+      <NoticePanel>Verification confirms whether a record exists in the Capital Portal system. It does not independently validate the legal effect, market value, transferability, or enforceability of any instrument.</NoticePanel>
+      <form className="glass-panel grid gap-4 p-5 sm:grid-cols-2">
+        {fields.map((field) => (
+          <label key={field} className="text-sm font-bold text-white">
+            {field}
+            <input className="capital-field mt-2" name={field.toLowerCase().replaceAll(' ', '-')} placeholder={field} />
+          </label>
+        ))}
+        <button type="button" className="premium-button sm:col-span-2">Submit Verification Request</button>
+      </form>
+    </CapitalPage>
+  );
 }

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -1,28 +1,12 @@
-import { certificates } from '../data';
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from '../components/CapitalPage';
 
-export default function CertificateRecordsPage() {
+const cards = ['Verify Certificate', 'Search Certificate ID', 'Download Record', 'View OBP-1 Reference', 'Certificate Status', 'Issuer Notes'];
+
+export default function CertificatesPage() {
   return (
-    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <section className="glass-panel p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Verification Records</p>
-        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Certificate Records</h1>
-        <p className="mt-3 leading-7 text-slate-300">Review certificate record status, instrument references, and verification metadata.</p>
-      </section>
-      <div className="mt-5 rounded-3xl border border-gold-300/30 bg-gold-300/10 p-4 text-sm leading-6 text-gold-100 backdrop-blur-xl">
-        Certificate records displayed in this portal are administrative records for documentation, verification support, and audit review. A listed record does not replace executed agreements, disclosure review, payment confirmation, legal review, or final internal acceptance.
-      </div>
-      <div className="mt-6 grid gap-4 md:grid-cols-2">
-        {certificates.map((record) => (
-          <article key={record.recordId} className="mobile-card space-y-2 text-sm leading-6 text-slate-200">
-            <p><strong className="text-gold-200">Record ID:</strong> {record.recordId}</p>
-            <p><strong className="text-gold-200">Instrument Reference:</strong> {record.instrumentReference}</p>
-            <p><strong className="text-gold-200">Holder Reference:</strong> {record.holderReference}</p>
-            <p><strong className="text-gold-200">Record Status:</strong> {record.recordStatus}</p>
-            <p><strong className="text-gold-200">Issuance Status:</strong> {record.issuanceStatus}</p>
-            <p><strong className="text-gold-200">Verification Metadata:</strong> {record.verificationMetadata}</p>
-          </article>
-        ))}
-      </div>
-    </main>
+    <CapitalPage title="Certificates" subtitle="The Certificates section supports document references, certificate records, OBP-1 verification references, QR validation, and downloadable proof-of-record files where applicable.">
+      <NoticePanel>Certificates are recordkeeping tools. They do not replace legal review, ownership documentation, offering documents, contracts, or required disclosures.</NoticePanel>
+      <CapitalCardGrid>{cards.map((card) => <CapitalCard key={card} title={card}><p>Certificate workflow support for record references, status confirmation, and verification routing.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
   );
 }

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -1,0 +1,12 @@
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from '../components/CapitalPage';
+
+const cards = ['Entity Boundary', 'Offering Boundary', 'Disclosure Boundary', 'Checkout Boundary', 'Certificate Boundary', 'Advisor Review Notice'];
+
+export default function CompliancePage() {
+  return (
+    <CapitalPage title="Compliance" subtitle="The Capital Portal is designed to support recordkeeping, disclosures, verification, and operational readiness.">
+      <NoticePanel>The portal does not independently create securities, approve offerings, solicit investment, guarantee returns, or replace legal, financial, tax, or compliance review.</NoticePanel>
+      <CapitalCardGrid>{cards.map((card) => <CapitalCard key={card} title={card}><p>Boundary guidance for controlled capital portal operations and review discipline.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
+  );
+}

--- a/src/app/components/CapitalFooter.tsx
+++ b/src/app/components/CapitalFooter.tsx
@@ -1,38 +1,33 @@
 import Link from 'next/link';
-import { complianceSafeWording, omosRoutes, productionRule } from '@/lib/omos-docs-content';
+import { additionalCapitalLinks, complianceFooterCopy, primaryCapitalLinks } from './capital-content';
 
 export function CapitalFooter() {
   return (
-    <footer className="mt-10 border-t border-gold-300/15 bg-black/55">
+    <footer className="mt-10 border-t border-gold-300/15 bg-black/55 pb-24 sm:pb-8">
       <div className="mx-auto grid max-w-7xl gap-6 px-4 py-8 text-sm text-slate-300 sm:px-6 md:grid-cols-[1.4fr_1fr_1fr] lg:px-8">
         <section>
-          <h2 className="text-base font-black text-white">OMOS™ — OneGodian Metaphysical Operating System™</h2>
-          <p className="mt-2 text-slate-300">A ONEGODIAN, LLC systems architecture node.</p>
-          <p className="mt-4 max-w-3xl text-xs leading-5 text-slate-400">{complianceSafeWording}</p>
-          <p className="mt-2 max-w-3xl text-xs font-semibold leading-5 text-gold-100">{productionRule}</p>
+          <h2 className="text-base font-black text-white">ONEGODIAN CAPITAL PORTAL™</h2>
+          <p className="mt-2 text-slate-300">Controlled recordkeeping and capital-documentation interface for ONEGODIAN, LLC.</p>
+          <p className="mt-4 max-w-3xl text-xs leading-5 text-slate-400">{complianceFooterCopy}</p>
         </section>
         <section>
-          <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-gold-300">Documentation</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-gold-300">Capital Portal</h2>
           <ul className="mt-3 grid grid-cols-2 gap-2">
-            {omosRoutes.map((link) => (
-              <li key={link.href}>
-                <Link href={link.href} className="hover:text-cyan-200">{link.label}</Link>
-              </li>
+            {primaryCapitalLinks.map((link) => (
+              <li key={link.href}><Link href={link.href} className="hover:text-gold-200">{link.label}</Link></li>
             ))}
           </ul>
         </section>
         <section>
-          <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-gold-300">Runtime</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-gold-300">Support</h2>
           <ul className="mt-3 space-y-2">
-            <li><Link href="/api" className="hover:text-cyan-200">POST /api/process</Link></li>
-            <li><Link href="/status" className="hover:text-cyan-200">Runtime status</Link></li>
-            <li><Link href="/roadmap" className="hover:text-cyan-200">Planned features</Link></li>
+            {additionalCapitalLinks.map((link) => (
+              <li key={link.href}><Link href={link.href} className="hover:text-gold-200">{link.label}</Link></li>
+            ))}
           </ul>
         </section>
       </div>
-      <div className="border-t border-gold-300/15 px-4 py-4 text-center text-xs leading-5 text-slate-400">
-        © ONEGODIAN, LLC. All rights reserved.
-      </div>
+      <div className="border-t border-gold-300/15 px-4 py-4 text-center text-xs leading-5 text-slate-400">© ONEGODIAN, LLC. All rights reserved.</div>
     </footer>
   );
 }

--- a/src/app/components/CapitalNavigation.tsx
+++ b/src/app/components/CapitalNavigation.tsx
@@ -2,29 +2,72 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { omosRoutes } from '@/lib/omos-docs-content';
+import { useState } from 'react';
+import { additionalCapitalLinks, mobilePrimaryLinks, primaryCapitalLinks } from './capital-content';
+
+const moreLinks = [
+  { label: 'Investor Portal', href: '/investor-portal' },
+  { label: 'Records', href: '/records' },
+  { label: 'Verification', href: '/verification' },
+  { label: 'Compliance', href: '/compliance' },
+  { label: 'Documents', href: '/documents' },
+  { label: 'FAQ', href: '/faq' },
+  { label: 'Contact', href: '/contact' }
+];
+
+function isActive(pathname: string, href: string) {
+  return href === '/' ? pathname === '/' : pathname === href || pathname.startsWith(`${href}/`);
+}
 
 export function CapitalNavigation() {
   const pathname = usePathname() ?? '/';
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreActive = moreLinks.some((link) => isActive(pathname, link.href));
 
   return (
-    <header className="capital-header">
-      <div className="capital-header-inner">
-        <Link href="/" className="capital-logo" aria-label="OMOS home">
-          <span className="capital-logo-mark">OM</span>
-          <span>OMOS<span className="hidden sm:inline"> Documentation Node</span></span>
-        </Link>
-        <nav className="capital-nav" aria-label="Primary OMOS navigation">
-          {omosRoutes.map((item) => {
-            const active = item.href === '/' ? pathname === '/' : pathname === item.href || pathname.startsWith(`${item.href}/`);
-            return (
-              <Link key={item.href} href={item.href} className={active ? 'is-active' : undefined}>
+    <>
+      <header className="capital-header">
+        <div className="capital-header-inner">
+          <Link href="/" className="capital-logo" aria-label="ONEGODIAN Capital Portal home">
+            <span className="capital-logo-mark">OC</span>
+            <span>ONEGODIAN CAPITAL PORTAL™</span>
+          </Link>
+          <nav className="capital-nav" aria-label="Primary capital navigation">
+            {primaryCapitalLinks.map((item) => (
+              <Link key={item.href} href={item.href} className={isActive(pathname, item.href) ? 'is-active' : undefined}>
                 {item.label}
               </Link>
-            );
-          })}
-        </nav>
-      </div>
-    </header>
+            ))}
+          </nav>
+          <nav className="capital-ecosystem-nav" aria-label="Additional capital navigation">
+            {additionalCapitalLinks.map((item) => (
+              <Link key={item.href} href={item.href} className={isActive(pathname, item.href) ? 'is-active' : undefined}>
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </header>
+
+      <nav className="capital-mobile-nav" aria-label="Mobile capital navigation">
+        {mobilePrimaryLinks.map((item) => (
+          <Link key={item.href} href={item.href} className={isActive(pathname, item.href) ? 'is-active' : undefined} onClick={() => setMoreOpen(false)}>
+            {item.label}
+          </Link>
+        ))}
+        <button type="button" className={moreActive || moreOpen ? 'is-active' : undefined} aria-expanded={moreOpen} aria-controls="capital-mobile-more" onClick={() => setMoreOpen((open) => !open)}>
+          More
+        </button>
+      </nav>
+      {moreOpen ? (
+        <div id="capital-mobile-more" className="capital-mobile-more">
+          {moreLinks.map((item) => (
+            <Link key={item.href} href={item.href} className={isActive(pathname, item.href) ? 'is-active' : undefined} onClick={() => setMoreOpen(false)}>
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/src/app/components/CapitalPage.tsx
+++ b/src/app/components/CapitalPage.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+import { type ReactNode } from 'react';
+
+type CapitalPageProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  actions?: { href: string; label: string }[];
+};
+
+export function CapitalPage({ eyebrow = 'ONEGODIAN CAPITAL PORTAL™', title, subtitle, children, actions }: CapitalPageProps) {
+  return (
+    <main className="capital-page onegodian-surface mx-auto w-full max-w-7xl px-4 py-6 text-slate-100 sm:px-6 lg:px-8 lg:py-10">
+      <section className="glass-panel capital-hero relative overflow-hidden p-5 sm:p-8 lg:p-10">
+        <div className="absolute -right-16 -top-20 h-52 w-52 rounded-full bg-gold-300/20 blur-3xl" />
+        <div className="absolute -bottom-24 left-1/4 h-56 w-56 rounded-full bg-purple-300/10 blur-3xl" />
+        <div className="relative">
+          <p className="text-xs font-black uppercase tracking-[0.28em] text-gold-300">{eyebrow}</p>
+          <h1 className="mt-3 max-w-5xl text-3xl font-black tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">{title}</h1>
+          {subtitle ? <p className="mt-4 max-w-4xl text-base leading-7 text-slate-300 sm:text-lg">{subtitle}</p> : null}
+          {actions ? (
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:flex lg:flex-wrap">
+              {actions.map((action, index) => (
+                <Link key={action.href} href={action.href} className={index === 0 ? 'premium-button' : 'premium-button-secondary'}>
+                  {action.label}
+                </Link>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </section>
+      <div className="mt-6 space-y-6">{children}</div>
+    </main>
+  );
+}
+
+export function CapitalCardGrid({ children, cols = 'lg:grid-cols-3' }: { children: ReactNode; cols?: string }) {
+  return <section className={`grid gap-4 sm:grid-cols-2 ${cols}`}>{children}</section>;
+}
+
+export function CapitalCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <article className="mobile-card">
+      <h2 className="text-xl font-black text-white">{title}</h2>
+      <div className="mt-3 text-sm leading-6 text-slate-300">{children}</div>
+    </article>
+  );
+}
+
+export function NoticePanel({ children }: { children: ReactNode }) {
+  return <section className="rounded-3xl border border-gold-300/25 bg-gold-300/10 p-5 text-sm leading-6 text-gold-50 backdrop-blur-xl">{children}</section>;
+}

--- a/src/app/components/capital-content.ts
+++ b/src/app/components/capital-content.ts
@@ -1,0 +1,25 @@
+export const primaryCapitalLinks = [
+  { label: 'Offerings', href: '/offerings' },
+  { label: 'Investor Portal', href: '/investor-portal' },
+  { label: 'Disclosures', href: '/disclosures' },
+  { label: 'Certificates', href: '/certificates' },
+  { label: 'Readiness', href: '/readiness' },
+  { label: 'Records', href: '/records' },
+  { label: 'Verification', href: '/verification' },
+  { label: 'Compliance', href: '/compliance' }
+];
+
+export const additionalCapitalLinks = [
+  { label: 'Documents', href: '/documents' },
+  { label: 'FAQ', href: '/faq' },
+  { label: 'Contact', href: '/contact' }
+];
+
+export const mobilePrimaryLinks = [
+  { label: 'Offerings', href: '/offerings' },
+  { label: 'Disclosures', href: '/disclosures' },
+  { label: 'Certificates', href: '/certificates' },
+  { label: 'Readiness', href: '/readiness' }
+];
+
+export const complianceFooterCopy = 'The ONEGODIAN Capital Portal is a recordkeeping, disclosure, certificate, verification, and readiness interface. It is not a broker-dealer, exchange, investment adviser, bank, or legal adviser. Nothing displayed here is legal, tax, financial, or investment advice.';

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,16 @@
+import { CapitalPage, NoticePanel } from '../components/CapitalPage';
+
+export default function ContactPage() {
+  return (
+    <CapitalPage title="Contact" subtitle="Use this page for capital portal support, document review questions, disclosure access, certificate verification issues, and contributor record assistance.">
+      <NoticePanel>Submit support details for routing to the appropriate capital portal review workflow.</NoticePanel>
+      <form className="glass-panel grid gap-4 p-5 sm:grid-cols-2">
+        <label className="text-sm font-bold text-white">Name<input className="capital-field mt-2" name="name" autoComplete="name" /></label>
+        <label className="text-sm font-bold text-white">Email<input className="capital-field mt-2" name="email" type="email" autoComplete="email" /></label>
+        <label className="text-sm font-bold text-white sm:col-span-2">Reason for inquiry<input className="capital-field mt-2" name="reason" /></label>
+        <label className="text-sm font-bold text-white sm:col-span-2">Message<textarea className="capital-field mt-2 min-h-36" name="message" /></label>
+        <button type="button" className="premium-button sm:col-span-2">Send Inquiry</button>
+      </form>
+    </CapitalPage>
+  );
+}

--- a/src/app/disclosures/page.tsx
+++ b/src/app/disclosures/page.tsx
@@ -1,11 +1,15 @@
-export default function Page() {
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from '../components/CapitalPage';
+
+const cards = ['General Disclosure Notice', 'Risk Factors', 'No Guarantee Notice', 'Forward-Looking Statements', 'Private Records Notice', 'Acknowledgement History'];
+
+export default function DisclosuresPage() {
   return (
-    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <section className="glass-panel p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
-        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Disclosures</h1>
-        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for disclosures with disclosure review and acknowledgement workflow support.</p>
-      </section>
-    </main>
+    <CapitalPage title="Disclosure Center" subtitle="All capital participation requires disclosure review and acknowledgement.">
+      <NoticePanel>
+        <p>This page provides access to general notices, risk language, participation disclaimers, review requirements, and acknowledgement records.</p>
+        <p className="mt-3">Nothing on this page is legal, financial, tax, or investment advice. Participation decisions should be reviewed with qualified advisors where appropriate.</p>
+      </NoticePanel>
+      <CapitalCardGrid>{cards.map((card) => <CapitalCard key={card} title={card}><p>Disclosure material and acknowledgement recordkeeping for controlled capital workflows.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
   );
 }

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,11 @@
+import { CapitalCard, CapitalCardGrid, CapitalPage } from '../components/CapitalPage';
+
+const docs = ['Public Summaries', 'Disclosure Documents', 'Readiness Materials', 'Certificate Templates', 'Review Files'];
+
+export default function DocumentsPage() {
+  return (
+    <CapitalPage title="Documents" subtitle="The Documents page provides access to public-facing summaries, disclosure documents, readiness materials, certificate templates, and review files where appropriate.">
+      <CapitalCardGrid>{docs.map((doc) => <CapitalCard key={doc} title={doc}><p>Document access and review material category for the Capital Portal.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
+  );
+}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,18 @@
+import { CapitalPage } from '../components/CapitalPage';
+
+const faqs = [
+  ['What is the ONEGODIAN Capital Portal?', 'It is a controlled recordkeeping, disclosure, certificate, verification, contributor intake, and readiness interface for ONEGODIAN, LLC.'],
+  ['Does this portal create a securities offering?', 'No. The portal does not independently create, approve, validate, market, or guarantee any securities offering.'],
+  ['Are certificates proof of investment ownership?', 'Certificates are recordkeeping tools and do not replace executed agreements, ownership documentation, offering documents, contracts, or required disclosures.'],
+  ['What does readiness mean?', 'Readiness means operational systems are being prepared, documented, and tested; it does not mean legal approval.'],
+  ['Why are disclosures required?', 'Disclosures help ensure notices, risks, disclaimers, confirmations, and participation gates are reviewed and acknowledged where appropriate.'],
+  ['What is the difference between WordPress, WooCommerce, and the Capital Portal?', 'WordPress may present public information, WooCommerce may support permitted checkout access, and the Capital Portal manages records, disclosures, certificates, verification, and readiness documentation.']
+];
+
+export default function FAQPage() {
+  return (
+    <CapitalPage title="FAQ">
+      <section className="space-y-4">{faqs.map(([question, answer]) => <article key={question} className="mobile-card"><h2 className="text-xl font-black text-white">{question}</h2><p className="mt-3 leading-7 text-slate-300">{answer}</p></article>)}</section>
+    </CapitalPage>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -242,3 +242,153 @@ a {
     border-radius: 1.25rem;
   }
 }
+
+/* Capital portal navigation and mobile controls */
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+.capital-page {
+  min-height: calc(100vh - 12rem);
+}
+.capital-hero {
+  border-radius: 1.5rem;
+}
+.capital-logo span:last-child {
+  white-space: normal;
+  line-height: 1.05;
+}
+.capital-ecosystem-nav a.is-active {
+  border-color: rgba(234, 200, 90, 0.65);
+  background: rgba(234, 200, 90, 0.14);
+  color: #fff4bf;
+  box-shadow: 0 10px 34px rgba(234, 200, 90, 0.12);
+}
+.capital-nav a,
+.capital-ecosystem-nav a,
+.capital-mobile-nav a,
+.capital-mobile-nav button,
+.capital-mobile-more a,
+button,
+input,
+select,
+textarea {
+  min-height: 44px;
+}
+.capital-mobile-nav,
+.capital-mobile-more {
+  display: none;
+}
+.capital-field {
+  width: 100%;
+  min-height: 44px;
+  border-radius: 1rem;
+  border: 1px solid rgba(234, 200, 90, 0.22);
+  background: rgba(3, 7, 18, 0.68);
+  padding: .8rem 1rem;
+  color: #fff;
+  outline: none;
+}
+.capital-field:focus {
+  border-color: rgba(234, 200, 90, 0.65);
+  box-shadow: 0 0 0 3px rgba(234, 200, 90, 0.12);
+}
+.status-badge {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(234, 200, 90, 0.36);
+  background: rgba(234, 200, 90, 0.12);
+  padding: .3rem .7rem;
+  color: #fff4bf;
+  font-size: .75rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+@media (max-width: 900px) {
+  .capital-header-inner {
+    display: block;
+  }
+  .capital-logo {
+    width: 100%;
+    max-width: 100%;
+  }
+  .capital-nav,
+  .capital-ecosystem-nav {
+    display: none;
+  }
+  .capital-mobile-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: .25rem;
+    border-top: 1px solid rgba(234, 200, 90, 0.2);
+    background: rgba(3, 7, 18, 0.94);
+    padding: .45rem max(.45rem, env(safe-area-inset-left)) calc(.45rem + env(safe-area-inset-bottom)) max(.45rem, env(safe-area-inset-right));
+    backdrop-filter: blur(20px);
+  }
+  .capital-mobile-nav a,
+  .capital-mobile-nav button {
+    display: inline-flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    border-radius: .9rem;
+    border: 1px solid rgba(255,255,255,.08);
+    background: rgba(255,255,255,.035);
+    padding: .45rem .2rem;
+    color: #d8d2e8;
+    font-size: clamp(.62rem, 2.4vw, .78rem);
+    font-weight: 800;
+    line-height: 1.1;
+    text-align: center;
+  }
+  .capital-mobile-nav a.is-active,
+  .capital-mobile-nav button.is-active,
+  .capital-mobile-more a.is-active {
+    border-color: rgba(234, 200, 90, 0.68);
+    background: rgba(234, 200, 90, 0.16);
+    color: #fff4bf;
+  }
+  .capital-mobile-more {
+    position: fixed;
+    left: .75rem;
+    right: .75rem;
+    bottom: calc(4.25rem + env(safe-area-inset-bottom));
+    z-index: 59;
+    display: grid;
+    max-height: min(60vh, 26rem);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .5rem;
+    overflow-y: auto;
+    border: 1px solid rgba(234, 200, 90, 0.2);
+    border-radius: 1.25rem;
+    background: rgba(5, 10, 22, 0.96);
+    padding: .75rem;
+    box-shadow: 0 24px 80px rgba(0,0,0,.55);
+    backdrop-filter: blur(22px);
+  }
+  .capital-mobile-more a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: .9rem;
+    border: 1px solid rgba(255,255,255,.08);
+    padding: .55rem .4rem;
+    color: #e7e0f4;
+    text-align: center;
+  }
+  .premium-button,
+  .premium-button-secondary {
+    min-height: 44px;
+    white-space: normal;
+    text-align: center;
+  }
+}

--- a/src/app/investor-portal/page.tsx
+++ b/src/app/investor-portal/page.tsx
@@ -1,11 +1,12 @@
-export default function Page() {
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from '../components/CapitalPage';
+
+const cards = ['Contributor Profile', 'Disclosure Acknowledgements', 'Instrument Records', 'Certificate References', 'Payment / Checkout History', 'Verification History', 'Support Requests'];
+
+export default function InvestorPortalPage() {
   return (
-    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <section className="glass-panel p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
-        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Investor Portal</h1>
-        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for investor portal with disclosure review and acknowledgement workflow support.</p>
-      </section>
-    </main>
+    <CapitalPage title="Investor Portal" subtitle="The Investor Portal is used to review contributor records, disclosure status, certificate references, verification history, and document access.">
+      <NoticePanel>Access should require authentication before showing private records.</NoticePanel>
+      <CapitalCardGrid>{cards.map((card) => <CapitalCard key={card} title={card}><p>Authenticated capital portal workspace for controlled review and record access.</p></CapitalCard>)}</CapitalCardGrid>
+    </CapitalPage>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { CapitalNavigation } from './components/CapitalNavigation';
 import { CapitalFooter } from './components/CapitalFooter';
 
-export const metadata: Metadata = { title: 'OneGodian Domain Surfaces', description: 'Separated app.onegodian.com member app and console.onegodian.com operator console.' };
+export const metadata: Metadata = { title: 'ONEGODIAN CAPITAL PORTAL™', description: 'Private capital infrastructure for records, disclosures, certificates, contributor intake, and verification.' };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return <html lang="en"><body><CapitalNavigation />{children}<CapitalFooter /></body></html>;

--- a/src/app/offerings/page.tsx
+++ b/src/app/offerings/page.tsx
@@ -1,11 +1,38 @@
-export default function Page() {
+import Link from 'next/link';
+import { CapitalPage } from '../components/CapitalPage';
+
+const offerings = [
+  { name: 'ONEGODIAN Capital Documentation Packet', code: 'OGC-DOC-001', status: 'Available for Review', term: 'As documented', rate: 'Not applicable', disclosure: 'Disclosure Required', certificate: 'Available after record acceptance' },
+  { name: 'Contributor Record Intake Reference', code: 'OGC-CRI-002', status: 'Internal Review', term: 'Internal workflow', rate: 'Not applicable', disclosure: 'Required before participation', certificate: 'Pending workflow readiness' },
+  { name: 'OBP-1 Certificate Reference File', code: 'OBP-1-REF-003', status: 'Draft', term: 'Recordkeeping reference', rate: 'Not applicable', disclosure: 'Review required', certificate: 'Draft template only' },
+  { name: 'Platform Participation Materials', code: 'OGC-PPM-004', status: 'Disclosure Required', term: 'Subject to review', rate: 'Not applicable', disclosure: 'Acknowledgement required', certificate: 'Conditional' },
+  { name: 'Legacy Review Archive', code: 'OGC-ARC-005', status: 'Archived', term: 'Closed record', rate: 'Not applicable', disclosure: 'Historical record', certificate: 'Unavailable' },
+  { name: 'Closed Internal Instrument Record', code: 'OGC-CIR-006', status: 'Closed', term: 'Closed', rate: 'Not applicable', disclosure: 'Completed record', certificate: 'Record only' }
+];
+
+export default function OfferingsPage() {
   return (
-    <main className="onegodian-surface mx-auto max-w-6xl px-4 py-10 text-slate-100">
-      <section className="glass-panel p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-gold-300">Administrative Records</p>
-        <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-white">Offerings</h1>
-        <p className="mt-3 leading-7 text-slate-300">Administrative record workspace for offerings with disclosure review and acknowledgement workflow support.</p>
+    <CapitalPage title="Offerings" subtitle="Review available ONEGODIAN capital-related documents, instruments, contribution records, and platform participation materials.">
+      <section className="grid gap-4 lg:grid-cols-2">
+        {offerings.map((item) => (
+          <article key={item.code} className="mobile-card">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-black text-white">{item.name}</h2>
+                <p className="mt-1 text-sm font-semibold text-gold-200">Reference code: {item.code}</p>
+              </div>
+              <span className="status-badge">{item.status}</span>
+            </div>
+            <dl className="mt-4 grid gap-3 text-sm leading-6 text-slate-300 sm:grid-cols-2">
+              <div><dt className="font-bold text-white">Term</dt><dd>{item.term}</dd></div>
+              <div><dt className="font-bold text-white">Rate</dt><dd>{item.rate}</dd></div>
+              <div><dt className="font-bold text-white">Disclosure requirement</dt><dd>{item.disclosure}</dd></div>
+              <div><dt className="font-bold text-white">Certificate availability</dt><dd>{item.certificate}</dd></div>
+            </dl>
+            <Link href="/disclosures" className="premium-button-secondary mt-5">Review Details</Link>
+          </article>
+        ))}
       </section>
-    </main>
+    </CapitalPage>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,44 +1,40 @@
-import Link from 'next/link';
-import { CardGrid, InfoCard, OmosPage, StatusPill } from './components/omos-docs-ui';
+import { CapitalCard, CapitalCardGrid, CapitalPage, NoticePanel } from './components/CapitalPage';
 
-const systems = [
-  ['Protocol kernel', 'Defines human, semantic, agent, interface, and compliance boundaries before any automation is labeled active.'],
-  ['Runtime model', 'Observe, distill, align, select, execute, and verify steps convert raw context into repeatable system outputs.'],
-  ['Developer surface', 'Documents base URL, x-omos-key authentication, endpoint classes, examples, errors, and deployment notes.'],
-  ['Governance layer', 'Separates operational documentation from legal, governmental, tax, or participant-jurisdiction claims.'],
-  ['Status discipline', 'Publishes active versus planned features with a rule that only operational, documented, repeatable functions are active.'],
-  ['Integration node', 'Normalizes public process documentation to POST /api/process while preserving the existing /process runtime concept.']
+const boundaryCards = [
+  ['Public Information Layer', 'Website pages, explanatory content, general education, summaries, and public-facing capital documentation.'],
+  ['Commerce / Checkout Layer', 'WooCommerce or Stripe-powered checkout access for approved products, documents, services, or permitted payment flows.'],
+  ['Capital Records Layer', 'Contributor records, instrument references, readiness status, document history, and internal recordkeeping.'],
+  ['Disclosure Review Layer', 'Disclosure acknowledgement, investor/contributor notices, risk language, required confirmations, and participation gates.'],
+  ['Certificate Verification Layer', 'Certificate IDs, OBP-1 references, QR verification, downloadable records, and status confirmation.'],
+  ['Compliance Boundary', 'The portal does not independently create, approve, validate, or guarantee any securities offering. All capital participation must be supported by appropriate review, disclosures, documentation, and applicable legal compliance.']
 ];
 
 export default function HomePage() {
   return (
-    <OmosPage
-      eyebrow="OMOS.ONEGODIAN.COM"
-      title="Production systems documentation for the OMOS runtime."
-      description="OMOS™ is a documentation and integration node for operational interpretation, API-assisted processing, semantic alignment, and compliance-safe system summaries."
-      cta={[{ href: '/docs', label: 'Read docs' }, { href: '/dashboard', label: 'Open dashboard' }]}
+    <CapitalPage
+      title="ONEGODIAN CAPITAL PORTAL™"
+      subtitle="Private capital infrastructure for records, disclosures, certificates, contributor intake, and verification."
+      actions={[
+        { href: '/offerings', label: 'View Offerings' },
+        { href: '/disclosures', label: 'Review Disclosures' },
+        { href: '/verification', label: 'Verify Certificate' },
+        { href: '/readiness', label: 'Check Readiness' }
+      ]}
     >
-      <CardGrid>
-        {systems.map(([title, detail], index) => (
-          <InfoCard key={title} title={title} accent={index % 3 === 0 ? 'gold' : index % 3 === 1 ? 'cyan' : 'green'}>
-            <p>{detail}</p>
-          </InfoCard>
-        ))}
-      </CardGrid>
-      <section className="grid gap-4 lg:grid-cols-[1.2fr_.8fr]">
-        <article className="glass-panel p-5 sm:p-6">
-          <StatusPill active>Documentation node active</StatusPill>
-          <h2 className="mt-4 text-2xl font-black text-white">Built for readers, builders, and governance reviewers.</h2>
-          <p className="mt-3 leading-7 text-slate-300">The node explains what OMOS does, how requests are shaped, where compliance boundaries live, and which capabilities are available today versus planned for later phases.</p>
-        </article>
-        <article className="rounded-3xl border border-cyan-300/25 bg-cyan-300/10 p-5 sm:p-6">
-          <h2 className="text-xl font-black text-white">Primary actions</h2>
-          <div className="mt-4 flex flex-col gap-3">
-            <Link href="/api" className="premium-button">Integrate API</Link>
-            <Link href="/roadmap" className="premium-button-secondary">Review roadmap</Link>
-          </div>
-        </article>
+      <NoticePanel>
+        <p>The ONEGODIAN Capital Portal is a controlled recordkeeping and capital-documentation interface for ONEGODIAN, LLC. It supports offerings documentation, disclosure review, contributor records, certificate verification, readiness tracking, and capital-related platform workflows.</p>
+        <p className="mt-3 font-semibold text-gold-100">It does not independently create, approve, validate, market, or guarantee any securities offering.</p>
+      </NoticePanel>
+      <section className="glass-panel p-5 sm:p-6">
+        <h2 className="text-2xl font-black text-white">Operating Boundary Model</h2>
+        <div className="mt-3 space-y-3 leading-7 text-slate-300">
+          <p>The ONEGODIAN Capital Portal separates public information, checkout activity, capital records, disclosure review, certificate issuance, and verification into distinct operating layers.</p>
+          <p>WordPress and WooCommerce may present public-facing information or checkout access where appropriate. The Capital Portal manages capital records, disclosure status, contributor intake records, certificate references, verification workflows, and readiness documentation.</p>
+        </div>
       </section>
-    </OmosPage>
+      <CapitalCardGrid>
+        {boundaryCards.map(([title, detail]) => <CapitalCard key={title} title={title}><p>{detail}</p></CapitalCard>)}
+      </CapitalCardGrid>
+    </CapitalPage>
   );
 }

--- a/src/app/readiness/page.tsx
+++ b/src/app/readiness/page.tsx
@@ -1,0 +1,14 @@
+import { CapitalPage } from '../components/CapitalPage';
+
+const metrics = [
+  ['Disclosure Center', 'Needs Review'], ['Certificate Verification', 'In Progress'], ['Contributor Records', 'In Progress'], ['Payment Routing', 'Needs Review'], ['WooCommerce Boundary', 'Documented'], ['Stripe Boundary', 'Pending Review'], ['Legal Review', 'Required'], ['Production Readiness', 'In Progress']
+];
+
+export default function ReadinessPage() {
+  return (
+    <CapitalPage title="Readiness" subtitle="The Readiness page tracks whether the capital portal, disclosures, records, certificate workflows, payment routing, and verification systems are prepared for controlled use.">
+      <section className="rounded-3xl border border-gold-300/25 bg-gold-300/10 p-5 leading-7 text-gold-50">Readiness does not mean legal approval. It means the operational system is being prepared, documented, and tested.</section>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">{metrics.map(([name, status]) => <article key={name} className="mobile-card"><h2 className="font-black text-white">{name}</h2><p className="mt-3 status-badge">{status}</p></article>)}</section>
+    </CapitalPage>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the OMOS documentation surface with a persistent, institutionally styled ONEGODIAN Capital Portal experience and make navigation consistent across all pages.  
- Improve mobile usability with a sticky bottom nav and a compact “More” menu while ensuring touch targets meet `44px` tap-height and preventing horizontal overflow.  
- Replace placeholder hero and operating-boundary content with real portal copy, layered operating-boundary cards, and real route pages for capital workflows.

### Description
- Added a shared header/navigation and mobile controls in `src/app/components/CapitalNavigation.tsx` and centralized link data in `src/app/components/capital-content.ts`; desktop primary/additional links and a sticky mobile bottom nav with a `More` drawer are implemented and show active state.  
- Created reusable page primitives in `src/app/components/CapitalPage.tsx` (hero, card grid, notice panel) and updated the footer in `src/app/components/CapitalFooter.tsx` to include the persistent compliance wording.  
- Replaced the homepage with the Capital Portal hero, CTAs, compliance notice, and the requested Operating Boundary Model with six cards in `src/app/page.tsx`.  
- Implemented/updated route pages for the portal: `/offerings`, `/investor-portal`, `/disclosures`, `/certificates`, `/readiness`, `/records`, `/verification`, `/compliance`, `/documents`, `/faq`, and `/contact` with the requested titles, copy, cards, forms, and UI elements (see `src/app/*/page.tsx`).  
- Updated global styles in `src/app/globals.css` to preserve dark navy/gold/white styling, add mobile rules (sticky bottom nav, `min-height: 44px` for interactive controls), active states, status badges, and horizontal overflow protection.  
- Fixed a malformed duplicate tail in the existing docs route so linting and build complete cleanly.

### Testing
- Ran `npm run lint` and there were no ESLint warnings or errors.  
- Ran `npm run typecheck` (`tsc --noEmit`) and the typecheck completed successfully.  
- Ran `npm run build` (`next build`) and the production build compiled and generated static pages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a0c8b574832d9a5d56f981650703)