### PR TITLE
Add Belief Mapper module, shortcodes, pages, admin action, and styling

### DIFF
--- a/onegodian-members/assets/css/ogm-public.css
+++ b/onegodian-members/assets/css/ogm-public.css
@@ -1,0 +1,118 @@
+.ogm-shortcode,
+.ogm-belief-panel {
+  --ogm-navy: #07162f;
+  --ogm-gold: #d7a936;
+  --ogm-cyan: #20d7f2;
+  --ogm-muted: #475569;
+  --ogm-border: rgba(15, 23, 42, 0.12);
+  background: linear-gradient(135deg, #07162f 0%, #0f2a4d 100%);
+  border: 1px solid rgba(32, 215, 242, 0.28);
+  border-radius: 24px;
+  box-shadow: 0 24px 60px rgba(7, 22, 47, 0.22);
+  color: #f8fafc;
+  margin: 24px 0;
+  overflow: hidden;
+  padding: 28px;
+}
+
+.ogm-shortcode h2,
+.ogm-shortcode h3 {
+  color: #fff;
+  margin-top: 0;
+}
+
+.ogm-shortcode p,
+.ogm-shortcode li,
+.ogm-shortcode dd {
+  color: #dbeafe;
+}
+
+.ogm-shortcode a,
+.ogm-button {
+  color: #07162f;
+}
+
+.ogm-kicker {
+  color: var(--ogm-cyan) !important;
+  font-size: 12px !important;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  margin: 0 0 8px !important;
+  text-transform: uppercase;
+}
+
+.ogm-button,
+.ogm-button-primary,
+.ogm-button-secondary {
+  align-items: center;
+  background: var(--ogm-gold);
+  border-radius: 999px;
+  display: inline-flex;
+  font-weight: 800;
+  gap: 8px;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+.ogm-button-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+.ogm-belief-description {
+  font-size: 1.05rem;
+  max-width: 780px;
+}
+
+.ogm-belief-steps,
+.ogm-belief-card-grid,
+.ogm-resource-list,
+.ogm-pricing-grid,
+.ogm-definition-list {
+  display: grid;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.ogm-belief-card-grid,
+.ogm-resource-list,
+.ogm-pricing-grid {
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.ogm-belief-card-grid article,
+.ogm-resource-card,
+.ogm-pricing-card,
+.ogm-definition-list div,
+.ogm-belief-prompts span {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  padding: 16px;
+}
+
+.ogm-belief-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.ogm-belief-prompts span {
+  color: #fff;
+  font-weight: 800;
+}
+
+.ogm-definition-list dt {
+  color: var(--ogm-cyan);
+  font-weight: 800;
+}
+
+.ogm-belief-disclaimer {
+  background: rgba(215, 169, 54, 0.14);
+  border-left: 4px solid var(--ogm-gold);
+  border-radius: 14px;
+  margin: 22px 0 0;
+  padding: 14px 16px;
+}

--- a/onegodian-members/includes/class-onegodian-belief-mapper.php
+++ b/onegodian-members/includes/class-onegodian-belief-mapper.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Belief Mapper module for Onegodian Members.
+ *
+ * @package Onegodian_Members
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Onegodian_Belief_Mapper_Module
+{
+    public function register(): void
+    {
+        add_shortcode('onegodian_belief_mapper', array($this, 'render_mapper'));
+        add_shortcode('onegodian_belief_mapper_lite', array($this, 'render_lite'));
+        add_shortcode('onegodian_belief_mapper_results', array($this, 'render_results'));
+        add_shortcode('onegodian_belief_mapper_certificate', array($this, 'render_certificate'));
+        add_shortcode('onegodian_belief_mapper_resources', array($this, 'render_resources'));
+        add_shortcode('onegodian_belief_mapper_dashboard', array($this, 'render_dashboard'));
+    }
+
+    /** @return array<string, string> */
+    public static function pages(): array
+    {
+        return array(
+            'Belief Mapper' => '[onegodian_belief_mapper]',
+            'Belief Mapper Lite' => '[onegodian_belief_mapper_lite]',
+            'Belief Mapper Results' => '[onegodian_belief_mapper_results]',
+            'Belief Mapper Certificate' => '[onegodian_belief_mapper_certificate]',
+            'Belief Mapper Resources' => '[onegodian_belief_mapper_resources]',
+            'Belief Mapper Dashboard' => '[onegodian_belief_mapper_dashboard]',
+        );
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_mapper($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper', 'onegodian-members'),
+            'description' => __('Map core beliefs, values, and next-step learning paths with the OneGodian alignment framework.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper');
+
+        $steps = array(
+            __('Reflect on your current beliefs.', 'onegodian-members'),
+            __('Identify shared values and growth areas.', 'onegodian-members'),
+            __('Review resources before making important decisions.', 'onegodian-members'),
+        );
+
+        return $this->panel('ogm-belief-mapper', $atts['title'], $atts['description'], $this->ordered_list($steps) . $this->disclaimer());
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_lite($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper Lite', 'onegodian-members'),
+            'description' => __('A quick orientation version for visitors who want a lightweight introduction.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper_lite');
+
+        return $this->panel('ogm-belief-mapper-lite', $atts['title'], $atts['description'], '<div class="ogm-belief-prompts"><span>Faith</span><span>Family</span><span>Service</span><span>Learning</span></div>' . $this->disclaimer());
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_results($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper Results', 'onegodian-members'),
+            'description' => __('Review saved mapper outcomes, learning recommendations, and certificate readiness notes.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper_results');
+
+        return $this->panel('ogm-belief-mapper-results', $atts['title'], $atts['description'], $this->definition_list(array(
+            __('Alignment summary', 'onegodian-members') => __('Pending user completion', 'onegodian-members'),
+            __('Recommended path', 'onegodian-members') => __('Review resources and speak with a qualified advisor when needed.', 'onegodian-members'),
+            __('Certificate readiness', 'onegodian-members') => __('Not yet issued', 'onegodian-members'),
+        )) . $this->disclaimer());
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_certificate($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper Certificate', 'onegodian-members'),
+            'description' => __('Certificate status and completion details for the Belief Mapper module.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper_certificate');
+
+        return $this->panel('ogm-belief-mapper-certificate', $atts['title'], $atts['description'], $this->definition_list(array(
+            __('Status', 'onegodian-members') => __('Pending review', 'onegodian-members'),
+            __('Certificate ID', 'onegodian-members') => __('Generated after completion', 'onegodian-members'),
+        )) . $this->disclaimer());
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_resources($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper Resources', 'onegodian-members'),
+            'description' => __('Helpful resources for reflection, learning, and responsible follow-up.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper_resources');
+
+        return $this->panel('ogm-belief-mapper-resources', $atts['title'], $atts['description'], $this->cards(array(
+            array(__('Reflection guide', 'onegodian-members'), __('Use prompts to record beliefs and open questions.', 'onegodian-members')),
+            array(__('Learning path', 'onegodian-members'), __('Review recommended OneGodian lessons and community resources.', 'onegodian-members')),
+            array(__('Support', 'onegodian-members'), __('Contact the OneGodian team for platform help.', 'onegodian-members')),
+        )) . $this->disclaimer());
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_dashboard($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Belief Mapper Dashboard', 'onegodian-members'),
+            'description' => __('Track Belief Mapper progress, results, resources, and certificate readiness.', 'onegodian-members'),
+        ), $atts, 'onegodian_belief_mapper_dashboard');
+
+        return $this->panel('ogm-belief-mapper-dashboard', $atts['title'], $atts['description'], $this->cards(array(
+            array(__('Mapper', 'onegodian-members'), __('Complete the full guided mapper.', 'onegodian-members')),
+            array(__('Results', 'onegodian-members'), __('Review saved alignment notes.', 'onegodian-members')),
+            array(__('Certificate', 'onegodian-members'), __('Check completion and certificate status.', 'onegodian-members')),
+        )) . $this->disclaimer());
+    }
+
+    private function panel(string $class_name, string $title, string $description, string $content): string
+    {
+        $this->enqueue_assets();
+        return sprintf(
+            '<section class="ogm-shortcode ogm-belief-panel %s"><p class="ogm-kicker">%s</p><h2>%s</h2><p class="ogm-belief-description">%s</p>%s</section>',
+            esc_attr($class_name),
+            esc_html__('OneGodian Belief Mapper', 'onegodian-members'),
+            esc_html($title),
+            wp_kses_post($description),
+            $content
+        );
+    }
+
+    /** @param array<int, string> $items */
+    private function ordered_list(array $items): string
+    {
+        $html = '<ol class="ogm-belief-steps">';
+        foreach ($items as $item) {
+            $html .= '<li>' . esc_html($item) . '</li>';
+        }
+        return $html . '</ol>';
+    }
+
+    /** @param array<string, string> $items */
+    private function definition_list(array $items): string
+    {
+        $html = '<dl class="ogm-definition-list">';
+        foreach ($items as $term => $description) {
+            $html .= '<div><dt>' . esc_html($term) . '</dt><dd>' . esc_html($description) . '</dd></div>';
+        }
+        return $html . '</dl>';
+    }
+
+    /** @param array<int, array{0:string, 1:string}> $cards */
+    private function cards(array $cards): string
+    {
+        $html = '<div class="ogm-belief-card-grid">';
+        foreach ($cards as $card) {
+            $html .= '<article><h3>' . esc_html($card[0]) . '</h3><p>' . esc_html($card[1]) . '</p></article>';
+        }
+        return $html . '</div>';
+    }
+
+    private function disclaimer(): string
+    {
+        return '<p class="ogm-belief-disclaimer"><strong>' . esc_html__('Disclaimer:', 'onegodian-members') . '</strong> ' . esc_html__('Belief Mapper content is educational and reflective only. It is not legal, medical, mental-health, financial, or spiritual counseling advice and does not replace qualified professional guidance.', 'onegodian-members') . '</p>';
+    }
+
+    private function enqueue_assets(): void
+    {
+        if (!defined('OGM_PLUGIN_URL') || !defined('OGM_VERSION')) {
+            return;
+        }
+
+        wp_enqueue_style('ogm-public', OGM_PLUGIN_URL . 'assets/css/ogm-public.css', array(), OGM_VERSION);
+    }
+}

--- a/onegodian-members/onegodian-members.php
+++ b/onegodian-members/onegodian-members.php
@@ -17,6 +17,7 @@ define('OGM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('OGM_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 require_once OGM_PLUGIN_DIR . 'includes/class-onegodian-members-shortcodes.php';
+require_once OGM_PLUGIN_DIR . 'includes/class-onegodian-belief-mapper.php';
 
 final class Onegodian_Members_Plugin
 {
@@ -46,6 +47,7 @@ final class Onegodian_Members_Plugin
         $plugin = new self();
         add_action('admin_menu', array($plugin, 'register_admin_menu'));
         add_action('admin_enqueue_scripts', array($plugin, 'enqueue_admin_assets'));
+        add_action('wp_enqueue_scripts', array($plugin, 'enqueue_public_assets'));
         add_action('admin_init', array($plugin, 'handle_admin_actions'));
         add_action('rest_api_init', array($plugin, 'register_rest_routes'));
         add_action('init', array($plugin, 'register_shortcodes'));
@@ -117,6 +119,17 @@ final class Onegodian_Members_Plugin
         );
     }
 
+
+    public function enqueue_public_assets(): void
+    {
+        wp_enqueue_style(
+            'ogm-public',
+            OGM_PLUGIN_URL . 'assets/css/ogm-public.css',
+            array(),
+            OGM_VERSION
+        );
+    }
+
     public function handle_admin_actions(): void
     {
         if (!is_admin() || !current_user_can('manage_options') || empty($_POST['ogm_action'])) {
@@ -147,6 +160,11 @@ final class Onegodian_Members_Plugin
         if ('generate_pages' === $action) {
             $created = $this->generate_required_pages();
             $redirect = add_query_arg(array('ogm_notice' => 'pages_generated', 'ogm_count' => $created), $redirect);
+        }
+
+        if ('generate_belief_mapper_pages' === $action) {
+            $created = $this->generate_belief_mapper_pages();
+            $redirect = add_query_arg(array('ogm_notice' => 'belief_mapper_pages_generated', 'ogm_count' => $created), $redirect);
         }
 
         if ('flush_rewrites' === $action) {
@@ -193,6 +211,9 @@ final class Onegodian_Members_Plugin
     {
         $shortcodes = new Onegodian_Members_Shortcodes(array($this, 'get_public_settings'));
         $shortcodes->register();
+
+        $belief_mapper = new Onegodian_Belief_Mapper_Module();
+        $belief_mapper->register();
     }
 
     public function render_dashboard_page(): void
@@ -224,6 +245,7 @@ final class Onegodian_Members_Plugin
                     <h2><?php esc_html_e('Quick Actions', 'onegodian-members'); ?></h2>
                     <div class="ogm-actions">
                         <?php $this->action_form('generate_pages', __('Generate Pages', 'onegodian-members'), 'onegodian-members'); ?>
+                        <?php $this->action_form('generate_belief_mapper_pages', __('Create Belief Mapper Pages', 'onegodian-members'), 'onegodian-members', 'button-secondary'); ?>
                         <?php $this->action_form('rotate_bridge_key', __('Rotate Bridge Key', 'onegodian-members'), 'onegodian-members'); ?>
                         <a class="button button-secondary" href="<?php echo esc_url($this->admin_url('onegodian-members-members')); ?>"><?php esc_html_e('View Members', 'onegodian-members'); ?></a>
                         <a class="button button-primary" href="<?php echo esc_url($this->get_setting('app_dashboard_url')); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Open App Dashboard', 'onegodian-members'); ?></a>
@@ -382,7 +404,7 @@ final class Onegodian_Members_Plugin
         $this->render_admin_shell('onegodian-members-tools', function (): void {
             ?>
             <div class="ogm-grid ogm-grid-2">
-                <section class="ogm-card"><h2><?php esc_html_e('Page & Shortcode Tools', 'onegodian-members'); ?></h2><div class="ogm-actions"><?php $this->action_form('generate_pages', __('Generate required pages', 'onegodian-members'), 'onegodian-members-tools'); ?><button class="button button-secondary" disabled><?php esc_html_e('Regenerate shortcodes', 'onegodian-members'); ?></button><?php $this->action_form('flush_rewrites', __('Flush rewrite rules', 'onegodian-members'), 'onegodian-members-tools', 'button-secondary'); ?></div></section>
+                <section class="ogm-card"><h2><?php esc_html_e('Page & Shortcode Tools', 'onegodian-members'); ?></h2><div class="ogm-actions"><?php $this->action_form('generate_pages', __('Generate required pages', 'onegodian-members'), 'onegodian-members-tools'); ?><?php $this->action_form('generate_belief_mapper_pages', __('Create Belief Mapper Pages', 'onegodian-members'), 'onegodian-members-tools', 'button-secondary'); ?><button class="button button-secondary" disabled><?php esc_html_e('Regenerate shortcodes', 'onegodian-members'); ?></button><?php $this->action_form('flush_rewrites', __('Flush rewrite rules', 'onegodian-members'), 'onegodian-members-tools', 'button-secondary'); ?></div></section>
                 <section class="ogm-card"><h2><?php esc_html_e('Member Data Tools', 'onegodian-members'); ?></h2><div class="ogm-actions"><?php $this->action_form('repair_member_metadata', __('Repair member metadata', 'onegodian-members'), 'onegodian-members-tools', 'button-secondary'); ?><button class="button button-secondary" disabled><?php esc_html_e('Export members CSV', 'onegodian-members'); ?></button><button class="button button-secondary" disabled><?php esc_html_e('Import tools', 'onegodian-members'); ?></button></div></section>
             </div>
             <?php
@@ -491,6 +513,7 @@ final class Onegodian_Members_Plugin
             'bridge_saved' => __('App bridge settings saved.', 'onegodian-members'),
             'bridge_key_rotated' => __('Bridge key generated. Copy the one-time value now.', 'onegodian-members'),
             'pages_generated' => sprintf(__('Required pages checked. %d page(s) created.', 'onegodian-members'), isset($_GET['ogm_count']) ? absint($_GET['ogm_count']) : 0),
+            'belief_mapper_pages_generated' => sprintf(__('Belief Mapper pages checked. %d page(s) created.', 'onegodian-members'), isset($_GET['ogm_count']) ? absint($_GET['ogm_count']) : 0),
             'rewrites_flushed' => __('Rewrite rules flushed.', 'onegodian-members'),
             'metadata_repaired' => __('Member metadata repair completed.', 'onegodian-members'),
         );
@@ -569,8 +592,28 @@ final class Onegodian_Members_Plugin
             'Member Dashboard' => '[onegodian_member_dashboard]',
             'Member Support' => '[onegodian_member_support]',
         );
+        $pages = array_merge($pages, Onegodian_Belief_Mapper_Module::pages());
         $created = 0;
         foreach ($pages as $title => $shortcode) {
+            if ($this->page_exists_with_shortcode(trim($shortcode, '[]'))) {
+                continue;
+            }
+            wp_insert_post(array(
+                'post_title' => $title,
+                'post_name' => sanitize_title($title),
+                'post_content' => $shortcode,
+                'post_status' => 'publish',
+                'post_type' => 'page',
+            ));
+            $created++;
+        }
+        return $created;
+    }
+
+    private function generate_belief_mapper_pages(): int
+    {
+        $created = 0;
+        foreach (Onegodian_Belief_Mapper_Module::pages() as $title => $shortcode) {
             if ($this->page_exists_with_shortcode(trim($shortcode, '[]'))) {
                 continue;
             }
@@ -624,7 +667,7 @@ final class Onegodian_Members_Plugin
 
     public function rest_manifest(): WP_REST_Response
     {
-        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => array('onegodian_membership_cta', 'onegodian_members_pricing', 'onegodian_membership_resources', 'onegodian_member_certificates', 'onegodian_member_dashboard', 'onegodian_member_support')));
+        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => array('onegodian_membership_cta', 'onegodian_members_pricing', 'onegodian_membership_resources', 'onegodian_member_certificates', 'onegodian_member_dashboard', 'onegodian_member_support', 'onegodian_belief_mapper', 'onegodian_belief_mapper_lite', 'onegodian_belief_mapper_results', 'onegodian_belief_mapper_certificate', 'onegodian_belief_mapper_resources', 'onegodian_belief_mapper_dashboard')));
     }
 
     public function rest_me(): WP_REST_Response


### PR DESCRIPTION
### Motivation
- Provide a new Belief Mapper feature within the OneGodian Members plugin: shortcodes, auto-generated pages, admin tooling, and public styling. 
- Make the feature safe for production by including a clear, production-safe disclaimer and only enqueuing public assets when available. 
- Keep existing membership shortcodes and WooCommerce feature-detection intact (do not remove or change those functions). 

### Description
- Add a Belief Mapper module at `onegodian-members/includes/class-onegodian-belief-mapper.php` that registers six shortcodes: `onegodian_belief_mapper`, `onegodian_belief_mapper_lite`, `onegodian_belief_mapper_results`, `onegodian_belief_mapper_certificate`, `onegodian_belief_mapper_resources`, and `onegodian_belief_mapper_dashboard`. 
- Expose auto-generated page definitions for: Belief Mapper, Belief Mapper Lite, Belief Mapper Results, Belief Mapper Certificate, Belief Mapper Resources, and Belief Mapper Dashboard and add generation logic. 
- Add an admin action and UI button `Create Belief Mapper Pages` that runs page creation, plus integrate those pages into the existing `generate_required_pages` flow. 
- Enqueue a small OneGodian public stylesheet `onegodian-members/assets/css/ogm-public.css` and add `enqueue_public_assets()` so public shortcodes are styled; include a production-safe disclaimer in outputs. 
- Wire the module into the plugin initialization and shortcode registration (keeps existing shortcodes and WooCommerce checks unchanged). 
- Add the new shortcodes to the plugin REST `manifest` output so runtime consumers can discover them. 
- Plugin metadata/version remains `1.0.0` (no version removal). 

### Testing
- Ran `php -l` syntax checks on modified PHP files and all returned no syntax errors. 
- Ran automated diff/check for whitespace and syntax problems (`diff --check`) and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230bf142d0832d889e0a4c6628d3a8)