### PR TITLE
Add membership frontend shortcodes to Onegodian Members plugin

### DIFF
--- a/onegodian-members/includes/class-onegodian-members-shortcodes.php
+++ b/onegodian-members/includes/class-onegodian-members-shortcodes.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Frontend membership shortcodes for Onegodian Members.
+ *
+ * @package Onegodian_Members
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Onegodian_Members_Shortcodes
+{
+    /** @var callable */
+    private $settings_callback;
+
+    /** @param callable $settings_callback Returns the plugin settings array. */
+    public function __construct(callable $settings_callback)
+    {
+        $this->settings_callback = $settings_callback;
+    }
+
+    public function register(): void
+    {
+        add_shortcode('onegodian_membership_cta', array($this, 'render_membership_cta'));
+        add_shortcode('onegodian_members_pricing', array($this, 'render_members_pricing'));
+        add_shortcode('onegodian_membership_resources', array($this, 'render_membership_resources'));
+        add_shortcode('onegodian_member_certificates', array($this, 'render_member_certificates'));
+        add_shortcode('onegodian_member_dashboard', array($this, 'render_member_dashboard'));
+        add_shortcode('onegodian_member_support', array($this, 'render_member_support'));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_membership_cta($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Join the OneGodian Membership', 'onegodian-members'),
+            'subtitle' => __('Access member guidance, resources, certificates, and support from the OneGodian membership hub.', 'onegodian-members'),
+            'button_text' => __('Join membership', 'onegodian-members'),
+            'secondary_text' => __('Member login', 'onegodian-members'),
+            'join_url' => $this->default_join_url(),
+            'login_url' => wp_login_url($this->current_url()),
+        ), $atts, 'onegodian_membership_cta');
+
+        return $this->section('ogm-membership-cta', sprintf(
+            '<div class="ogm-shortcode__content"><p class="ogm-kicker">%s</p><h2>%s</h2><p>%s</p></div><div class="ogm-shortcode__actions"><a class="ogm-button ogm-button-primary" href="%s">%s</a><a class="ogm-button ogm-button-secondary" href="%s">%s</a></div>',
+            esc_html__('Membership', 'onegodian-members'),
+            esc_html($atts['title']),
+            wp_kses_post($atts['subtitle']),
+            esc_url($atts['join_url']),
+            esc_html($atts['button_text']),
+            esc_url($atts['login_url']),
+            esc_html($atts['secondary_text'])
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_members_pricing($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Membership options', 'onegodian-members'),
+            'description' => __('Choose the membership level that matches your current path. Pricing and checkout can be connected through existing WooCommerce membership products when configured.', 'onegodian-members'),
+            'join_url' => $this->default_join_url(),
+            'button_text' => __('Get started', 'onegodian-members'),
+        ), $atts, 'onegodian_members_pricing');
+
+        $cards = '';
+        foreach ($this->membership_tiers() as $tier) {
+            $cards .= sprintf(
+                '<article class="ogm-pricing-card"><h3>%s</h3><p>%s</p><a class="ogm-button ogm-button-primary" href="%s">%s</a></article>',
+                esc_html($tier),
+                esc_html(sprintf(__('%s membership access with OneGodian member resources and support.', 'onegodian-members'), $tier)),
+                esc_url($atts['join_url']),
+                esc_html($atts['button_text'])
+            );
+        }
+
+        return $this->section('ogm-members-pricing', sprintf(
+            '<header class="ogm-shortcode__header"><h2>%s</h2><p>%s</p></header><div class="ogm-pricing-grid">%s</div>',
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            $cards
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_membership_resources($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Member resources', 'onegodian-members'),
+            'description' => __('Use these membership resources to orient your OneGodian journey.', 'onegodian-members'),
+            'dashboard_url' => $this->dashboard_url(),
+            'support_url' => $this->support_url(),
+        ), $atts, 'onegodian_membership_resources');
+
+        $resources = array(
+            array(__('Member dashboard', 'onegodian-members'), __('Open your membership overview, profile, and next steps.', 'onegodian-members'), $atts['dashboard_url']),
+            array(__('Certificates', 'onegodian-members'), __('Review certificate status and member identification details.', 'onegodian-members'), $this->current_url()),
+            array(__('Support', 'onegodian-members'), __('Request help with membership access, certificates, or resources.', 'onegodian-members'), $atts['support_url']),
+        );
+
+        $items = '';
+        foreach ($resources as $resource) {
+            $items .= sprintf(
+                '<li class="ogm-resource-card"><h3>%s</h3><p>%s</p><a href="%s">%s</a></li>',
+                esc_html($resource[0]),
+                esc_html($resource[1]),
+                esc_url($resource[2]),
+                esc_html__('Open resource', 'onegodian-members')
+            );
+        }
+
+        return $this->section('ogm-membership-resources', sprintf(
+            '<header class="ogm-shortcode__header"><h2>%s</h2><p>%s</p></header><ul class="ogm-resource-list">%s</ul>',
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            $items
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_member_certificates($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Member certificates', 'onegodian-members'),
+            'logged_out_message' => __('Sign in to view your member certificate details.', 'onegodian-members'),
+            'login_url' => wp_login_url($this->current_url()),
+        ), $atts, 'onegodian_member_certificates');
+
+        if (!is_user_logged_in()) {
+            return $this->logged_out_card($atts['title'], $atts['logged_out_message'], $atts['login_url']);
+        }
+
+        $user_id = get_current_user_id();
+        $certificate_id = (string) get_user_meta($user_id, 'ogm_certificate_id', true);
+        $certificate_status = $certificate_id ? __('Issued', 'onegodian-members') : __('Pending review', 'onegodian-members');
+        $issued_at = (string) get_user_meta($user_id, 'ogm_certificate_issued_at', true);
+
+        return $this->section('ogm-member-certificates', sprintf(
+            '<h2>%s</h2><dl class="ogm-definition-list"><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div></dl>',
+            esc_html($atts['title']),
+            esc_html__('Certificate ID', 'onegodian-members'),
+            esc_html($certificate_id ?: __('Not issued yet', 'onegodian-members')),
+            esc_html__('Status', 'onegodian-members'),
+            esc_html($certificate_status),
+            esc_html__('Issued', 'onegodian-members'),
+            esc_html($issued_at ?: __('Not available', 'onegodian-members'))
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_member_dashboard($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Member dashboard', 'onegodian-members'),
+            'logged_out_message' => __('Sign in or join the membership to access your OneGodian member dashboard.', 'onegodian-members'),
+            'login_url' => wp_login_url($this->current_url()),
+            'join_url' => $this->default_join_url(),
+        ), $atts, 'onegodian_member_dashboard');
+
+        if (!is_user_logged_in()) {
+            return $this->section('ogm-member-dashboard ogm-member-dashboard--logged-out', sprintf(
+                '<h2>%s</h2><p>%s</p><div class="ogm-shortcode__actions"><a class="ogm-button ogm-button-primary" href="%s">%s</a><a class="ogm-button ogm-button-secondary" href="%s">%s</a></div>',
+                esc_html($atts['title']),
+                wp_kses_post($atts['logged_out_message']),
+                esc_url($atts['login_url']),
+                esc_html__('Log in', 'onegodian-members'),
+                esc_url($atts['join_url']),
+                esc_html__('Join membership', 'onegodian-members')
+            ));
+        }
+
+        $user = wp_get_current_user();
+        $membership_tier = (string) get_user_meta($user->ID, 'ogm_membership_tier', true);
+        $ohsid = (string) get_user_meta($user->ID, 'ogm_ohsid', true);
+
+        return $this->section('ogm-member-dashboard', sprintf(
+            '<h2>%s</h2><p>%s</p><dl class="ogm-definition-list"><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div></dl><div class="ogm-shortcode__actions"><a class="ogm-button ogm-button-secondary" href="%s">%s</a></div>',
+            esc_html($atts['title']),
+            esc_html(sprintf(__('Welcome back, %s.', 'onegodian-members'), $user->display_name ?: $user->user_login)),
+            esc_html__('Membership tier', 'onegodian-members'),
+            esc_html($membership_tier ?: __('Member', 'onegodian-members')),
+            esc_html__('OHSID', 'onegodian-members'),
+            esc_html($ohsid ?: __('Not assigned', 'onegodian-members')),
+            esc_html__('Email', 'onegodian-members'),
+            esc_html($user->user_email),
+            esc_url(get_edit_profile_url($user->ID)),
+            esc_html__('Edit profile', 'onegodian-members')
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_member_support($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Member support', 'onegodian-members'),
+            'description' => __('Need help with your membership, dashboard access, certificates, or resources? Contact support and include your account email when possible.', 'onegodian-members'),
+            'support_url' => $this->support_url(),
+            'button_text' => __('Contact member support', 'onegodian-members'),
+        ), $atts, 'onegodian_member_support');
+
+        return $this->section('ogm-member-support', sprintf(
+            '<h2>%s</h2><p>%s</p><a class="ogm-button ogm-button-primary" href="%s">%s</a>',
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            esc_url($atts['support_url']),
+            esc_html($atts['button_text'])
+        ));
+    }
+
+    private function section(string $class_name, string $content): string
+    {
+        return '<section class="ogm-shortcode ' . esc_attr($class_name) . '">' . $content . '</section>';
+    }
+
+    private function logged_out_card(string $title, string $message, string $login_url): string
+    {
+        return $this->section('ogm-member-login-required', sprintf(
+            '<h2>%s</h2><p>%s</p><a class="ogm-button ogm-button-primary" href="%s">%s</a>',
+            esc_html($title),
+            wp_kses_post($message),
+            esc_url($login_url),
+            esc_html__('Log in', 'onegodian-members')
+        ));
+    }
+
+    /** @return array<string, string> */
+    private function settings(): array
+    {
+        $settings = call_user_func($this->settings_callback);
+        return is_array($settings) ? $settings : array();
+    }
+
+    /** @return array<int, string> */
+    private function membership_tiers(): array
+    {
+        $settings = $this->settings();
+        $tiers = isset($settings['membership_tiers']) ? explode(',', (string) $settings['membership_tiers']) : array();
+        $tiers = array_values(array_filter(array_map('trim', $tiers)));
+        return $tiers ?: array(__('Standard', 'onegodian-members'), __('Premium', 'onegodian-members'), __('Founding', 'onegodian-members'));
+    }
+
+    private function dashboard_url(): string
+    {
+        $settings = $this->settings();
+        if (!empty($settings['app_dashboard_url'])) {
+            return (string) $settings['app_dashboard_url'];
+        }
+        if (!empty($settings['app_url'])) {
+            return trailingslashit((string) $settings['app_url']);
+        }
+        return home_url('/member-dashboard/');
+    }
+
+    private function default_join_url(): string
+    {
+        return home_url('/membership/');
+    }
+
+    private function support_url(): string
+    {
+        return home_url('/contact/');
+    }
+
+    private function current_url(): string
+    {
+        global $wp;
+
+        if (isset($wp) && isset($wp->request)) {
+            return home_url('/' . ltrim((string) $wp->request, '/'));
+        }
+
+        return home_url('/');
+    }
+}

--- a/onegodian-members/onegodian-members.php
+++ b/onegodian-members/onegodian-members.php
@@ -16,6 +16,8 @@ define('OGM_PLUGIN_FILE', __FILE__);
 define('OGM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('OGM_PLUGIN_URL', plugin_dir_url(__FILE__));
 
+require_once OGM_PLUGIN_DIR . 'includes/class-onegodian-members-shortcodes.php';
+
 final class Onegodian_Members_Plugin
 {
     private const OPTION_SETTINGS = 'ogm_settings';
@@ -189,20 +191,8 @@ final class Onegodian_Members_Plugin
 
     public function register_shortcodes(): void
     {
-        $shortcodes = array(
-            'onegodian_member_dashboard' => __('Member dashboard content will appear here.', 'onegodian-members'),
-            'onegodian_member_certificate' => __('Member certificate tools will appear here.', 'onegodian-members'),
-            'onegodian_member_resources' => __('Member resources will appear here.', 'onegodian-members'),
-            'onegodian_membership_pricing' => __('Membership pricing will appear here.', 'onegodian-members'),
-            'onegodian_member_account' => __('Member account details will appear here.', 'onegodian-members'),
-            'onegodian_member_directory' => __('Member directory will appear here.', 'onegodian-members'),
-        );
-
-        foreach ($shortcodes as $tag => $message) {
-            add_shortcode($tag, static function () use ($message): string {
-                return '<div class="ogm-shortcode-placeholder">' . esc_html($message) . '</div>';
-            });
-        }
+        $shortcodes = new Onegodian_Members_Shortcodes(array($this, 'get_public_settings'));
+        $shortcodes->register();
     }
 
     public function render_dashboard_page(): void
@@ -454,7 +444,7 @@ final class Onegodian_Members_Plugin
         $this->render_admin_shell('onegodian-members-docs', function (): void {
             ?>
             <div class="ogm-grid ogm-grid-2">
-                <?php $this->code_list_card(__('Available shortcodes', 'onegodian-members'), array('[onegodian_member_dashboard]', '[onegodian_member_certificate]', '[onegodian_member_resources]', '[onegodian_membership_pricing]', '[onegodian_member_account]', '[onegodian_member_directory]')); ?>
+                <?php $this->code_list_card(__('Available shortcodes', 'onegodian-members'), array('[onegodian_membership_cta]', '[onegodian_members_pricing]', '[onegodian_membership_resources]', '[onegodian_member_certificates]', '[onegodian_member_dashboard]', '[onegodian_member_support]')); ?>
                 <?php $this->code_list_card(__('REST endpoints', 'onegodian-members'), array('/wp-json/onegodian-members/v1/health', '/wp-json/onegodian-members/v1/manifest', '/wp-json/onegodian-members/v1/me', '/wp-json/onegodian-members/v1/admin/summary')); ?>
                 <?php $this->code_list_card(__('Environment variable setup', 'onegodian-members'), array('NEXT_PUBLIC_MEMBERS_WORDPRESS_BASE_URL', 'MEMBERS_REST_BASE_URL', 'MEMBERS_APP_BRIDGE_KEY', 'MEMBERS_MODULE_SLUG')); ?>
                 <section class="ogm-card"><h2><?php esc_html_e('App bridge instructions', 'onegodian-members'); ?></h2><p><?php esc_html_e('Set the WordPress base URL, REST base URL, module slug, and bridge key in the OneGodian app environment. Rotate the bridge key after every exposed deployment artifact.', 'onegodian-members'); ?></p></section>
@@ -507,6 +497,11 @@ final class Onegodian_Members_Plugin
         if (isset($messages[$notice])) {
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html($messages[$notice]) . '</p></div>';
         }
+    }
+
+    public function get_public_settings(): array
+    {
+        return $this->get_settings();
     }
 
     private function get_settings(): array
@@ -567,12 +562,12 @@ final class Onegodian_Members_Plugin
     private function generate_required_pages(): int
     {
         $pages = array(
+            'Membership' => '[onegodian_membership_cta]',
+            'Membership Pricing' => '[onegodian_members_pricing]',
+            'Member Resources' => '[onegodian_membership_resources]',
+            'Member Certificates' => '[onegodian_member_certificates]',
             'Member Dashboard' => '[onegodian_member_dashboard]',
-            'Member Certificate' => '[onegodian_member_certificate]',
-            'Member Resources' => '[onegodian_member_resources]',
-            'Membership Pricing' => '[onegodian_membership_pricing]',
-            'Member Account' => '[onegodian_member_account]',
-            'Member Directory' => '[onegodian_member_directory]',
+            'Member Support' => '[onegodian_member_support]',
         );
         $created = 0;
         foreach ($pages as $title => $shortcode) {
@@ -629,7 +624,7 @@ final class Onegodian_Members_Plugin
 
     public function rest_manifest(): WP_REST_Response
     {
-        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => array('onegodian_member_dashboard', 'onegodian_member_certificate', 'onegodian_member_resources', 'onegodian_membership_pricing', 'onegodian_member_account', 'onegodian_member_directory')));
+        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => array('onegodian_membership_cta', 'onegodian_members_pricing', 'onegodian_membership_resources', 'onegodian_member_certificates', 'onegodian_member_dashboard', 'onegodian_member_support')));
     }
 
     public function rest_me(): WP_REST_Response


### PR DESCRIPTION
### Motivation
- Provide frontend-only membership shortcodes for the Onegodian membership experience so pages and themes can render membership CTAs, pricing, resources, certificates, dashboard, and support without adding non-membership modules.
- Replace placeholder shortcode stubs with implementations that use the plugin's settings and safe WordPress output APIs so sites can style and use them immediately.

### Description
- Added `onegodian-members/includes/class-onegodian-members-shortcodes.php` which implements and registers the required shortcodes: `onegodian_membership_cta`, `onegodian_members_pricing`, `onegodian_membership_resources`, `onegodian_member_certificates`, `onegodian_member_dashboard`, and `onegodian_member_support` and renders lightweight semantic HTML with wrapper classes.
- Hooked the new class into the plugin by requiring the include and updating `register_shortcodes()` to instantiate `Onegodian_Members_Shortcodes` via a `get_public_settings` callback that forwards plugin settings.
- Updated generated page definitions, the admin docs shortcode listing, and the REST `manifest` response to advertise the new membership-only shortcodes.
- Implemented member-aware behavior: certificate and dashboard shortcodes show a logged-out message with login/join CTAs when `is_user_logged_in()` is false, and used safe output helpers (`esc_html()`, `esc_url()`, `wp_kses_post()`, `shortcode_atts()`) throughout.
- No payment processing, contributor, creator network, affiliate, referral, or campaign asset modules were added or modified in this change.

### Testing
- Ran `php -l onegodian-members/onegodian-members.php` and it reported no syntax errors.
- Ran `php -l onegodian-members/includes/class-onegodian-members-shortcodes.php` and it reported no syntax errors.
- Ran `rg` scans to verify no unwanted contributor/affiliate/campaign code was introduced and the membership files contain only the intended shortcode implementations (scan succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d0ee5628832d88dd803e4b61cf0f)