### PR TITLE
Fix production deploy repository origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# OneGodian App Deploy
+
+Production deployment repository for **https://app.onegodian.com**.
+
+## Production repository lock
+
+- `ohi-stack/onegodian-app-deploy` is the single production deployment repository for the public/member-facing OneGodian App.
+- Hostinger deploys from this repository only. Do not point the production Hostinger app at `ohi-stack/onegodian-app` or the legacy `ohi-stack/execution-interface` repository.
+- If a local or Hostinger checkout cannot push or pull because `origin` points at the wrong repository, reset it with:
+
+```bash
+git remote set-url origin https://github.com/ohi-stack/onegodian-app-deploy.git
+git checkout main
+git pull --ff-only origin main
+```
+
 # OMOS Node Runtime
 
 Production runtime and documentation platform for **https://omos.onegodian.com**.

--- a/docs/hostinger-console-deploy-checklist.md
+++ b/docs/hostinger-console-deploy-checklist.md
@@ -16,7 +16,6 @@ In Hostinger, provision a separate Node.js/Next.js app for:
 
 - Domain: `console.onegodian.com`
 - Preferred repository: `ohi-stack/ohi-control-plane`
-- Temporary fallback repository (if needed): `ohi-stack/execution-interface`
 - Branch: `main`
 
 Required build/runtime settings:

--- a/docs/hostinger-deploy-checklist.md
+++ b/docs/hostinger-deploy-checklist.md
@@ -6,6 +6,7 @@ Use this checklist when promoting the latest `main` build to production.
 
 - SSH into the Hostinger/VPS machine.
 - Open the project directory containing this repo.
+- Confirm the production checkout origin is `https://github.com/ohi-stack/onegodian-app-deploy.git`; reset any legacy `execution-interface` or source-app origin before deploying.
 - Confirm required environment variables are set (for example `DATABASE_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, and OMOS bridge values).
 
 ## 2) Deploy latest code

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 APP_DIR="${APP_DIR:-$(pwd)}"
 BRANCH="${BRANCH:-main}"
-REPO_URL="${REPO_URL:-https://github.com/ohi-stack/execution-interface.git}"
+REPO_URL="${REPO_URL:-https://github.com/ohi-stack/onegodian-app-deploy.git}"
 RESTART_MODE="${RESTART_MODE:-none}" # none | pm2 | node
 PM2_APP_NAME="${PM2_APP_NAME:-onegodian-app}"
 VERIFY_BASE_URL="${VERIFY_BASE_URL:-https://app.onegodian.com}"
@@ -19,7 +19,15 @@ cd "$APP_DIR"
 echo "== Git remote check =="
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if git remote get-url origin >/dev/null 2>&1; then
-    echo "origin exists: $(git remote get-url origin)"
+    ORIGIN_URL="$(git remote get-url origin)"
+    echo "origin exists: $ORIGIN_URL"
+
+    case "$ORIGIN_URL" in
+      *ohi-stack/execution-interface.git|*ohi-stack/execution-interface)
+        echo "origin points at legacy execution-interface repo; updating origin to production deploy repo: $REPO_URL"
+        git remote set-url origin "$REPO_URL"
+        ;;
+    esac
   else
     echo "origin missing; adding origin: $REPO_URL"
     git remote add origin "$REPO_URL"


### PR DESCRIPTION
### Motivation
- Prevent Hostinger or local checkouts from pointing at the legacy `ohi-stack/execution-interface` repository and ensure production deploys use `ohi-stack/onegodian-app-deploy`. 
- Make the deploy helper resilient by auto-correcting legacy `origin` values to avoid failed pushes/pulls during deployment. 
- Update documentation to clearly state the production repository lock and remove references to the legacy fallback. 

### Description
- Updated the default `REPO_URL` in `scripts/deploy-prod.sh` to `https://github.com/ohi-stack/onegodian-app-deploy.git`. 
- Added an automatic `origin` correction in `scripts/deploy-prod.sh` that detects `ohi-stack/execution-interface` and replaces it with the production deploy repo. 
- Prepend production repository guidance and a `git remote set-url` recovery command to `README.md`. 
- Added an origin verification note to `docs/hostinger-deploy-checklist.md` and removed the `execution-interface` fallback from `docs/hostinger-console-deploy-checklist.md`. 

### Testing
- Ran `npm install` which completed without errors. 
- Ran `npm run lint` which returned no ESLint warnings or errors. 
- Ran `npm run build` which compiled and produced a successful production build. 
- Validated `scripts/deploy-prod.sh` syntax with `bash -n scripts/deploy-prod.sh` and ran `git diff --check` to ensure no diff-check issues; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a2389674832db36b6f313de3c787)