### PR TITLE
Add contributors and affiliate program shortcodes to Onegodian Members plugin

### DIFF
--- a/onegodian-members/includes/class-onegodian-members-contributors-affiliates.php
+++ b/onegodian-members/includes/class-onegodian-members-contributors-affiliates.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Contributor, creator network, affiliate, referral, and campaign asset shortcodes.
+ *
+ * @package Onegodian_Members
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Onegodian_Members_Contributors_Affiliates
+{
+    private const CONTRIBUTOR_DISCLAIMER = 'Contributions are voluntary support payments for ONEGODIAN, LLC public-facing products, education, media, technology, membership, and community infrastructure. Contributions are not equity, securities, loans, bonds, investment contracts, or promises of financial return.';
+
+    /** @var callable */
+    private $settings_callback;
+
+    /** @param callable $settings_callback Returns the plugin settings array. */
+    public function __construct(callable $settings_callback)
+    {
+        $this->settings_callback = $settings_callback;
+    }
+
+    public function register(): void
+    {
+        add_shortcode('onegodian_contributors_page', array($this, 'render_contributors_page'));
+        add_shortcode('onegodian_contributor_tiers', array($this, 'render_contributor_tiers'));
+        add_shortcode('onegodian_creator_network', array($this, 'render_creator_network'));
+        add_shortcode('onegodian_affiliate_dashboard', array($this, 'render_affiliate_dashboard'));
+        add_shortcode('onegodian_referral_link', array($this, 'render_referral_link'));
+        add_shortcode('onegodian_contributor_wall', array($this, 'render_contributor_wall'));
+        add_shortcode('onegodian_contributor_disclaimer', array($this, 'render_contributor_disclaimer'));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_contributors_page($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Support ONEGODIAN infrastructure', 'onegodian-members'),
+            'description' => __('Contributors help sustain public-facing products, education, media, technology, membership, and community infrastructure. Payment processing is intentionally not included in this module yet.', 'onegodian-members'),
+        ), $atts, 'onegodian_contributors_page');
+
+        return $this->section('ogm-contributors-page', sprintf(
+            '<header class="ogm-shortcode__header"><p class="ogm-kicker">%s</p><h2>%s</h2><p>%s</p></header>%s%s%s%s',
+            esc_html__('Contributors', 'onegodian-members'),
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            $this->render_contributor_tiers(array('title' => __('Contributor tiers', 'onegodian-members'))),
+            $this->render_creator_network(array('title' => __('Creator Network', 'onegodian-members'))),
+            $this->campaign_assets_section(),
+            $this->render_contributor_disclaimer(array())
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_contributor_tiers($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Contributor tiers', 'onegodian-members'),
+            'description' => __('Choose a voluntary support level when contribution processing is connected. No payment processing is included here.', 'onegodian-members'),
+        ), $atts, 'onegodian_contributor_tiers');
+
+        $cards = '';
+        foreach ($this->contributor_tiers() as $tier) {
+            $cards .= sprintf(
+                '<article class="ogm-pricing-card ogm-contributor-tier"><h3>%s</h3><strong>%s</strong><p>%s</p></article>',
+                esc_html($tier['name']),
+                esc_html($tier['amount']),
+                esc_html($tier['description'])
+            );
+        }
+
+        return $this->section('ogm-contributor-tiers', sprintf(
+            '<header class="ogm-shortcode__header"><h2>%s</h2><p>%s</p></header><div class="ogm-pricing-grid">%s</div>',
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            $cards
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_creator_network($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Creator Network', 'onegodian-members'),
+            'description' => __('A frontend home for creators, educators, media partners, and community builders who want to collaborate with ONEGODIAN public-facing products and campaigns.', 'onegodian-members'),
+        ), $atts, 'onegodian_creator_network');
+
+        $items = array(
+            __('Creator onboarding placeholder', 'onegodian-members'),
+            __('Campaign collaboration placeholder', 'onegodian-members'),
+            __('Affiliate and referral education placeholder', 'onegodian-members'),
+        );
+
+        return $this->section('ogm-creator-network', sprintf(
+            '<header class="ogm-shortcode__header"><p class="ogm-kicker">%s</p><h2>%s</h2><p>%s</p></header>%s%s',
+            esc_html__('Creator program', 'onegodian-members'),
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            $this->list_items($items),
+            $this->campaign_assets_section()
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_affiliate_dashboard($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Affiliate Dashboard', 'onegodian-members'),
+            'logged_out_message' => __('Log in to view your affiliate dashboard placeholder and referral tools.', 'onegodian-members'),
+            'login_url' => wp_login_url($this->current_url()),
+        ), $atts, 'onegodian_affiliate_dashboard');
+
+        if (!is_user_logged_in()) {
+            return $this->logged_out_card($atts['title'], $atts['logged_out_message'], $atts['login_url']);
+        }
+
+        $user = wp_get_current_user();
+
+        return $this->section('ogm-affiliate-dashboard', sprintf(
+            '<h2>%s</h2><p>%s</p><dl class="ogm-definition-list"><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div><div><dt>%s</dt><dd>%s</dd></div></dl>%s',
+            esc_html($atts['title']),
+            esc_html__('Affiliate reporting, referral attribution, and campaign metrics will appear here after the program is connected. No commission or payment processing logic is active in this placeholder.', 'onegodian-members'),
+            esc_html__('Account', 'onegodian-members'),
+            esc_html($user->display_name ?: $user->user_login),
+            esc_html__('Affiliate status', 'onegodian-members'),
+            esc_html__('Pending program setup', 'onegodian-members'),
+            esc_html__('Referral link', 'onegodian-members'),
+            wp_kses_post($this->referral_link_markup()),
+            $this->campaign_assets_section()
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_referral_link($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Your referral link', 'onegodian-members'),
+            'logged_out_message' => __('Log in to generate your referral link.', 'onegodian-members'),
+            'login_url' => wp_login_url($this->current_url()),
+        ), $atts, 'onegodian_referral_link');
+
+        if (!is_user_logged_in()) {
+            return $this->logged_out_card($atts['title'], $atts['logged_out_message'], $atts['login_url']);
+        }
+
+        return $this->section('ogm-referral-link', sprintf(
+            '<h2>%s</h2><p>%s</p>%s',
+            esc_html($atts['title']),
+            esc_html__('Share this placeholder referral URL while attribution workflows are prepared.', 'onegodian-members'),
+            $this->referral_link_markup()
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_contributor_wall($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Contributor Wall', 'onegodian-members'),
+            'description' => __('Public contributor recognition will appear here after approvals, privacy preferences, and publishing workflows are connected.', 'onegodian-members'),
+        ), $atts, 'onegodian_contributor_wall');
+
+        return $this->section('ogm-contributor-wall', sprintf(
+            '<h2>%s</h2><p>%s</p><div class="ogm-placeholder-card"><strong>%s</strong><p>%s</p></div>',
+            esc_html($atts['title']),
+            wp_kses_post($atts['description']),
+            esc_html__('Contributor wall placeholder', 'onegodian-members'),
+            esc_html__('No contributor names are published by this module yet.', 'onegodian-members')
+        ));
+    }
+
+    /** @param array<string, string>|string $atts */
+    public function render_contributor_disclaimer($atts = array()): string
+    {
+        $atts = is_array($atts) ? $atts : array();
+        $atts = shortcode_atts(array(
+            'title' => __('Compliance notice', 'onegodian-members'),
+        ), $atts, 'onegodian_contributor_disclaimer');
+
+        return $this->section('ogm-contributor-disclaimer', sprintf(
+            '<h2>%s</h2><p>%s</p>',
+            esc_html($atts['title']),
+            esc_html(self::CONTRIBUTOR_DISCLAIMER)
+        ));
+    }
+
+    /** @return array<int, array{name:string, amount:string, description:string}> */
+    private function contributor_tiers(): array
+    {
+        return array(
+            array('name' => __('Supporter', 'onegodian-members'), 'amount' => __('$11', 'onegodian-members'), 'description' => __('Entry-level voluntary support for public education, media, technology, membership, and community infrastructure.', 'onegodian-members')),
+            array('name' => __('Builder', 'onegodian-members'), 'amount' => __('$33', 'onegodian-members'), 'description' => __('Voluntary support for continued product, content, and community-building work.', 'onegodian-members')),
+            array('name' => __('Sustainer', 'onegodian-members'), 'amount' => __('$77', 'onegodian-members'), 'description' => __('Voluntary recurring-style support positioning without activating payment collection here.', 'onegodian-members')),
+            array('name' => __('Founder Circle', 'onegodian-members'), 'amount' => __('$111', 'onegodian-members'), 'description' => __('Voluntary supporter recognition level for early infrastructure backers.', 'onegodian-members')),
+            array('name' => __('Infrastructure Partner', 'onegodian-members'), 'amount' => __('$333+', 'onegodian-members'), 'description' => __('Voluntary support tier for larger public-facing infrastructure contributions.', 'onegodian-members')),
+            array('name' => __('Custom Contribution', 'onegodian-members'), 'amount' => __('Custom', 'onegodian-members'), 'description' => __('A flexible voluntary contribution amount to be handled by future approved workflows.', 'onegodian-members')),
+        );
+    }
+
+    private function campaign_assets_section(): string
+    {
+        return '<div class="ogm-campaign-assets"><h3>' . esc_html__('Campaign Assets', 'onegodian-members') . '</h3><p>' . esc_html__('Campaign graphics, copy blocks, creator briefs, affiliate links, and share assets will appear here after review workflows are connected.', 'onegodian-members') . '</p></div>';
+    }
+
+    /** @param array<int, string> $items */
+    private function list_items(array $items): string
+    {
+        $markup = '<ul class="ogm-resource-list">';
+        foreach ($items as $item) {
+            $markup .= '<li class="ogm-resource-card"><p>' . esc_html($item) . '</p></li>';
+        }
+        return $markup . '</ul>';
+    }
+
+    private function referral_link_markup(): string
+    {
+        if (!is_user_logged_in()) {
+            return '';
+        }
+
+        $user_id = get_current_user_id();
+        $user = wp_get_current_user();
+        $referral_code = $user->user_login ? $user->user_login : (string) $user_id;
+        $referral_url = add_query_arg('ogm_ref', $referral_code, home_url('/'));
+
+        return sprintf(
+            '<code class="ogm-referral-url">%s</code><p><a class="ogm-button ogm-button-secondary" href="%s">%s</a></p>',
+            esc_html($referral_url),
+            esc_url($referral_url),
+            esc_html__('Open referral link', 'onegodian-members')
+        );
+    }
+
+    private function section(string $class_name, string $content): string
+    {
+        return '<section class="ogm-shortcode ' . esc_attr($class_name) . '">' . $content . '</section>';
+    }
+
+    private function logged_out_card(string $title, string $message, string $login_url): string
+    {
+        return $this->section('ogm-member-login-required', sprintf(
+            '<h2>%s</h2><p>%s</p><a class="ogm-button ogm-button-primary" href="%s">%s</a>',
+            esc_html($title),
+            wp_kses_post($message),
+            esc_url($login_url),
+            esc_html__('Log in', 'onegodian-members')
+        ));
+    }
+
+    /** @return array<string, string> */
+    private function settings(): array
+    {
+        $settings = call_user_func($this->settings_callback);
+        return is_array($settings) ? $settings : array();
+    }
+
+    private function current_url(): string
+    {
+        global $wp;
+
+        if (isset($wp) && isset($wp->request)) {
+            return home_url('/' . ltrim((string) $wp->request, '/'));
+        }
+
+        return home_url('/');
+    }
+}

--- a/onegodian-members/onegodian-members.php
+++ b/onegodian-members/onegodian-members.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Onegodian Members
  * Description: Membership tools, app bridge, shortcodes, and admin operations for OneGodian members.
- * Version: 1.0.0
+ * Version: 1.7.0
  * Author: OneGodian
  * Text Domain: onegodian-members
  */
@@ -11,12 +11,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('OGM_VERSION', '1.0.0');
+define('OGM_VERSION', '1.7.0');
 define('OGM_PLUGIN_FILE', __FILE__);
 define('OGM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('OGM_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 require_once OGM_PLUGIN_DIR . 'includes/class-onegodian-members-shortcodes.php';
+require_once OGM_PLUGIN_DIR . 'includes/class-onegodian-members-contributors-affiliates.php';
 
 final class Onegodian_Members_Plugin
 {
@@ -39,6 +40,7 @@ final class Onegodian_Members_Plugin
         'onegodian-members-status' => array('label' => 'Status', 'title' => 'Status'),
         'onegodian-members-checklist' => array('label' => 'Checklist', 'title' => 'Production Checklist'),
         'onegodian-members-docs' => array('label' => 'Docs', 'title' => 'Documentation'),
+        'onegodian-members-programs' => array('label' => 'Programs', 'title' => 'Contributor Programs'),
     );
 
     public static function init(): void
@@ -89,6 +91,7 @@ final class Onegodian_Members_Plugin
             'onegodian-members-status' => 'render_status_page',
             'onegodian-members-checklist' => 'render_checklist_page',
             'onegodian-members-docs' => 'render_docs_page',
+            'onegodian-members-programs' => 'render_programs_page',
         );
 
         return array($this, $callbacks[$slug] ?? 'render_dashboard_page');
@@ -193,6 +196,9 @@ final class Onegodian_Members_Plugin
     {
         $shortcodes = new Onegodian_Members_Shortcodes(array($this, 'get_public_settings'));
         $shortcodes->register();
+
+        $contributors_affiliates = new Onegodian_Members_Contributors_Affiliates(array($this, 'get_public_settings'));
+        $contributors_affiliates->register();
     }
 
     public function render_dashboard_page(): void
@@ -252,6 +258,10 @@ final class Onegodian_Members_Plugin
                     <?php $this->input_field('app_url', __('App URL settings', 'onegodian-members'), $settings['app_url'], __('Base URL of the OneGodian app.', 'onegodian-members'), 'url'); ?>
                     <?php $this->input_field('module_slug', __('Module slug settings', 'onegodian-members'), $settings['module_slug'], __('Module slug used by the app bridge.', 'onegodian-members')); ?>
                 </div>
+                <section class="ogm-card">
+                    <h2><?php esc_html_e('Contributor and affiliate module references', 'onegodian-members'); ?></h2>
+                    <p><?php esc_html_e('Settings coverage includes Contributors, Creator Network, Affiliate Dashboard, Referral Links, Campaign Assets, Contributor Wall, and Compliance Notices. These modules are shortcode-driven placeholders until approved program operations are connected.', 'onegodian-members'); ?></p>
+                </section>
                 <?php submit_button(__('Save Settings', 'onegodian-members')); ?>
             </form>
             <?php
@@ -444,12 +454,28 @@ final class Onegodian_Members_Plugin
         $this->render_admin_shell('onegodian-members-docs', function (): void {
             ?>
             <div class="ogm-grid ogm-grid-2">
-                <?php $this->code_list_card(__('Available shortcodes', 'onegodian-members'), array('[onegodian_membership_cta]', '[onegodian_members_pricing]', '[onegodian_membership_resources]', '[onegodian_member_certificates]', '[onegodian_member_dashboard]', '[onegodian_member_support]')); ?>
+                <?php $this->code_list_card(__('Available shortcodes', 'onegodian-members'), array_map(static function (string $shortcode): string { return '[' . $shortcode . ']'; }, $this->public_shortcodes())); ?>
+                <?php $this->code_list_card(__('Generated page definitions', 'onegodian-members'), array('/contributors', '/creator-network', '/affiliate-dashboard', '/contribute-now', '/contributor-wall')); ?>
                 <?php $this->code_list_card(__('REST endpoints', 'onegodian-members'), array('/wp-json/onegodian-members/v1/health', '/wp-json/onegodian-members/v1/manifest', '/wp-json/onegodian-members/v1/me', '/wp-json/onegodian-members/v1/admin/summary')); ?>
                 <?php $this->code_list_card(__('Environment variable setup', 'onegodian-members'), array('NEXT_PUBLIC_MEMBERS_WORDPRESS_BASE_URL', 'MEMBERS_REST_BASE_URL', 'MEMBERS_APP_BRIDGE_KEY', 'MEMBERS_MODULE_SLUG')); ?>
+                <section class="ogm-card"><h2><?php esc_html_e('Contributor program references', 'onegodian-members'); ?></h2><p><?php esc_html_e('Docs cover Contributors, Creator Network, Affiliate Dashboard, Referral Links, Campaign Assets, Contributor Wall, and Compliance Notices. Contribution modules must remain voluntary support placeholders until approved processing is added.', 'onegodian-members'); ?></p></section>
                 <section class="ogm-card"><h2><?php esc_html_e('App bridge instructions', 'onegodian-members'); ?></h2><p><?php esc_html_e('Set the WordPress base URL, REST base URL, module slug, and bridge key in the OneGodian app environment. Rotate the bridge key after every exposed deployment artifact.', 'onegodian-members'); ?></p></section>
                 <section class="ogm-card"><h2><?php esc_html_e('BuddyPress integration notes', 'onegodian-members'); ?></h2><p><?php esc_html_e('BuddyPress profile links appear only when BuddyPress functions are available, preventing fatal errors on sites without BuddyPress.', 'onegodian-members'); ?></p></section>
                 <section class="ogm-card"><h2><?php esc_html_e('WooCommerce integration notes', 'onegodian-members'); ?></h2><p><?php esc_html_e('WooCommerce checks are feature-detected and safe when WooCommerce is inactive.', 'onegodian-members'); ?></p></section>
+            </div>
+            <?php
+        });
+    }
+
+    public function render_programs_page(): void
+    {
+        $this->render_admin_shell('onegodian-members-programs', function (): void {
+            ?>
+            <div class="ogm-grid ogm-grid-2">
+                <?php $this->code_list_card(__('Contributor modules', 'onegodian-members'), array('Contributors', 'Contributor Tiers', 'Contributor Wall', 'Compliance Notices')); ?>
+                <?php $this->code_list_card(__('Creator and affiliate modules', 'onegodian-members'), array('Creator Network', 'Affiliate Dashboard', 'Referral Links', 'Campaign Assets')); ?>
+                <?php $this->code_list_card(__('Contributor tiers', 'onegodian-members'), array('Supporter $11', 'Builder $33', 'Sustainer $77', 'Founder Circle $111', 'Infrastructure Partner $333+', 'Custom Contribution')); ?>
+                <section class="ogm-card"><h2><?php esc_html_e('Compliance notice', 'onegodian-members'); ?></h2><p><?php esc_html_e('Contributions are voluntary support payments for ONEGODIAN, LLC public-facing products, education, media, technology, membership, and community infrastructure. Contributions are not equity, securities, loans, bonds, investment contracts, or promises of financial return.', 'onegodian-members'); ?></p></section>
             </div>
             <?php
         });
@@ -561,29 +587,60 @@ final class Onegodian_Members_Plugin
 
     private function generate_required_pages(): int
     {
-        $pages = array(
-            'Membership' => '[onegodian_membership_cta]',
-            'Membership Pricing' => '[onegodian_members_pricing]',
-            'Member Resources' => '[onegodian_membership_resources]',
-            'Member Certificates' => '[onegodian_member_certificates]',
-            'Member Dashboard' => '[onegodian_member_dashboard]',
-            'Member Support' => '[onegodian_member_support]',
-        );
         $created = 0;
-        foreach ($pages as $title => $shortcode) {
-            if ($this->page_exists_with_shortcode(trim($shortcode, '[]'))) {
+        foreach ($this->generated_page_definitions() as $page) {
+            $shortcode = trim($page['shortcode'], '[]');
+            if ($this->page_exists_with_shortcode($shortcode)) {
                 continue;
             }
             wp_insert_post(array(
-                'post_title' => $title,
-                'post_name' => sanitize_title($title),
-                'post_content' => $shortcode,
+                'post_title' => $page['title'],
+                'post_name' => $page['slug'],
+                'post_content' => $page['shortcode'],
                 'post_status' => 'publish',
                 'post_type' => 'page',
             ));
             $created++;
         }
         return $created;
+    }
+
+    /** @return array<int, array{title:string, slug:string, shortcode:string}> */
+    private function generated_page_definitions(): array
+    {
+        return array(
+            array('title' => 'Membership', 'slug' => 'membership', 'shortcode' => '[onegodian_membership_cta]'),
+            array('title' => 'Membership Pricing', 'slug' => 'membership-pricing', 'shortcode' => '[onegodian_members_pricing]'),
+            array('title' => 'Member Resources', 'slug' => 'member-resources', 'shortcode' => '[onegodian_membership_resources]'),
+            array('title' => 'Member Certificates', 'slug' => 'member-certificates', 'shortcode' => '[onegodian_member_certificates]'),
+            array('title' => 'Member Dashboard', 'slug' => 'member-dashboard', 'shortcode' => '[onegodian_member_dashboard]'),
+            array('title' => 'Member Support', 'slug' => 'member-support', 'shortcode' => '[onegodian_member_support]'),
+            array('title' => 'Contributors', 'slug' => 'contributors', 'shortcode' => '[onegodian_contributors_page]'),
+            array('title' => 'Creator Network', 'slug' => 'creator-network', 'shortcode' => '[onegodian_creator_network]'),
+            array('title' => 'Affiliate Dashboard', 'slug' => 'affiliate-dashboard', 'shortcode' => '[onegodian_affiliate_dashboard]'),
+            array('title' => 'Contribute Now', 'slug' => 'contribute-now', 'shortcode' => '[onegodian_contributor_tiers]'),
+            array('title' => 'Contributor Wall', 'slug' => 'contributor-wall', 'shortcode' => '[onegodian_contributor_wall]'),
+        );
+    }
+
+    /** @return array<int, string> */
+    private function public_shortcodes(): array
+    {
+        return array(
+            'onegodian_membership_cta',
+            'onegodian_members_pricing',
+            'onegodian_membership_resources',
+            'onegodian_member_certificates',
+            'onegodian_member_dashboard',
+            'onegodian_member_support',
+            'onegodian_contributors_page',
+            'onegodian_contributor_tiers',
+            'onegodian_creator_network',
+            'onegodian_affiliate_dashboard',
+            'onegodian_referral_link',
+            'onegodian_contributor_wall',
+            'onegodian_contributor_disclaimer',
+        );
     }
 
     private function page_exists_with_shortcode(string $shortcode): bool
@@ -624,7 +681,7 @@ final class Onegodian_Members_Plugin
 
     public function rest_manifest(): WP_REST_Response
     {
-        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => array('onegodian_membership_cta', 'onegodian_members_pricing', 'onegodian_membership_resources', 'onegodian_member_certificates', 'onegodian_member_dashboard', 'onegodian_member_support')));
+        return rest_ensure_response(array('module' => $this->get_setting('module_slug'), 'rest_base' => rest_url(self::REST_NAMESPACE), 'shortcodes' => $this->public_shortcodes(), 'generated_pages' => array_values($this->generated_page_definitions())));
     }
 
     public function rest_me(): WP_REST_Response

--- a/src/data/plugin-shortcodes.json
+++ b/src/data/plugin-shortcodes.json
@@ -5,6 +5,19 @@
     "[omos_bridge_builder]",
     "[omos_tool_grid]",
     "[omos_docs_grid]",
-    "[algq_offer_generator]"
+    "[algq_offer_generator]",
+    "[onegodian_membership_cta]",
+    "[onegodian_members_pricing]",
+    "[onegodian_membership_resources]",
+    "[onegodian_member_certificates]",
+    "[onegodian_member_dashboard]",
+    "[onegodian_member_support]",
+    "[onegodian_contributors_page]",
+    "[onegodian_contributor_tiers]",
+    "[onegodian_creator_network]",
+    "[onegodian_affiliate_dashboard]",
+    "[onegodian_referral_link]",
+    "[onegodian_contributor_wall]",
+    "[onegodian_contributor_disclaimer]"
   ]
 }


### PR DESCRIPTION
### Motivation

- Fill gaps left by the earlier membership frontend work by adding contributor, creator-network, affiliate, referral, campaign-asset, and contributor-wall modules as shortcode-driven frontend placeholders.
- Provide admin references, generated page definitions, and a REST manifest that expose the new public shortcodes to consuming systems while keeping payment/commission logic out of scope.

### Description

- Added a new class `onegodian-members/includes/class-onegodian-members-contributors-affiliates.php` that registers the shortcodes `onegodian_contributors_page`, `onegodian_contributor_tiers`, `onegodian_creator_network`, `onegodian_affiliate_dashboard`, `onegodian_referral_link`, `onegodian_contributor_wall`, and `onegodian_contributor_disclaimer` and implements the requested frontend placeholders and markup.
- Implemented contributor tiers with the requested levels and amounts: `Supporter $11`, `Builder $33`, `Sustainer $77`, `Founder Circle $111`, `Infrastructure Partner $333+`, and `Custom Contribution` in `contributor_tiers()`.
- Implemented Creator Network section, Affiliate Dashboard placeholder, Contributor Wall placeholder, Campaign Assets placeholder, and the compliance disclaimer text exactly as requested (disclaimer constant in the new class).
- Referral link output is generated using current login state and identity via `is_user_logged_in()`, `get_current_user_id()`, and `wp_get_current_user()` and renders a URL with an `ogm_ref` parameter derived from the username or user ID.
- Registered the new class in `onegodian-members/onegodian-members.php` and preserved all existing membership shortcodes and behaviors; added `public_shortcodes()` and `generated_page_definitions()` and updated `generate_required_pages()` to create pages for `/contributors`, `/creator-network`, `/affiliate-dashboard`, `/contribute-now`, and `/contributor-wall` and to expose the shortcodes via the REST `rest_manifest` response.
- Bumped the plugin version to `1.7.0` and added the new shortcodes to the app-side manifest at `src/data/plugin-shortcodes.json`.
- Added admin docs/settings references and a new admin subpage grouping for contributor/affiliate programs (shortcode-driven placeholders only; no payment or commission processing logic added).

### Testing

- Ran PHP lint on the modified plugin files: `php -l onegodian-members/onegodian-members.php`, `php -l onegodian-members/includes/class-onegodian-members-shortcodes.php`, and `php -l onegodian-members/includes/class-onegodian-members-contributors-affiliates.php`, and all returned no syntax errors.
- Validated the updated shortcodes manifest JSON with `node -e "JSON.parse(require('fs').readFileSync('src/data/plugin-shortcodes.json','utf8'));"` which parsed successfully.
- Ran TypeScript checks via `npm run typecheck` which completed successfully.
- Ran `npm test` (smoke tests) which failed because the application `/api/manifest` currently returns additional API routes beyond the static route list expected by the smoke test script; this is unrelated to the PHP shortcode additions and is noted in the test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230aa79670832db7f2fe8145f001a1)