### PR TITLE
Fix Capital Portal mobile navigation

### DIFF
--- a/onegodian-capital-plugin/assets/capital-portal.css
+++ b/onegodian-capital-plugin/assets/capital-portal.css
@@ -1,0 +1,82 @@
+/* ONEGODIAN Capital Portal — Mobile Navigation Fix */
+.onegodian-capital-header,
+.capital-header,
+.site-header {
+  width: 100%;
+  padding: 18px 24px;
+  box-sizing: border-box;
+}
+
+.onegodian-capital-brand,
+.capital-brand,
+.site-branding {
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1.25;
+  color: #071b33;
+}
+
+.onegodian-capital-nav,
+.capital-nav,
+.site-navigation,
+.main-navigation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 18px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.onegodian-capital-nav a,
+.capital-nav a,
+.site-navigation a,
+.main-navigation a {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  color: #071b33;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .onegodian-capital-header,
+  .capital-header,
+  .site-header {
+    padding: 18px 22px;
+  }
+
+  .onegodian-capital-brand,
+  .capital-brand,
+  .site-branding {
+    font-size: 16px;
+    letter-spacing: 0.06em;
+  }
+
+  .onegodian-capital-nav,
+  .capital-nav,
+  .site-navigation,
+  .main-navigation {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 9px;
+    margin-top: 14px;
+  }
+
+  .onegodian-capital-nav a,
+  .capital-nav a,
+  .site-navigation a,
+  .main-navigation a {
+    width: 100%;
+    min-height: 44px;
+    padding: 12px 14px;
+    border: 1px solid rgba(7, 27, 51, 0.12);
+    border-radius: 12px;
+    background: #f7f8fb;
+    box-sizing: border-box;
+  }
+}

--- a/onegodian-capital-plugin/onegodian-capital-plugin.php
+++ b/onegodian-capital-plugin/onegodian-capital-plugin.php
@@ -40,6 +40,13 @@ register_activation_hook(
 );
 
 add_action(
+	'wp_enqueue_scripts',
+	static function () {
+		wp_enqueue_style( 'ogc-capital-portal', OGC_URL . 'assets/capital-portal.css', array(), OGC_VERSION );
+	}
+);
+
+add_action(
 	'plugins_loaded',
 	static function () {
 		OGC_Product_Sync::instance();


### PR DESCRIPTION
### Motivation
- Mobile navigation on the Capital Portal was collapsing into a single unspaced text string and mobile links were not presented as accessible stacked tap targets, causing poor usability on small screens.

### Description
- Add a new frontend stylesheet at `onegodian-capital-plugin/assets/capital-portal.css` implementing wrapped desktop nav and stacked 44px mobile tap targets for `.onegodian-capital-nav`, `.capital-nav`, `.site-navigation`, and `.main-navigation`.
- Enqueue the stylesheet from the plugin by adding a `wp_enqueue_scripts` action in `onegodian-capital-plugin/onegodian-capital-plugin.php` that registers `ogc-capital-portal` pointing to the new CSS file.
- No other functional changes to plugin behavior were made.

### Testing
- Ran `php -l onegodian-capital-plugin/onegodian-capital-plugin.php` which reported no syntax errors (success).
- Ran `./scripts/build-onegodian-capital-plugin.sh` which ran PHP syntax checks across plugin files and produced the build zip (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259a94ba60832d9cd73cfcdb2c9304)