### PR TITLE
Fix missing method closing braces in Onegodian_Members_Plugin

### DIFF
--- a/onegodian-members/onegodian-members.php
+++ b/onegodian-members/onegodian-members.php
@@ -723,6 +723,8 @@ final class Onegodian_Members_Plugin
     public function shortcode_contributor_disclaimer(): string
     {
         return '<p class="ogm-front ogm-contributor-disclaimer">' . esc_html($this->get_setting('default_disclaimer_text')) . '</p>';
+    }
+
     public function render_programs_page(): void
     {
         $this->render_admin_shell('onegodian-members-programs', function (): void {
@@ -916,6 +918,8 @@ final class Onegodian_Members_Plugin
             $created++;
         }
         return $created;
+    }
+
     /** @return array<int, array{title:string, slug:string, shortcode:string}> */
     private function generated_page_definitions(): array
     {


### PR DESCRIPTION
### Motivation
- Restore valid PHP syntax by closing two methods that were missing trailing braces so the plugin can be parsed and loaded without fatal errors.

### Description
- Added the missing closing braces for `shortcode_contributor_disclaimer()` and `generate_belief_mapper_pages()` in `onegodian-members/onegodian-members.php`.

### Testing
- Performed a PHP syntax check with `php -l onegodian-members/onegodian-members.php`, which succeeded; no automated unit tests were changed or required for this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a9d6d520832d81dce367aad5327c)