### PR TITLE
Finalize OneGodian Platform Plugin v1.0.0 production packaging and verification

### DIFF
--- a/.github/workflows/build-onegodian-platform-plugin.yml
+++ b/.github/workflows/build-onegodian-platform-plugin.yml
@@ -1,0 +1,42 @@
+name: Build OneGodian Platform Plugin
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'onegodian-platform-plugin/**'
+
+jobs:
+  build:
+    name: Validate and package plugin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Validate plugin PHP syntax
+        run: |
+          find onegodian-platform-plugin -type f -name '*.php' -print0 \
+            | xargs -0 -n 1 php -l
+
+      - name: Build production ZIP
+        run: ./scripts/build-onegodian-platform-plugin.sh
+
+      - name: Verify production ZIP
+        run: ./scripts/verify-onegodian-platform-plugin.sh
+
+      - name: Upload production ZIP artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: onegodian-platform-plugin-v1.0.0
+          path: onegodian-platform-plugin-v1.0.0.zip
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ ONEGODIAN, LLC is the commercial/IP/software entity. OMOS is a voluntary educati
 [algq_offer_generator]
 [/vc_column_text]
 ```
+
+## Production ZIP Build
+
+Build and verify the OneGodian Platform Plugin production ZIP locally before publishing a release artifact:
+
+```bash
+chmod +x scripts/build-onegodian-platform-plugin.sh
+chmod +x scripts/verify-onegodian-platform-plugin.sh
+./scripts/build-onegodian-platform-plugin.sh
+./scripts/verify-onegodian-platform-plugin.sh
+```
+
+The generated `onegodian-platform-plugin-v1.0.0.zip` file is a release artifact and should not be committed unless the repository release policy explicitly changes to allow generated ZIP files.

--- a/onegodian-platform-plugin/docs/ONEGODIAN_PLATFORM_V1.md
+++ b/onegodian-platform-plugin/docs/ONEGODIAN_PLATFORM_V1.md
@@ -78,12 +78,15 @@ Activation creates styled pages using the reusable template library, including h
 
 The plugin does not remove existing functionality. Legacy shortcode tags are registered only when another plugin has not already registered them, allowing dedicated modules for WooCommerce, Belief Mapper, member resources, and contributor systems to continue taking precedence.
 
-## Packaging
+## Production ZIP Build
 
-The distributable ZIP is intentionally generated locally and ignored by Git so repository pushes do not include binary release artifacts. Build it with:
+The distributable ZIP is intentionally generated locally and ignored by Git so repository pushes do not include binary release artifacts. Build and verify it with:
 
 ```bash
+chmod +x scripts/build-onegodian-platform-plugin.sh
+chmod +x scripts/verify-onegodian-platform-plugin.sh
 ./scripts/build-onegodian-platform-plugin.sh
