### PR TITLE
Add OneGodian Command Center homepage, platform navigation, and store/developer hubs

### DIFF
--- a/src/app/(app)/developer/page.tsx
+++ b/src/app/(app)/developer/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+const developerLinks = [
+  { title: 'System Health', href: '/system-health', description: 'Review runtime and application health surfaces.' },
+  { title: 'API Status', href: '/api-status', description: 'Open API status and route readiness references.' },
+  { title: 'Documentation', href: '/docs', description: 'Read platform guides, standards, and implementation notes.' },
+  { title: 'OMOS Runtime', href: '/omos', description: 'Connect with protocol, manifest, and runtime node information.' },
+  { title: 'ODIN Registry', href: '/odin', description: 'Open registry and canon-linked system interfaces.' },
+  { title: 'App Structure', href: '/standards/app-structure', description: 'Review route, navigation, and platform structure standards.' }
+];
+
+export default function DeveloperPage() {
+  return (
+    <main className="space-y-6">
+      <section className="glass-panel p-6 sm:p-8">
+        <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-300">Developer Hub</p>
+        <h1 className="mt-3 text-4xl font-black tracking-[-0.04em] text-white">Developer</h1>
+        <p className="mt-3 max-w-4xl text-base leading-7 text-slate-300">
+          Developer access collects app structure, runtime references, API status, documentation, ODIN system links, and operational implementation notes for the OneGodian app layer.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {developerLinks.map((link) => (
+          <Link key={link.href} href={link.href} className="mobile-card block">
+            <h2 className="text-xl font-black text-white">{link.title}</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{link.description}</p>
+            <span className="mt-5 inline-flex rounded-full border border-cyan-300/35 bg-cyan-300/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-cyan-100">Open →</span>
+          </Link>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/store/page.tsx
+++ b/src/app/(app)/store/page.tsx
@@ -1,5 +1,39 @@
-import { redirect } from 'next/navigation';
+import Link from 'next/link';
 
-export default function StoreRedirectPage() {
-  redirect('/products');
+const storeCategories = [
+  { title: 'Digital Downloads', href: 'https://onegodian.com/product-category/digital-downloads', description: 'Downloadable OneGodian resources, documents, templates, and digital tools.' },
+  { title: 'Books & Guides', href: 'https://onegodian.com/product-category/books-guides', description: 'Books, study guides, explanatory material, and framework references.' },
+  { title: 'Membership Resources', href: 'https://onegodian.com/product-category/membership-resources', description: 'Commercial member resources and access products fulfilled through Onegodian.com.' },
+  { title: 'Certificates', href: 'https://onegodian.com/product-category/certificates', description: 'Certificate products and record-related commercial offerings.' },
+  { title: 'Apparel & Goods', href: 'https://onegodian.com/product-category/apparel-goods', description: 'Branded goods, apparel, and physical product categories.' },
+  { title: 'Services', href: 'https://onegodian.com/product-category/services', description: 'Service offerings, business products, and commercial access points.' }
+];
+
+export default function StorePage() {
+  return (
+    <main className="space-y-6">
+      <section className="glass-panel p-6 sm:p-8">
+        <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-300">Onegodian.com Store Bridge</p>
+        <h1 className="mt-3 text-4xl font-black tracking-[-0.04em] text-white">Store</h1>
+        <p className="mt-3 max-w-4xl text-base leading-7 text-slate-300">
+          Onegodian.com is the commercial store for OneGodian products, services, digital downloads, educational materials, branded goods, member resources, and business offerings. This app routes users to store categories while purchases and fulfillment remain on Onegodian.com.
+        </p>
+        <Link href="https://onegodian.com" className="premium-button mt-6">Open Storefront</Link>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {storeCategories.map((category) => (
+          <Link key={category.href} href={category.href} className="mobile-card block">
+            <h2 className="text-xl font-black text-white">{category.title}</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{category.description}</p>
+            <span className="mt-5 inline-flex rounded-full border border-cyan-300/35 bg-cyan-300/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-cyan-100">Open →</span>
+          </Link>
+        ))}
+      </section>
+
+      <p className="rounded-2xl border border-gold-300/25 bg-gold-300/10 p-4 text-sm leading-6 text-gold-100">
+        Simple separation: Onegodian.org explains the framework. Onegodian.com powers the store, products, services, and commercial access. app.OneGodian.com connects users to tools, dashboards, and platform infrastructure.
+      </p>
+    </main>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,258 @@
-import { PageRenderer } from '@/components/PageRenderer';
+import Link from 'next/link';
+
+type LinkCard = {
+  title: string;
+  description?: string;
+  href: string;
+  cta?: string;
+};
+
+type PathwayCard = LinkCard & {
+  subtitle: string;
+  items: string[];
+};
+
+const platformCards: LinkCard[] = [
+  {
+    title: 'Onegodian.org',
+    description: 'Public home for identity, belief, community, education, historical record, and interpretive clarity.',
+    href: 'https://onegodian.org',
+    cta: 'Open Onegodian.org'
+  },
+  {
+    title: 'Onegodian.com',
+    description: 'Commercial store for products, services, digital downloads, books, certificates, branded goods, and business offerings.',
+    href: 'https://onegodian.com',
+    cta: 'Open Store'
+  },
+  {
+    title: 'u.Onegodian.org',
+    description: 'Education portal for courses, learning paths, Onegodianese™, curriculum, certification, and student progress.',
+    href: 'https://u.onegodian.org',
+    cta: 'Open Learning Portal'
+  },
+  {
+    title: 'app.OneGodian.com',
+    description: 'Operational dashboard layer for registries, identity tools, verification, systems, media, platform navigation, and connected infrastructure.',
+    href: '/',
+    cta: 'Open App Dashboard'
+  }
+];
+
+const identityBridgeCards: LinkCard[] = [
+  {
+    title: 'Identity & Meaning',
+    description: 'Learn the meaning of ONEGODIAN™, the identity framework, and key definitions.',
+    href: 'https://onegodian.org/about'
+  },
+  {
+    title: 'Membership Pathway',
+    description: 'Explore member education, community participation, and structured access.',
+    href: 'https://onegodian.org/membership'
+  },
+  {
+    title: 'Historical Record',
+    description: 'Review origin, authorship, records, timeline, and institutional continuity.',
+    href: 'https://onegodian.org/history'
+  },
+  {
+    title: 'OneGodian Sciences™',
+    description: 'Conceptual and educational materials related to OneGodian thought, systems, and research.',
+    href: 'https://onegodian.org/onegodian-science'
+  }
+];
+
+const memberToolCards: LinkCard[] = [
+  {
+    title: 'Member Identity',
+    description: 'Access member profile information, identity explanations, status, and participation records.',
+    href: '/identity'
+  },
+  {
+    title: 'Member Education',
+    description: 'Connect to guided materials, learning paths, courses, and Onegodianese™ resources.',
+    href: '/learn'
+  },
+  {
+    title: 'Certificates & Records',
+    description: 'View certificate tools, record references, verification pathways, and document lookup.',
+    href: '/verification'
+  },
+  {
+    title: 'Member Dashboard',
+    description: 'Use the dashboard as the central place for updates, tools, profile access, and member-only actions.',
+    href: '/dashboard'
+  }
+];
+
+const storeCards: LinkCard[] = [
+  { title: 'Digital Downloads', href: 'https://onegodian.com/product-category/digital-downloads' },
+  { title: 'Books & Guides', href: 'https://onegodian.com/product-category/books-guides' },
+  { title: 'Membership Resources', href: 'https://onegodian.com/product-category/membership-resources' },
+  { title: 'Certificates', href: 'https://onegodian.com/product-category/certificates' },
+  { title: 'Apparel & Goods', href: 'https://onegodian.com/product-category/apparel-goods' },
+  { title: 'Services', href: 'https://onegodian.com/product-category/services' }
+];
+
+const pathwayCards: PathwayCard[] = [
+  {
+    title: 'Learn',
+    subtitle: 'Identity + Meaning',
+    items: ['Definition of OneGodian', 'Core concepts', 'Public explanation pages', 'Frequently asked questions'],
+    href: 'https://onegodian.org/about',
+    cta: 'Start Learning'
+  },
+  {
+    title: 'Participate',
+    subtitle: 'Membership + Community',
+    items: ['Membership overview', 'Community pathway', 'Internal guidance', 'Participation structure'],
+    href: 'https://onegodian.org/membership',
+    cta: 'Explore Membership'
+  },
+  {
+    title: 'Study',
+    subtitle: 'History + Research',
+    items: ['Historical record', 'Foundational writings', 'Scientific and conceptual pages', 'Timeline and archive'],
+    href: 'https://onegodian.org/history',
+    cta: 'View Archive'
+  },
+  {
+    title: 'Build',
+    subtitle: 'App + Systems',
+    items: ['ODIN registry', 'Planetary canon', 'Verification tools', 'Connected platform infrastructure'],
+    href: '/odin',
+    cta: 'Open ODIN'
+  }
+];
+
+const accessCards: LinkCard[] = [
+  { title: 'Open App Dashboard', href: '/' },
+  { title: 'Learning Portal', href: 'https://u.onegodian.org/dashboard' },
+  { title: 'Storefront', href: 'https://onegodian.com' },
+  { title: 'ODIN Registry', href: '/odin' },
+  { title: 'Planetary Registry', href: '/odin/planetary-registry' },
+  { title: 'Identity Tools', href: '/identity' },
+  { title: 'Verification Tools', href: '/verification' },
+  { title: 'Media Center', href: '/media' },
+  { title: 'Capital Access', href: '/capital' },
+  { title: 'OneGodian Time', href: '/time' }
+];
+
+function SectionHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="max-w-3xl">
+      <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-300">OneGodian ecosystem</p>
+      <h2 className="mt-3 text-3xl font-black tracking-[-0.04em] text-white sm:text-4xl">{title}</h2>
+      {description ? <p className="mt-3 text-base leading-7 text-slate-300">{description}</p> : null}
+    </div>
+  );
+}
+
+function CardGrid({ cards, compact = false }: { cards: LinkCard[]; compact?: boolean }) {
+  return (
+    <div className={`mt-5 grid gap-4 ${compact ? 'sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5' : 'md:grid-cols-2 xl:grid-cols-4'}`}>
+      {cards.map((card) => (
+        <Link key={`${card.title}-${card.href}`} href={card.href} className="mobile-card group block min-h-full">
+          <h3 className="text-xl font-black tracking-[-0.02em] text-white">{card.title}</h3>
+          {card.description ? <p className="mt-3 text-sm leading-6 text-slate-300">{card.description}</p> : null}
+          <span className="mt-5 inline-flex rounded-full border border-cyan-300/35 bg-cyan-300/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-cyan-100 transition group-hover:border-gold-300/60 group-hover:text-gold-100">
+            {card.cta ?? 'Open'} →
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
 
 export default function HomePage() {
-  return <PageRenderer path="/" showEcosystemMap showRuntimeHealth />;
+  return (
+    <main className="space-y-8 sm:space-y-10">
+      <section className="glass-panel overflow-hidden p-5 sm:p-7 lg:p-10">
+        <div className="max-w-5xl">
+          <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-300 sm:tracking-[0.3em]">ONEGODIAN APP · APP.ONEGODIAN.COM</p>
+          <h1 className="mt-4 text-[clamp(2.5rem,11vw,5.6rem)] font-black leading-[0.9] tracking-[-0.06em] text-white">OneGodian Everything App</h1>
+          <p className="mt-5 max-w-4xl text-lg font-bold leading-8 text-gold-100 sm:text-2xl sm:leading-9">
+            The central Node/Next.js interface for the OneGodian ecosystem: ODIN registry systems, planetary canon, moon systems, products, certificates, media tools, identity access, education bridges, verification, and synchronized platform infrastructure.
+          </p>
+        </div>
+        <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <Link href="/" className="premium-button">Open Dashboard</Link>
+          <Link href="/ecosystem" className="premium-button-secondary">Explore Ecosystem</Link>
+          <Link href="/odin" className="premium-button-secondary">Open ODIN Registry</Link>
+          <Link href="https://u.onegodian.org/dashboard" className="premium-button-secondary">Student Portal</Link>
+        </div>
+      </section>
+
+      <section className="mobile-card">
+        <p className="text-xs font-black uppercase tracking-[0.22em] text-cyan-300">Platform Role</p>
+        <h2 className="mt-3 text-2xl font-black tracking-[-0.03em] text-white">What This App Does</h2>
+        <p className="mt-3 max-w-5xl text-base leading-7 text-slate-300">
+          app.OneGodian.com serves as the operational access layer for OneGodian tools, dashboards, registries, identity resources, media modules, certificates, platform bridges, and system interfaces. It connects public explanation, commerce, education, and infrastructure without replacing those dedicated domains.
+        </p>
+      </section>
+
+      <section>
+        <SectionHeader title="Platform Separation" />
+        <CardGrid cards={platformCards} />
+      </section>
+
+      <section>
+        <SectionHeader
+          title="Identity · Belief · Community · Education"
+          description="Onegodian.org explains the meaning of OneGodian, preserves its public record, supports educational guidance, and provides a structured pathway for people to learn, reflect, and participate with clarity."
+        />
+        <CardGrid cards={identityBridgeCards} />
+      </section>
+
+      <section>
+        <SectionHeader
+          title="Member Tools"
+          description="Member tools provide structured access to identity resources, educational materials, certificates, community updates, and guided participation within the OneGodian framework."
+        />
+        <CardGrid cards={memberToolCards} />
+      </section>
+
+      <section>
+        <SectionHeader
+          title="Onegodian.com Store Bridge"
+          description="Onegodian.com is the commercial store for OneGodian products, services, digital downloads, educational materials, branded goods, member resources, and business offerings."
+        />
+        <CardGrid cards={storeCards} compact />
+        <p className="mt-4 rounded-2xl border border-gold-300/25 bg-gold-300/10 p-4 text-sm leading-6 text-gold-100">
+          Simple separation: Onegodian.org explains the framework. Onegodian.com powers the store, products, services, and commercial access. app.OneGodian.com connects users to tools, dashboards, and platform infrastructure.
+        </p>
+      </section>
+
+      <section>
+        <SectionHeader title="Start with the Right Path" />
+        <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {pathwayCards.map((card) => (
+            <Link key={card.title} href={card.href} className="mobile-card group block">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">{card.subtitle}</p>
+              <h3 className="mt-3 text-2xl font-black tracking-[-0.03em] text-white">{card.title}</h3>
+              <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-300">
+                {card.items.map((item) => <li key={item}>• {item}</li>)}
+              </ul>
+              <span className="mt-5 inline-flex rounded-full border border-cyan-300/35 bg-cyan-300/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-cyan-100 transition group-hover:border-gold-300/60 group-hover:text-gold-100">
+                {card.cta} →
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Live Platform Access" />
+        <CardGrid cards={accessCards} compact />
+      </section>
+
+      <section className="glass-panel p-5 sm:p-7">
+        <p className="text-xs font-black uppercase tracking-[0.22em] text-cyan-300">Public Clarification</p>
+        <h2 className="mt-3 text-2xl font-black tracking-[-0.03em] text-white">Public Clarification</h2>
+        <p className="mt-3 max-w-5xl text-base leading-7 text-slate-300">
+          Onegodian.org presents an identity, educational, philosophical, and community framework. app.OneGodian.com provides operational access to platform tools, dashboards, registries, and system interfaces. Commercial products and services are handled separately through Onegodian.com and related commercial platforms. Nothing on this app should be read as a claim of nation-state authority, governmental status, or exemption from applicable law.
+        </p>
+      </section>
+    </main>
+  );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,10 +6,10 @@ import appPages from '@/data/app-pages.json';
 
 const bottomTabs = [
   { label: 'Home', href: '/', icon: '⌂' },
-  { label: 'Dashboard', href: '/dashboard', icon: '◈' },
-  { label: 'OMOS', href: '/omos', icon: '◎' },
-  { label: 'Tools', href: '/tools', icon: '✦' },
-  { label: 'More', href: '/docs', icon: '☰' }
+  { label: 'Systems', href: '/odin', icon: '◎' },
+  { label: 'Learn', href: '/learn', icon: '✦' },
+  { label: 'Community', href: '/membership', icon: '◇' },
+  { label: 'Identity', href: '/identity', icon: '◈' }
 ];
 
 function isActive(pathname: string, href: string) {
@@ -19,8 +19,7 @@ function isActive(pathname: string, href: string) {
 
 export function Navigation() {
   const pathname = usePathname() || '/';
-  const primary = appPages.navigation.slice(0, 7);
-  const secondary = appPages.navigation.slice(7);
+  const primary = appPages.navigation;
 
   return (
     <>
@@ -35,11 +34,11 @@ export function Navigation() {
           </Link>
 
           <nav className="ml-auto hidden items-center gap-1 lg:flex" aria-label="Primary navigation">
-            {[...primary, ...secondary].map((item) => (
+            {primary.map((item) => (
               <Link
                 key={item.path}
                 href={item.path}
-                className={`rounded-full px-3 py-2 text-sm font-semibold transition ${
+                className={`rounded-full px-2.5 py-2 text-xs font-semibold transition xl:px-3 xl:text-sm ${
                   isActive(pathname, item.path)
                     ? 'border border-gold-300/45 bg-gold-300/15 text-gold-100'
                     : 'text-slate-300 hover:bg-white/[0.06] hover:text-white'

--- a/src/data/app-pages.json
+++ b/src/data/app-pages.json
@@ -11,68 +11,73 @@
     {
       "label": "Dashboard",
       "path": "/dashboard",
-      "description": "Member overview, account status, active tools, and ecosystem progress."
+      "description": "Central member dashboard for updates, tools, profile access, records, and member actions."
     },
     {
       "label": "Ecosystem",
       "path": "/ecosystem",
-      "description": "Map of OneGodian domains, platforms, systems, and operating layers."
-    },
-    {
-      "label": "OMOS",
-      "path": "/omos",
-      "description": "Connection layer to OMOS.OneGodian.com, the protocol and runtime node."
+      "description": "Map the role of Onegodian.org, Onegodian.com, u.Onegodian.org, and app.OneGodian.com."
     },
     {
       "label": "Registry",
       "path": "/registry",
-      "description": "Public-facing registry access for records, certificates, identifiers, and verification links."
+      "description": "Registry access for records, certificates, identifiers, ODIN references, and verification links."
     },
     {
-      "label": "Tools",
-      "path": "/tools",
-      "description": "Belief Mapper Lite, OneGodian Time tools, system utilities, and identity reflection tools."
+      "label": "ODIN",
+      "path": "/odin",
+      "description": "Open ODIN registry systems, canon references, platform records, and system interfaces."
     },
     {
-      "label": "Members",
-      "path": "/members",
-      "description": "Membership pathways, contributor access, profile infrastructure, and participation options."
+      "label": "Planets",
+      "path": "/odin/planetary-registry",
+      "description": "Access the planetary registry and canon-linked world records."
     },
     {
-      "label": "Certificates",
-      "path": "/certificates",
-      "description": "Certificates, badges, QRV verification links, and credential records."
+      "label": "Learn",
+      "path": "/learn",
+      "description": "Bridge to learning paths, Onegodianese\u2122 resources, curriculum, and u.Onegodian.org courses."
     },
     {
-      "label": "Products",
-      "path": "/products",
-      "description": "Books, downloads, courses, founder products, memberships, and digital tools."
+      "label": "Identity",
+      "path": "/identity",
+      "description": "Member identity explanations, profile context, participation records, and access resources."
+    },
+    {
+      "label": "Verification",
+      "path": "/verification",
+      "description": "Certificate tools, record references, verification pathways, and document lookup."
     },
     {
       "label": "Media",
       "path": "/media",
-      "description": "Videos, music, visual campaigns, founder updates, and public media assets."
+      "description": "Media center for videos, campaigns, cultural assets, founder updates, and platform content."
     },
     {
-      "label": "Settings",
-      "path": "/settings",
-      "description": "Profile settings, preferences, notification controls, and account configuration."
+      "label": "Store",
+      "path": "/store",
+      "description": "Bridge to Onegodian.com products, services, digital downloads, certificates, and branded goods."
     },
     {
-      "label": "Docs",
-      "path": "/docs",
-      "description": "Documentation, white papers, platform guides, and integration references."
+      "label": "Capital",
+      "path": "/capital",
+      "description": "Capital access tools, funding tracker modules, instruments, and business infrastructure."
+    },
+    {
+      "label": "Time",
+      "path": "/time",
+      "description": "OneGodian Time tools for internal/system chronology with Gregorian and UTC compatibility."
     }
   ],
   "pages": {
     "/": {
-      "title": "The OneGodian App",
-      "eyebrow": "Unified Ecosystem Interface",
-      "headline": "Unified access for identity, systems, records, education, commerce, media, and verification.",
-      "body": "The OneGodian App is the central experience layer for the OneGodian ecosystem. It connects public information, member tools, digital products, OMOS runtime services, registry access, certificates, education pathways, and media into one structured interface.",
+      "title": "OneGodian Everything App",
+      "eyebrow": "ONEGODIAN APP \u00b7 APP.ONEGODIAN.COM",
+      "headline": "The operational launcher and dashboard layer for the OneGodian ecosystem.",
+      "body": "app.OneGodian.com connects ODIN registry systems, planetary canon, moon systems, products, certificates, media tools, identity access, education bridges, verification, and synchronized platform infrastructure.",
       "primaryCta": {
         "label": "Open Dashboard",
-        "href": "/dashboard"
+        "href": "/"
       },
       "secondaryCta": {
         "label": "Explore Ecosystem",
@@ -81,31 +86,30 @@
     },
     "/dashboard": {
       "title": "Dashboard",
-      "eyebrow": "Member Command View",
-      "headline": "Your OneGodian ecosystem overview.",
-      "body": "The dashboard brings together current access, saved tools, active records, certificates, membership status, and recommended next steps. This is the member-facing experience layer. Operator-only controls belong outside the app and stay in the separate console environment.",
+      "eyebrow": "Command Center",
+      "headline": "Central dashboard for OneGodian updates, tools, profile access, records, and member-only actions.",
+      "body": "Use the dashboard as the operational home for identity resources, certificates, platform links, education bridges, system status, ODIN access, and recommended next steps.",
       "sections": [
-        "Profile Snapshot",
-        "Active Tools",
+        "Member Profile",
+        "Identity Access",
         "Certificates",
-        "Membership",
-        "Recommended Next Steps",
+        "Education Bridge",
+        "ODIN Shortcuts",
         "System Status"
       ]
     },
     "/ecosystem": {
       "title": "Ecosystem",
-      "eyebrow": "Platform Map",
-      "headline": "Understand how each OneGodian domain works together.",
-      "body": "The ecosystem is organized by role: OneGodian.org for public explanation and education, OneGodian.com for commerce and memberships, OMOS.OneGodian.com for runtime systems, QuantumOHI.com for enterprise positioning, capital.OneGodian.com for capital infrastructure, u.OneGodian.com for education, galaxy.OneGodian.com for lore and exploration, and QRV.Network for verification infrastructure.",
+      "eyebrow": "Platform Separation",
+      "headline": "See how the OneGodian platform domains work together without replacing each other.",
+      "body": "Onegodian.org explains identity, belief, community, education, and public history. Onegodian.com powers commerce. u.Onegodian.org runs education. app.OneGodian.com connects dashboards, tools, registries, identity access, verification, and system infrastructure.",
       "sections": [
-        "Public Layer",
-        "Commerce Layer",
-        "Runtime Layer",
-        "Education Layer",
-        "Capital Layer",
-        "Verification Layer",
-        "Media Layer"
+        "Onegodian.org",
+        "Onegodian.com",
+        "u.Onegodian.org",
+        "app.OneGodian.com",
+        "ODIN",
+        "Verification"
       ]
     },
     "/omos": {
@@ -129,14 +133,14 @@
     "/registry": {
       "title": "Registry",
       "eyebrow": "Records & Verification",
-      "headline": "Access OneGodian records, certificates, and verification pathways.",
-      "body": "The registry page organizes identity records, certificate references, public identifiers, QRV verification links, and documentation pathways. Legal and financial records should retain Gregorian dates as the controlling reference, with OneGodian Time displayed as supplemental internal sequencing where applicable.",
+      "headline": "Access OneGodian records, certificates, registry pathways, and ODIN references.",
+      "body": "The registry organizes certificate references, identity records, public identifiers, verification links, and ODIN registry pathways for app-based lookup and navigation.",
       "sections": [
         "Certificate Registry",
         "QRV Verification",
         "ODIN References",
-        "Public Records",
-        "Chronology Links"
+        "Planetary Registry",
+        "Identity Records"
       ]
     },
     "/tools": {
@@ -194,13 +198,13 @@
     },
     "/media": {
       "title": "Media",
-      "eyebrow": "Public Communication",
-      "headline": "Watch, listen, read, and share OneGodian media.",
-      "body": "The media area organizes videos, music, campaign assets, founder updates, educational clips, and branded visuals. It supports cultural recognition and public engagement without turning the app into an internal control surface.",
+      "eyebrow": "Media Center",
+      "headline": "Use the media center for OneGodian platform content, education assets, campaigns, and public communication.",
+      "body": "The media area organizes videos, campaign assets, educational clips, founder updates, and shareable ecosystem media while keeping dashboards and commerce in their dedicated layers.",
       "sections": [
         "Featured Videos",
-        "Music",
         "Campaigns",
+        "Education Clips",
         "Founder Updates",
         "Press Assets"
       ]
@@ -231,6 +235,97 @@
         "OneGodian Time",
         "Plugin Guides",
         "API References"
+      ]
+    },
+    "/store": {
+      "title": "Store Bridge",
+      "eyebrow": "Commerce Access",
+      "headline": "Connect to Onegodian.com products, services, downloads, certificates, and branded goods.",
+      "body": "The app provides store navigation and product-category access while checkout, purchases, and commercial fulfillment stay on Onegodian.com.",
+      "sections": [
+        "Digital Downloads",
+        "Books & Guides",
+        "Membership Resources",
+        "Certificates",
+        "Apparel & Goods",
+        "Services"
+      ]
+    },
+    "/learn": {
+      "title": "Learn",
+      "eyebrow": "Education Bridge",
+      "headline": "Connect to guided materials, learning paths, Onegodianese\u2122 resources, curriculum, and student portals.",
+      "body": "Learning content is bridged from the app into public educational pages and u.Onegodian.org, the dedicated course and certification portal.",
+      "sections": [
+        "Identity & Meaning",
+        "Onegodianese\u2122",
+        "Courses",
+        "Curriculum",
+        "Certification"
+      ]
+    },
+    "/identity": {
+      "title": "Identity",
+      "eyebrow": "Member Identity",
+      "headline": "Access member profile information, identity explanations, status, and participation records.",
+      "body": "Identity resources explain the OneGodian framework, membership context, records, certificates, and voluntary participation pathways without implying governmental status or exemption from applicable law.",
+      "sections": [
+        "Profile",
+        "Identity Meaning",
+        "Member Records",
+        "Participation",
+        "Certificates"
+      ]
+    },
+    "/verification": {
+      "title": "Verification",
+      "eyebrow": "Records Lookup",
+      "headline": "View certificate tools, record references, verification pathways, and document lookup.",
+      "body": "Verification tools help users locate references and records across the OneGodian app while keeping legal, commercial, and educational context clearly separated.",
+      "sections": [
+        "Certificate Lookup",
+        "Record References",
+        "Document Lookup",
+        "ODIN Verification",
+        "QRV Links"
+      ]
+    },
+    "/capital": {
+      "title": "Capital",
+      "eyebrow": "Capital Access",
+      "headline": "Access capital tools, funding trackers, instruments, licensing, and business infrastructure.",
+      "body": "Capital modules provide operational visibility for funding, instruments, valuation, licensing, and platform business infrastructure with appropriate disclosures.",
+      "sections": [
+        "Funding Tracker",
+        "Instruments",
+        "Valuation",
+        "Licensing",
+        "Payments"
+      ]
+    },
+    "/time": {
+      "title": "OneGodian Time",
+      "eyebrow": "Internal/System Chronology",
+      "headline": "Use OneGodian Time tools as an internal presentation layer with Gregorian and UTC compatibility.",
+      "body": "OneGodian Time supports internal cultural and system chronology. Gregorian dates and UTC timestamps remain controlling for legal, financial, regulatory, contractual, and technical records.",
+      "sections": [
+        "Today in OneGodian Time",
+        "Dual Dating",
+        "UTC Compatibility",
+        "Legal-Safe Display"
+      ]
+    },
+    "/membership": {
+      "title": "Membership",
+      "eyebrow": "Member Pathway",
+      "headline": "Explore member education, community participation, resources, and structured access.",
+      "body": "Membership routes support voluntary participation, member education, profile records, community updates, certificates, and guided access within the OneGodian framework.",
+      "sections": [
+        "Membership Overview",
+        "Community Pathway",
+        "Member Education",
+        "Certificates",
+        "Dashboard Access"
       ]
     }
   }


### PR DESCRIPTION
### Motivation
- Replace the generic placeholder homepage with a real Command Center that serves as the operational launcher and dashboard layer for the OneGodian ecosystem while preserving domain separation between Onegodian.org, Onegodian.com, u.Onegodian.org, and app.OneGodian.com. 
- Surface clickable bridges to public, education, and commercial domains and provide clear, non-governmental public clarification text. 
- Ensure common routes and navigation reflect the app’s role as an access layer for registries, identity, ODIN, verification, media, learning, and platform tools.

### Description
- Replaced the homepage renderer with a full Command Center in `src/app/page.tsx`, adding the requested hero (label, title, subtitle), primary CTAs, `What This App Does` panel, Platform Separation, Identity/Belief/Education bridge, Member Tools, Store Bridge, Featured Pathways, Live Platform Access, and Public Clarification sections; cards are clickable and route to internal or external targets. 
- Converted `/store` from a redirect into a clickable bridge at `src/app/(app)/store/page.tsx` with product-category links pointing to `onegodian.com`. 
- Added a developer hub at `src/app/(app)/developer/page.tsx` and updated the main navigation data in `src/data/app-pages.json` to include `Dashboard`, `Ecosystem`, `Registry`, `ODIN`, `Planets`, `Learn`, `Identity`, `Verification`, `Media`, `Store`, `Capital`, and `Time`. 
- Updated `src/components/Navigation.tsx` to use the new navigation list for desktop/horizontal nav and to update the mobile bottom tabs to `Home`, `Systems`, `Learn`, `Community`, `Identity`; ensured mobile nav remains horizontally scrollable.

### Testing
- Ran `npm run check` and it completed successfully. 
- Ran `npm run build` and the Next.js production build completed successfully (pages compiled and static pages generated). 
- Ran `npm run lint` and there were no ESLint warnings or errors. 
- Verified required route files exist (e.g. `src/app/(app)/dashboard/page.tsx`, `src/app/(app)/ecosystem/page.tsx`, `src/app/(app)/odin/page.tsx`, `src/app/(app)/odin/planetary-registry/page.tsx`, `src/app/(app)/learn/page.tsx`, `src/app/(app)/identity/page.tsx`, `src/app/(app)/verification/page.tsx`, `src/app/(app)/store/page.tsx`, `src/app/(app)/media/page.tsx`, `src/app/(app)/capital/page.tsx`, `src/app/(app)/time/page.tsx`, `src/app/(app)/membership/page.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a8afdb70832d851a3cd035ce8539)