+./scripts/verify-onegodian-platform-plugin.sh
 ```
 
-The script produces `onegodian-platform-plugin-v1.0.0.zip` at the repository root and verifies it with `unzip -t`.
+The build script produces `onegodian-platform-plugin-v1.0.0.zip` at the repository root and verifies archive integrity with `unzip -t`. The verification script confirms plugin structure, version metadata, required files, class registrations, REST route strings, and the one-folder ZIP layout.

--- a/onegodian-platform-plugin/docs/RELEASE_CHECKLIST_V1.md
+++ b/onegodian-platform-plugin/docs/RELEASE_CHECKLIST_V1.md
@@ -1,0 +1,25 @@
+# OneGodian Platform Plugin v1.0.0 Release Checklist
+
+Use this checklist before publishing the production ZIP for the OneGodian Platform Plugin v1.0.0 release.
+
+## Required Manual Verification
+
+- [ ] **Activation test**: Install and activate the plugin on a clean WordPress site without PHP fatal errors or admin notices.
+- [ ] **REST endpoint test**: Confirm the runtime endpoints return valid JSON for `/wp-json/onegodian/v1/health`, `/manifest`, `/tools`, and `/stats`.
+- [ ] **Connectors admin test**: Open the OneGodian Platform connector admin screen and verify connector status and test actions render correctly.
+- [ ] **Pattern registration test**: Confirm OneGodian block pattern categories and bundled patterns appear in the WordPress block editor.
+- [ ] **Navigation overlay display test**: Render each navigation overlay shortcode and verify columns, links, and labels display correctly.
+- [ ] **Unified OneGodian style CSS load test**: Confirm `assets/css/onegodian-platform.css` is enqueued on the front end and styles plugin modules consistently.
+- [ ] **WooCommerce compatibility test**: Activate WooCommerce alongside the plugin and confirm plugin activation, admin screens, and REST health output remain stable.
+- [ ] **Shortcode backward compatibility test**: Confirm legacy OneGodian shortcode tags continue to render or defer to dedicated module plugins when already registered.
+- [ ] **Mobile responsive review**: Review core templates, patterns, overlays, and generated pages on mobile breakpoints.
+- [ ] **ZIP installation test**: Install `onegodian-platform-plugin-v1.0.0.zip` through the WordPress plugin uploader and confirm the extracted folder is `onegodian-platform-plugin/`.
+
+## Packaging Commands
+
+```bash
+chmod +x scripts/build-onegodian-platform-plugin.sh
+chmod +x scripts/verify-onegodian-platform-plugin.sh
+./scripts/build-onegodian-platform-plugin.sh
+./scripts/verify-onegodian-platform-plugin.sh
+```

--- a/scripts/verify-onegodian-platform-plugin.sh
+++ b/scripts/verify-onegodian-platform-plugin.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_SLUG="onegodian-platform-plugin"
+PLUGIN_DIR="$ROOT_DIR/$PLUGIN_SLUG"
+MAIN_FILE="$PLUGIN_DIR/onegodian-platform-plugin.php"
+ZIP_PATH="$ROOT_DIR/${PLUGIN_SLUG}-v1.0.0.zip"
+VERSION="1.0.0"
+
+fail() {
+  echo "Verification failed: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "✓ $*"
+}
+
+contains_text() {
+  local file="$1"
+  local text="$2"
+  grep -Fq "$text" "$file" || fail "Missing '$text' in ${file#$ROOT_DIR/}"
+}
+
+[[ -d "$PLUGIN_DIR" ]] || fail "Missing plugin directory: ${PLUGIN_DIR#$ROOT_DIR/}"
+pass "Plugin directory exists"
+
+[[ -f "$MAIN_FILE" ]] || fail "Missing main plugin file: ${MAIN_FILE#$ROOT_DIR/}"
+pass "Main plugin file exists"
+
+contains_text "$MAIN_FILE" "Version: $VERSION"
+contains_text "$MAIN_FILE" "ONEGODIAN_PLATFORM_VERSION', '$VERSION'"
+pass "Plugin version is $VERSION"
+
+required_files=(
+  "assets/css/onegodian-platform.css"
+  "docs/ONEGODIAN_PLATFORM_V1.md"
+)
+for relative_path in "${required_files[@]}"; do
+  [[ -f "$PLUGIN_DIR/$relative_path" ]] || fail "Missing required file: $PLUGIN_SLUG/$relative_path"
+  pass "Required file exists: $PLUGIN_SLUG/$relative_path"
+done
+
+connector_classes=(
+  "class OG_Connector_Admin"
+  "class OG_Connector_Registry"
+  "class OG_Connectors"
+)
+for class_name in "${connector_classes[@]}"; do
+  rg --type php --fixed-strings --quiet "$class_name" "$PLUGIN_DIR/includes/connectors" || fail "Missing connector class: $class_name"
+  pass "Connector class exists: $class_name"
+done
+
+pattern_classes=(
+  "class OG_Patterns"
+)
+for class_name in "${pattern_classes[@]}"; do
+  rg --type php --fixed-strings --quiet "$class_name" "$PLUGIN_DIR/includes/patterns" || fail "Missing pattern class: $class_name"
+  pass "Pattern class exists: $class_name"
+done
+
+overlay_classes=(
+  "class OG_Navigation_Overlays"
+)
+for class_name in "${overlay_classes[@]}"; do
+  rg --type php --fixed-strings --quiet "$class_name" "$PLUGIN_DIR/includes/navigation-overlays" || fail "Missing navigation overlay class: $class_name"
+  pass "Navigation overlay class exists: $class_name"
+done
+
+rest_routes=(
+  "/health"
+  "/manifest"
+  "/tools"
+  "/stats"
+  "/connectors"
+  "/connectors/status"
+  "/connectors/test"
+)
+for route in "${rest_routes[@]}"; do
+  rg --type php --fixed-strings --quiet "$route" "$PLUGIN_DIR" || fail "Missing REST route string: $route"
+  pass "REST route string exists: $route"
+done
+
+[[ -f "$ZIP_PATH" ]] || fail "Missing ZIP artifact: ${ZIP_PATH#$ROOT_DIR/}. Run scripts/build-onegodian-platform-plugin.sh first."
+
+mapfile -t top_level_entries < <(zipinfo -1 "$ZIP_PATH" | awk -F/ 'NF > 1 { print $1 "/" } NF == 1 && $1 != "" { print $1 }' | sort -u)
+if [[ "${#top_level_entries[@]}" -ne 1 || "${top_level_entries[0]}" != "$PLUGIN_SLUG/" ]]; then
+  printf 'ZIP top-level entries found:\n' >&2
+  printf ' - %s\n' "${top_level_entries[@]}" >&2
+  fail "ZIP must contain exactly one top-level folder: $PLUGIN_SLUG/"
+fi
+pass "ZIP contains one top-level folder only: $PLUGIN_SLUG/"
+
+unzip -t "$ZIP_PATH" >/dev/null
+pass "ZIP integrity check passed"
+
+pass "OneGodian Platform Plugin production verification complete"


### PR DESCRIPTION
### Motivation

- Finalize production packaging for the OneGodian Platform Plugin v1.0.0 so releases are reproducible and verifiable.
- Add automated CI steps to validate PHP, build a production ZIP, verify its contents and layout, and upload a release artifact.
- Provide a local verification script and a release checklist so maintainers can validate the package before publishing.

### Description

- Add CI workflow ` .github/workflows/build-onegodian-platform-plugin.yml` that runs on `workflow_dispatch` and `push` to `main` for `onegodian-platform-plugin/**`, validates PHP syntax, runs the build script `scripts/build-onegodian-platform-plugin.sh`, runs the verification script `scripts/verify-onegodian-platform-plugin.sh`, and uploads `onegodian-platform-plugin-v1.0.0.zip` as an artifact.
- Add `scripts/verify-onegodian-platform-plugin.sh`, a POSIX shell verifier that checks the plugin directory and main file, asserts `Version: 1.0.0` and runtime constant, validates required files (`assets/css/onegodian-platform.css`, `docs/ONEGODIAN_PLATFORM_V1.md`), confirms connector/pattern/navigation overlay classes and REST route strings, enforces the ZIP contains a single top-level folder `onegodian-platform-plugin/`, and performs `unzip -t`.
- Add release checklist `onegodian-platform-plugin/docs/RELEASE_CHECKLIST_V1.md` with activation, REST endpoint, connectors admin, pattern registration, overlay display, CSS, WooCommerce, shortcode, mobile, and ZIP installation tests.
- Update docs (`README.md` and `onegodian-platform-plugin/docs/ONEGODIAN_PLATFORM_V1.md`) to include a `Production ZIP Build` section with the commands to build and verify locally using `chmod +x` and the build/verify scripts.

### Testing

- Ran PHP syntax validation: `find onegodian-platform-plugin -type f -name '*.php' -print0 | xargs -0 -n 1 php -l`, and it completed with no syntax errors.
- Ran the build and verification sequence: `./scripts/build-onegodian-platform-plugin.sh && ./scripts/verify-onegodian-platform-plugin.sh`, which produced `onegodian-platform-plugin-v1.0.0.zip` and the verifier reported all checks passed.
- Performed shell static checks with `bash -n scripts/build-onegodian-platform-plugin.sh` and `bash -n scripts/verify-onegodian-platform-plugin.sh`, and both scripts parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23268f8374832db6c3e49037e9c893)