### PR TITLE
Update OneGodian App: real contributors, membership, creator network, and affiliate content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "acc",
-  "version": "1.0.0",
+  "name": "onegodian-app-deploy",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "acc",
-      "version": "1.0.0",
+      "name": "onegodian-app-deploy",
+      "version": "1.1.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.59.2",
         "@typescript-eslint/parser": "^8.59.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "acc",
-  "version": "1.0.0",
+  "name": "onegodian-app-deploy",
+  "version": "1.1.0",
   "private": true,
-  "description": "ACC™ Agent Command Console — operator-facing command console for OneGodian operational surfaces.",
+  "description": "OneGodian App™ — public and member-facing gateway for OneGodian identity, education, membership, tools, certificates, products, media, and ecosystem access.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ohi-stack/acc.git"
+    "url": "https://github.com/ohi-stack/onegodian-app-deploy.git"
   },
-  "homepage": "https://acc.onegodian.com",
+  "homepage": "https://app.onegodian.com",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,10 @@
 {
-  "name": "ACC™ Agent Command Console",
-  "short_name": "ACC™",
+  "name": "OneGodian App",
+  "short_name": "OneGodian App",
+  "description": "Public and member-facing gateway for OneGodian identity, education, membership, tools, certificates, products, media, and ecosystem access.",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#020617",
-  "theme_color": "#0891b2"
+  "theme_color": "#fbbf24"
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://acc.onegodian.com/</loc></url>
+  <url><loc>https://app.onegodian.com/</loc></url>
+  <url><loc>https://app.onegodian.com/dashboard</loc></url>
+  <url><loc>https://app.onegodian.com/members</loc></url>
+  <url><loc>https://app.onegodian.com/contributors</loc></url>
+  <url><loc>https://app.onegodian.com/creator-network</loc></url>
+  <url><loc>https://app.onegodian.com/affiliate-dashboard</loc></url>
+  <url><loc>https://app.onegodian.com/referral-links</loc></url>
+  <url><loc>https://app.onegodian.com/contributor-wall</loc></url>
+  <url><loc>https://app.onegodian.com/certificates</loc></url>
+  <url><loc>https://app.onegodian.com/products</loc></url>
+  <url><loc>https://app.onegodian.com/media</loc></url>
+  <url><loc>https://app.onegodian.com/learning</loc></url>
+  <url><loc>https://app.onegodian.com/registry</loc></url>
+  <url><loc>https://app.onegodian.com/tools</loc></url>
+  <url><loc>https://app.onegodian.com/settings</loc></url>
+  <url><loc>https://app.onegodian.com/ecosystem</loc></url>
 </urlset>

--- a/src/app/affiliate-dashboard/page.tsx
+++ b/src/app/affiliate-dashboard/page.tsx
@@ -1,0 +1,13 @@
+import { ConsolePage } from '@/components/ConsolePage';
+import { affiliateDashboardItems } from '@/lib/acc-content';
+
+export default function Page() {
+  return (
+    <ConsolePage href="/affiliate-dashboard">
+      <div className="grid gap-3 md:grid-cols-2">
+        {affiliateDashboardItems.map((item) => <div key={item} className="rounded-2xl border border-white/10 bg-slate-950/35 p-4 font-black text-white">{item}</div>)}
+      </div>
+      <p className="mt-5 text-slate-300">Payment, commission, and earnings logic is not active in this app surface unless a backend is connected.</p>
+    </ConsolePage>
+  );
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,7 +1,7 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ resource: 'agents', authoritative: false, note: 'ACC exposes operator-facing read models only; authority remains with external services.' });
+  return appJson({ resource: 'agents', authoritative: false, note: 'This legacy endpoint is not a payment, contribution, or securities workflow on the public OneGodian App surface.' });
 }

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -1,7 +1,7 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ resource: 'audit', authoritative: false, note: 'ACC exposes operator-facing read models only; authority remains with external services.' });
+  return appJson({ resource: 'audit', authoritative: false, note: 'This legacy endpoint is not a payment, contribution, or securities workflow on the public OneGodian App surface.' });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,7 +1,7 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ ok: true, status: 'healthy', surface: 'operator-interface' });
+  return appJson({ ok: true, status: 'healthy', surface: 'public-member-gateway' });
 }

--- a/src/app/api/readiness/route.ts
+++ b/src/app/api/readiness/route.ts
@@ -1,8 +1,8 @@
-import { accJson } from '@/lib/api';
-import { consoleModules } from '@/lib/acc-content';
+import { appJson } from '@/lib/api';
+import { dashboardModules } from '@/lib/acc-content';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ ready: true, modules: consoleModules.map(({ title, href, status }) => ({ title, href, status })) });
+  return appJson({ ready: true, modules: dashboardModules.map(({ title, href, status }) => ({ title, href, status })) });
 }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,16 @@
+import { appJson } from '@/lib/api';
+import { dashboardModules, domainStructure, pluginShortcodes, tools } from '@/lib/acc-content';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return appJson({
+    stats: {
+      modules: dashboardModules.length,
+      routes: dashboardModules.length + 2,
+      domains: domainStructure.length,
+      pluginBridgeShortcodes: pluginShortcodes.length,
+      tools: tools.length
+    }
+  });
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,7 +1,7 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ resource: 'tasks', authoritative: false, note: 'ACC exposes operator-facing read models only; authority remains with external services.' });
+  return appJson({ resource: 'tasks', authoritative: false, note: 'This legacy endpoint is not a payment, contribution, or securities workflow on the public OneGodian App surface.' });
 }

--- a/src/app/api/tools/route.ts
+++ b/src/app/api/tools/route.ts
@@ -1,0 +1,7 @@
+import { appJson, toolsPayload } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return appJson(toolsPayload());
+}

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,7 +1,8 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
+import { appPositioning } from '@/lib/acc-content';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ version: process.env.NEXT_PUBLIC_ACC_VERSION ?? '1.0.0' });
+  return appJson({ version: process.env.NEXT_PUBLIC_APP_VERSION ?? appPositioning.version });
 }

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,7 +1,7 @@
-import { accJson } from '@/lib/api';
+import { appJson } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export function GET() {
-  return accJson({ resource: 'workflows', authoritative: false, note: 'ACC exposes operator-facing read models only; authority remains with external services.' });
+  return appJson({ resource: 'workflows', authoritative: false, note: 'This legacy endpoint is not a payment, contribution, or securities workflow on the public OneGodian App surface.' });
 }

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -1,0 +1,5 @@
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/certificates">Member certificates are represented through <code>[onegodian_member_certificates]</code> and registry-aware certificate references.</ConsolePage>;
+}

--- a/src/app/contributor-wall/page.tsx
+++ b/src/app/contributor-wall/page.tsx
@@ -1,0 +1,5 @@
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/contributor-wall">Contributor Wall recognition is connected to <code>[onegodian_contributor_wall]</code> and must remain paired with the contributor disclaimer shortcode.</ConsolePage>;
+}

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -1,0 +1,19 @@
+import { ConsolePage } from '@/components/ConsolePage';
+import { contributorNotice, contributorTiers } from '@/lib/acc-content';
+
+export default function Page() {
+  return (
+    <ConsolePage href="/contributors">
+      <p>Contributors support ONEGODIAN, LLC public-facing products, education, media, technology, membership, and community infrastructure.</p>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        {contributorTiers.map((tier) => (
+          <div key={tier.name} className="rounded-2xl border border-amber-200/15 bg-amber-200/10 p-4">
+            <p className="font-black text-white">{tier.name}</p>
+            <p className="mt-1 text-2xl font-black text-amber-100">{tier.amount}</p>
+          </div>
+        ))}
+      </div>
+      <p className="mt-5 rounded-2xl border border-purple-300/30 bg-purple-400/10 p-4 font-semibold text-purple-50">{contributorNotice}</p>
+    </ConsolePage>
+  );
+}

--- a/src/app/creator-network/page.tsx
+++ b/src/app/creator-network/page.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return (
+    <ConsolePage href="/creator-network">
+      <p>Creators, affiliates, educators, and community voices can help share OneGodian identity, education, public resources, products, and campaigns.</p>
+      <Link href="/affiliate-dashboard" className="mt-5 inline-flex rounded-full border border-amber-200/60 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950">Apply to Creator Network</Link>
+    </ConsolePage>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,14 @@
-import { ConsolePage } from '@/components/ConsolePage';
+import { ModuleCard } from '@/components/ModuleCard';
+import { PageHeader } from '@/components/PageHeader';
+import { dashboardModules } from '@/lib/acc-content';
 
 export default function Page() {
-  return <ConsolePage href="/dashboard" />;
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Member Dashboard" title="OneGodian App Dashboard" description="Open the current OneGodian member, contributor, creator, affiliate, certificate, product, media, learning, registry, tools, and settings modules." />
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {dashboardModules.map((module) => <ModuleCard key={module.href} module={module} />)}
+      </section>
+    </main>
+  );
 }

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,25 +1,31 @@
 import { PageHeader } from '@/components/PageHeader';
-import { accPositioning, accRepository, separationRules } from '@/lib/acc-content';
+import { appPositioning, appRepository, domainStructure, pluginShortcodes } from '@/lib/acc-content';
 
 export default function DocsPage() {
   return (
     <main className="space-y-6">
-      <PageHeader eyebrow="ACC Doctrine" title="Canonical repository and deployment doctrine" description="ACC is isolated as ohi-stack/acc and deployed to acc.onegodian.com as the operator-facing interface only." />
+      <PageHeader eyebrow="App Documentation" title="OneGodian App content and plugin bridge" description={appPositioning.summary} />
       <section className="grid gap-4 lg:grid-cols-2">
         <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-5">
           <h2 className="text-2xl font-black text-white">Canonical placement</h2>
           <dl className="mt-4 space-y-3 text-sm leading-6 text-slate-300">
-            <div><dt className="font-black text-slate-100">Repository</dt><dd>{accRepository.url}</dd></div>
-            <div><dt className="font-black text-slate-100">Deployment</dt><dd>{accRepository.deployTarget}</dd></div>
-            <div><dt className="font-black text-slate-100">Boundary</dt><dd>{accPositioning.boundary}</dd></div>
+            <div><dt className="font-black text-slate-100">Repository</dt><dd>{appRepository.url}</dd></div>
+            <div><dt className="font-black text-slate-100">Deployment</dt><dd>{appRepository.deployTarget}</dd></div>
+            <div><dt className="font-black text-slate-100">Boundary</dt><dd>{appPositioning.boundary}</dd></div>
           </dl>
         </article>
-        <article className="rounded-3xl border border-amber-300/30 bg-amber-300/10 p-5">
-          <h2 className="text-2xl font-black text-white">Do-not-merge policy</h2>
-          <ul className="mt-4 space-y-3 text-sm font-semibold leading-6 text-amber-50">
-            {separationRules.map((rule) => <li key={rule}>• {rule}</li>)}
-          </ul>
+        <article className="rounded-3xl border border-purple-300/30 bg-purple-400/10 p-5">
+          <h2 className="text-2xl font-black text-white">Plugin bridge shortcodes</h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {pluginShortcodes.map((shortcode) => <code key={shortcode} className="rounded-full border border-white/10 bg-slate-950/40 px-3 py-2 text-xs text-slate-200">{shortcode}</code>)}
+          </div>
         </article>
+      </section>
+      <section className="rounded-3xl border border-amber-300/25 bg-amber-300/10 p-5">
+        <h2 className="text-2xl font-black text-white">Domain roles</h2>
+        <div className="mt-4 grid gap-3 text-sm text-amber-50 md:grid-cols-2">
+          {domainStructure.map((domain) => <p key={domain.host}><strong>{domain.host}</strong> — {domain.role}</p>)}
+        </div>
       </section>
     </main>
   );

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -1,0 +1,13 @@
+import { PageHeader } from '@/components/PageHeader';
+import { domainStructure } from '@/lib/acc-content';
+
+export default function Page() {
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Ecosystem" title="OneGodian production domain structure" description="The app keeps public/member access, operator runtime, capital operations, education/community, and commerce/payments on the correct production surfaces." />
+      <section className="grid gap-4 md:grid-cols-2">
+        {domainStructure.map((domain) => <article key={domain.host} className="rounded-3xl border border-white/10 bg-white/[0.055] p-5"><h2 className="break-words text-2xl font-black text-white">{domain.host}</h2><p className="mt-3 text-sm leading-6 text-slate-300">{domain.role}</p></article>)}
+      </section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,8 +14,8 @@ body {
   min-height: 100vh;
   margin: 0;
   background:
-    radial-gradient(circle at 12% 0%, rgba(34, 211, 238, 0.22), transparent 32rem),
-    radial-gradient(circle at 90% 4%, rgba(99, 102, 241, 0.18), transparent 30rem),
+    radial-gradient(circle at 12% 0%, rgba(251, 191, 36, 0.20), transparent 32rem),
+    radial-gradient(circle at 90% 4%, rgba(147, 51, 234, 0.20), transparent 30rem),
     linear-gradient(135deg, #020617 0%, #0f172a 52%, #020617 100%);
   color: #f8fafc;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -40,4 +40,5 @@ a { text-decoration: none; }
 
 @layer utilities {
   .shadow-cyan { box-shadow: 0 18px 60px rgba(34, 211, 238, 0.16); }
+  .shadow-gold { box-shadow: 0 18px 60px rgba(251, 191, 36, 0.18); }
 }

--- a/src/app/identity/page.tsx
+++ b/src/app/identity/page.tsx
@@ -1,5 +1,5 @@
 import { ConsolePage } from '@/components/ConsolePage';
 
 export default function Page() {
-  return <ConsolePage href="/identity">Identity and role assertions remain with the external identity service. ACC reads claims and presents operator context only.</ConsolePage>;
+  return <ConsolePage href="/members">OneGodian identity access is presented through the member gateway and education/community resources on OneGodian.org.</ConsolePage>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,27 +1,26 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AppShell } from '@/components/AppShell';
-import { accPositioning, accRepository } from '@/lib/acc-content';
+import { appPositioning, appRepository } from '@/lib/acc-content';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(accRepository.deployTarget),
+  metadataBase: new URL(appRepository.deployTarget),
   title: {
-    default: accPositioning.name,
-    template: `%s | ${accPositioning.shortName}`
+    default: appPositioning.name,
+    template: `%s | ${appPositioning.shortName}`
   },
-  description: accPositioning.summary,
-  applicationName: accPositioning.name,
+  description: appPositioning.summary,
+  applicationName: appPositioning.name,
   alternates: { canonical: '/' },
   robots: {
-    index: false,
-    follow: false,
-    nocache: true
+    index: true,
+    follow: true
   },
   openGraph: {
-    title: accPositioning.name,
-    description: accPositioning.summary,
-    url: accRepository.deployTarget,
-    siteName: accPositioning.name,
+    title: appPositioning.name,
+    description: appPositioning.summary,
+    url: appRepository.deployTarget,
+    siteName: appPositioning.name,
     type: 'website'
   }
 };

--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -1,0 +1,6 @@
+import Link from 'next/link';
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/learning">Learning connects members and visitors to education, resources, documentation, and community pathways on <Link href="https://onegodian.org" className="font-black text-amber-100">OneGodian.org</Link>.</ConsolePage>;
+}

--- a/src/app/media/page.tsx
+++ b/src/app/media/page.tsx
@@ -1,0 +1,5 @@
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/media">Media includes public education, campaigns, creator updates, community stories, product announcements, and ecosystem access materials.</ConsolePage>;
+}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,0 +1,17 @@
+import { ConsolePage } from '@/components/ConsolePage';
+import { membershipShortcodeMap } from '@/lib/acc-content';
+
+export default function Page() {
+  return (
+    <ConsolePage href="/members">
+      <div className="grid gap-3 md:grid-cols-2">
+        {membershipShortcodeMap.map((item) => (
+          <div key={item.shortcode} className="rounded-2xl border border-white/10 bg-slate-950/35 p-4">
+            <p className="font-black text-white">{item.label}</p>
+            <code className="mt-2 block break-words text-xs text-amber-100">{item.shortcode}</code>
+          </div>
+        ))}
+      </div>
+    </ConsolePage>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,61 +1,67 @@
 import Link from 'next/link';
-import { AuthorityGrid } from '@/components/AuthorityGrid';
 import { ModuleCard } from '@/components/ModuleCard';
-import { accPositioning, accRepository, consoleModules, separationRules } from '@/lib/acc-content';
+import { appPositioning, appRepository, dashboardModules, domainStructure, homepageSections } from '@/lib/acc-content';
 
 export default function HomePage() {
   return (
     <main className="space-y-8">
-      <section className="overflow-hidden rounded-[2.25rem] border border-white/10 bg-white/[0.055] p-6 shadow-2xl shadow-black/20 sm:p-8 lg:p-10">
-        <p className="text-xs font-black uppercase tracking-[0.28em] text-cyan-200">{accPositioning.eyebrow}</p>
-        <h1 className="mt-4 max-w-5xl text-[clamp(3rem,10vw,6.5rem)] font-black leading-[0.9] tracking-[-0.07em] text-white">{accPositioning.name}</h1>
-        <p className="mt-6 max-w-4xl text-xl font-bold leading-9 text-cyan-50 sm:text-2xl">{accPositioning.summary}</p>
-        <p className="mt-4 max-w-4xl text-base leading-8 text-slate-300">{accPositioning.boundary}</p>
+      <section className="overflow-hidden rounded-[2.25rem] border border-amber-200/15 bg-white/[0.055] p-6 shadow-2xl shadow-black/20 backdrop-blur sm:p-8 lg:p-10">
+        <p className="text-xs font-black uppercase tracking-[0.28em] text-amber-200">{appPositioning.eyebrow}</p>
+        <h1 className="mt-4 max-w-5xl text-[clamp(2.6rem,9vw,6.25rem)] font-black leading-[0.92] tracking-[-0.07em] text-white">{appPositioning.shortName}</h1>
+        <p className="mt-6 max-w-4xl text-xl font-bold leading-9 text-amber-50 sm:text-2xl">{appPositioning.summary}</p>
+        <p className="mt-4 max-w-4xl text-base leading-8 text-slate-300">{appPositioning.boundary}</p>
         <div className="mt-8 flex flex-wrap gap-3">
-          <Link href="/dashboard" className="rounded-full border border-cyan-200/60 bg-cyan-200 px-5 py-3 text-sm font-black uppercase tracking-[0.16em] text-slate-950 shadow-cyan transition hover:-translate-y-0.5 hover:bg-cyan-100">Open Dashboard</Link>
-          <Link href="/docs" className="rounded-full border border-white/15 bg-white/[0.06] px-5 py-3 text-sm font-black uppercase tracking-[0.16em] text-white transition hover:-translate-y-0.5 hover:border-cyan-200/40">Read Console Doctrine</Link>
+          <Link href="/dashboard" className="rounded-full border border-amber-200/60 bg-amber-200 px-5 py-3 text-sm font-black uppercase tracking-[0.16em] text-slate-950 shadow-gold transition hover:-translate-y-0.5 hover:bg-amber-100">Open Dashboard</Link>
+          <Link href="/members" className="rounded-full border border-white/15 bg-white/[0.06] px-5 py-3 text-sm font-black uppercase tracking-[0.16em] text-white transition hover:-translate-y-0.5 hover:border-purple-200/40">Membership</Link>
         </div>
       </section>
 
       <section className="grid gap-4 lg:grid-cols-3">
         <article className="rounded-3xl border border-white/10 bg-white/[0.05] p-5">
           <p className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">Repository</p>
-          <p className="mt-3 text-2xl font-black text-white">{accRepository.owner}/{accRepository.name}</p>
-          <p className="mt-2 text-sm text-slate-300">Canonical ACC repository for operator interface code.</p>
+          <p className="mt-3 break-words text-2xl font-black text-white">{appRepository.owner}/{appRepository.name}</p>
+          <p className="mt-2 text-sm text-slate-300">Production deployment repository for the public OneGodian App surface.</p>
         </article>
         <article className="rounded-3xl border border-white/10 bg-white/[0.05] p-5">
           <p className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">Deploy Target</p>
-          <p className="mt-3 text-2xl font-black text-white">{accRepository.canonicalHost}</p>
-          <p className="mt-2 text-sm text-slate-300">Noindex operator deployment at {accRepository.deployTarget}.</p>
+          <p className="mt-3 break-words text-2xl font-black text-white">{appRepository.canonicalHost}</p>
+          <p className="mt-2 text-sm text-slate-300">Public and member-facing gateway at {appRepository.deployTarget}.</p>
         </article>
         <article className="rounded-3xl border border-white/10 bg-white/[0.05] p-5">
-          <p className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">Scope</p>
-          <p className="mt-3 text-2xl font-black text-white">Interface Only</p>
-          <p className="mt-2 text-sm text-slate-300">OSCC, OCP, OEG, identity, registry, and audit retain authority.</p>
+          <p className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">Domain Role</p>
+          <p className="mt-3 text-2xl font-black text-white">Gateway</p>
+          <p className="mt-2 text-sm text-slate-300">Identity and education link to .org; commerce and payments link to .com.</p>
         </article>
       </section>
 
       <section>
         <div className="mb-5 max-w-3xl">
-          <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-200">Operator modules</p>
-          <h2 className="mt-2 text-3xl font-black tracking-[-0.04em] text-white sm:text-4xl">ACC screens and routes</h2>
+          <p className="text-xs font-black uppercase tracking-[0.24em] text-amber-200">App sections</p>
+          <h2 className="mt-2 text-3xl font-black tracking-[-0.04em] text-white sm:text-4xl">Current OneGodian ecosystem access</h2>
         </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{consoleModules.map((module) => <ModuleCard key={module.href} module={module} />)}</div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {homepageSections.map((section) => (
+            <Link key={section.title} href={section.href} className="rounded-3xl border border-white/10 bg-white/[0.05] p-5 transition hover:-translate-y-1 hover:border-amber-300/40">
+              <h3 className="text-xl font-black text-white">{section.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-slate-300">{section.description}</p>
+            </Link>
+          ))}
+        </div>
       </section>
 
-      <section className="space-y-5">
-        <div className="max-w-3xl">
-          <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-200">Authority boundary</p>
-          <h2 className="mt-2 text-3xl font-black tracking-[-0.04em] text-white sm:text-4xl">ACC observes and invokes; external systems authorize.</h2>
+      <section>
+        <div className="mb-5 max-w-3xl">
+          <p className="text-xs font-black uppercase tracking-[0.24em] text-purple-200">Dashboard modules</p>
+          <h2 className="mt-2 text-3xl font-black tracking-[-0.04em] text-white sm:text-4xl">Real module cards and routes</h2>
         </div>
-        <AuthorityGrid />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{dashboardModules.map((module) => <ModuleCard key={module.href} module={module} />)}</div>
       </section>
 
       <section className="rounded-[2rem] border border-amber-300/30 bg-amber-300/10 p-6">
-        <p className="text-xs font-black uppercase tracking-[0.24em] text-amber-100">Repository separation rules</p>
-        <ul className="mt-4 grid gap-3 text-sm font-semibold leading-6 text-amber-50 md:grid-cols-2">
-          {separationRules.map((rule) => <li key={rule}>• {rule}</li>)}
-        </ul>
+        <p className="text-xs font-black uppercase tracking-[0.24em] text-amber-100">Production domain structure</p>
+        <div className="mt-4 grid gap-3 text-sm leading-6 text-amber-50 md:grid-cols-2">
+          {domainStructure.map((domain) => <p key={domain.host}><strong>{domain.host}</strong> — {domain.role}</p>)}
+        </div>
       </section>
     </main>
   );

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,0 +1,6 @@
+import Link from 'next/link';
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/products">Products are discovered in the app and routed to <Link href="https://onegodian.com" className="font-black text-amber-100">OneGodian.com</Link> for commerce, services, and payments.</ConsolePage>;
+}

--- a/src/app/referral-links/page.tsx
+++ b/src/app/referral-links/page.tsx
@@ -1,0 +1,5 @@
+import { ConsolePage } from '@/components/ConsolePage';
+
+export default function Page() {
+  return <ConsolePage href="/referral-links">Referral links are reserved for the WordPress bridge shortcode <code>[onegodian_referral_link]</code>. No payment, commission, or earnings logic is active here.</ConsolePage>;
+}

--- a/src/app/registry/page.tsx
+++ b/src/app/registry/page.tsx
@@ -1,5 +1,5 @@
 import { ConsolePage } from '@/components/ConsolePage';
 
 export default function Page() {
-  return <ConsolePage href="/registry">Registry records are displayed through ACC only when backed by the external registry authority. ACC does not become the source of registry truth.</ConsolePage>;
+  return <ConsolePage href="/registry">Registry references organize identity, member certificates, module records, tools, and ecosystem entries without making the app a payment or securities system.</ConsolePage>;
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,8 +4,9 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      disallow: '/'
+      allow: '/'
     },
-    host: 'https://acc.onegodian.com'
+    host: 'https://app.onegodian.com',
+    sitemap: 'https://app.onegodian.com/sitemap.xml'
   };
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import { ConsolePage } from '@/components/ConsolePage';
 
 export default function Page() {
-  return <ConsolePage href="/settings">Settings are limited to operator interface preferences and environment visibility. Authority-bearing configuration remains in OSCC, OCP, OEG, identity, registry, and audit services.</ConsolePage>;
+  return <ConsolePage href="/settings">Settings provide member-facing app preferences, support routing, account links, and domain guidance across app.onegodian.com, onegodian.org, and onegodian.com.</ConsolePage>;
 }

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,32 +1,32 @@
 import { PageHeader } from '@/components/PageHeader';
-import { accRepository, authorityServices, consoleModules } from '@/lib/acc-content';
+import { appRepository, dashboardModules, domainStructure } from '@/lib/acc-content';
 import { StatusBadge } from '@/components/StatusBadge';
 
 export default function StatusPage() {
   return (
     <main className="space-y-6">
-      <PageHeader eyebrow="ACC Status" title="Operational Status" description="Readiness summary for the canonical ACC operator interface and its external authority bindings." />
+      <PageHeader eyebrow="App Status" title="OneGodian App readiness" description="Readiness summary for the public and member-facing OneGodian App gateway." />
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         <article className="rounded-3xl border border-emerald-300/30 bg-emerald-300/10 p-5">
           <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-100">Deploy target</p>
-          <p className="mt-3 text-2xl font-black text-white">{accRepository.deployTarget}</p>
-          <p className="mt-2 text-sm text-emerald-50/80">Canonical host configured for ACC.</p>
+          <p className="mt-3 break-words text-2xl font-black text-white">{appRepository.deployTarget}</p>
+          <p className="mt-2 text-sm text-emerald-50/80">Canonical host configured for the OneGodian App.</p>
         </article>
-        <article className="rounded-3xl border border-cyan-300/30 bg-cyan-300/10 p-5">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-cyan-100">Modules</p>
-          <p className="mt-3 text-2xl font-black text-white">{consoleModules.length}</p>
-          <p className="mt-2 text-sm text-cyan-50/80">Operator-facing routes available.</p>
+        <article className="rounded-3xl border border-amber-300/30 bg-amber-300/10 p-5">
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-amber-100">Modules</p>
+          <p className="mt-3 text-2xl font-black text-white">{dashboardModules.length}</p>
+          <p className="mt-2 text-sm text-amber-50/80">Public and member-facing routes available.</p>
         </article>
-        <article className="rounded-3xl border border-cyan-300/30 bg-cyan-300/10 p-5">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-cyan-100">Authority services</p>
-          <p className="mt-3 text-2xl font-black text-white">{authorityServices.length}</p>
-          <p className="mt-2 text-sm text-cyan-50/80">External systems retain authority.</p>
+        <article className="rounded-3xl border border-purple-300/30 bg-purple-400/10 p-5">
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-purple-100">Domain roles</p>
+          <p className="mt-3 text-2xl font-black text-white">{domainStructure.length}</p>
+          <p className="mt-2 text-sm text-purple-50/80">Production domain roles documented.</p>
         </article>
       </section>
       <section className="rounded-3xl border border-white/10 bg-white/[0.055] p-5">
         <h2 className="text-2xl font-black text-white">Module readiness</h2>
         <div className="mt-5 grid gap-3">
-          {consoleModules.map((module) => (
+          {dashboardModules.map((module) => (
             <div key={module.href} className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-slate-950/40 p-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="font-black text-white">{module.title}</p>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,12 @@
+import { ConsolePage } from '@/components/ConsolePage';
+import { tools } from '@/lib/acc-content';
+
+export default function Page() {
+  return (
+    <ConsolePage href="/tools">
+      <div className="grid gap-3">
+        {tools.map((tool) => <div key={tool.name} className="rounded-2xl border border-white/10 bg-slate-950/35 p-4"><p className="font-black text-white">{tool.name}</p><p className="mt-1 text-slate-300">{tool.description}</p></div>)}
+      </div>
+    </ConsolePage>
+  );
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,33 +1,32 @@
 import Link from 'next/link';
-import { accPositioning, accRepository, consoleModules } from '@/lib/acc-content';
+import { appPositioning, appRepository, dashboardModules } from '@/lib/acc-content';
 
 const nav = [
   { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Agents', href: '/agents' },
-  { label: 'Tasks', href: '/tasks' },
-  { label: 'Workflows', href: '/workflows' },
-  { label: 'Approvals', href: '/approvals' },
-  { label: 'Audit', href: '/audit' },
-  { label: 'Status', href: '/status' },
-  { label: 'Docs', href: '/docs' }
+  { label: 'Members', href: '/members' },
+  { label: 'Contributors', href: '/contributors' },
+  { label: 'Creators', href: '/creator-network' },
+  { label: 'Products', href: '/products' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Ecosystem', href: '/ecosystem' }
 ];
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <body>
-      <header className="sticky top-0 z-50 border-b border-white/10 bg-slate-950/85 backdrop-blur-2xl">
+      <header className="sticky top-0 z-50 border-b border-amber-200/10 bg-slate-950/85 backdrop-blur-2xl">
         <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-            <Link href="/" className="flex items-center gap-3">
-              <span className="grid h-11 w-11 place-items-center rounded-2xl border border-cyan-200/40 bg-cyan-200/10 text-sm font-black text-cyan-100 shadow-cyan">ACC</span>
-              <span>
-                <span className="block text-sm font-black uppercase tracking-[0.22em] text-cyan-100">{accPositioning.shortName}</span>
-                <span className="block text-xs font-semibold text-slate-400">{accRepository.deployTarget}</span>
+            <Link href="/" className="flex min-w-0 items-center gap-3">
+              <span className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-amber-200/50 bg-amber-200/10 text-sm font-black text-amber-100 shadow-gold">OG</span>
+              <span className="min-w-0">
+                <span className="block text-sm font-black uppercase tracking-[0.22em] text-amber-100">{appPositioning.shortName}</span>
+                <span className="block truncate text-xs font-semibold text-slate-400">{appRepository.canonicalHost}</span>
               </span>
             </Link>
-            <nav aria-label="ACC primary" className="flex flex-wrap gap-2">
+            <nav className="flex gap-2 overflow-x-auto pb-1 lg:flex-wrap lg:justify-end lg:overflow-visible">
               {nav.map((item) => (
-                <Link key={item.href} href={item.href} className="rounded-full border border-white/10 px-3 py-2 text-xs font-bold uppercase tracking-[0.12em] text-slate-200 transition hover:border-cyan-300/40 hover:bg-cyan-300/10 hover:text-white">
+                <Link key={item.href} href={item.href} className="shrink-0 rounded-full border border-white/10 bg-white/[0.045] px-4 py-2 text-xs font-bold uppercase tracking-[0.12em] text-slate-200 transition hover:border-amber-300/40 hover:bg-amber-300/10 hover:text-white">
                   {item.label}
                 </Link>
               ))}
@@ -38,8 +37,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <div className="mx-auto min-h-screen max-w-7xl px-4 py-8 sm:px-6 lg:px-8">{children}</div>
       <footer className="border-t border-white/10 px-4 py-8 text-sm text-slate-400 sm:px-6 lg:px-8">
         <div className="mx-auto grid max-w-7xl gap-4 md:grid-cols-[1fr_auto] md:items-center">
-          <p>{accPositioning.boundary}</p>
-          <p className="font-bold text-slate-300">{consoleModules.length} operator modules · no public/member surface</p>
+          <p>{appPositioning.boundary}</p>
+          <p className="font-bold text-slate-300">{dashboardModules.length} member modules · public gateway</p>
         </div>
       </footer>
     </body>

--- a/src/components/ConsolePage.tsx
+++ b/src/components/ConsolePage.tsx
@@ -1,50 +1,59 @@
-import { AuthorityGrid } from '@/components/AuthorityGrid';
+import Link from 'next/link';
 import { PageHeader } from '@/components/PageHeader';
 import { StatusBadge } from '@/components/StatusBadge';
-import { accPositioning, consoleModules } from '@/lib/acc-content';
+import { appPositioning, dashboardModules, pluginShortcodes } from '@/lib/acc-content';
 
 const fallback = {
-  title: 'ACC Module',
+  title: 'OneGodian App Module',
   href: '/',
-  status: 'planned' as const,
-  description: 'Operator module reserved for canonical ACC coverage.'
+  status: 'coming-soon' as const,
+  description: 'Member-facing module reserved for the OneGodian App gateway.'
 };
 
 export function ConsolePage({ href, children }: { href: string; children?: React.ReactNode }) {
-  const consoleModule = consoleModules.find((item) => item.href === href) ?? fallback;
+  const appModule = dashboardModules.find((item) => item.href === href) ?? fallback;
 
   return (
     <main className="space-y-6">
-      <PageHeader eyebrow="ACC Operator Route" title={consoleModule.title} description={consoleModule.description} />
+      <PageHeader eyebrow="OneGodian App Route" title={appModule.title} description={appModule.description} />
       <section className="grid gap-4 lg:grid-cols-[0.72fr_1.28fr]">
         <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-5">
-          <div className="flex items-start justify-between gap-3">
-            <h2 className="text-2xl font-black text-white">Route posture</h2>
-            <StatusBadge status={consoleModule.status} />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <h2 className="text-2xl font-black text-white">Route details</h2>
+            <StatusBadge status={appModule.status} />
           </div>
           <dl className="mt-5 space-y-4 text-sm">
             <div>
               <dt className="font-black uppercase tracking-[0.16em] text-slate-400">Route</dt>
-              <dd className="mt-1 font-semibold text-slate-100">{consoleModule.href}</dd>
+              <dd className="mt-1 font-semibold text-slate-100">{appModule.href}</dd>
             </div>
             <div>
               <dt className="font-black uppercase tracking-[0.16em] text-slate-400">Scope</dt>
-              <dd className="mt-1 leading-6 text-slate-300">Operator-facing interface only; no public/member-facing workflow lives here.</dd>
+              <dd className="mt-1 leading-6 text-slate-300">Public and member-facing gateway for the OneGodian ecosystem.</dd>
             </div>
             <div>
-              <dt className="font-black uppercase tracking-[0.16em] text-slate-400">Authority</dt>
-              <dd className="mt-1 leading-6 text-slate-300">{accPositioning.boundary}</dd>
+              <dt className="font-black uppercase tracking-[0.16em] text-slate-400">Domain separation</dt>
+              <dd className="mt-1 leading-6 text-slate-300">{appPositioning.boundary}</dd>
             </div>
           </dl>
         </article>
         <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-5">
-          <h2 className="text-2xl font-black text-white">Operator notes</h2>
+          <h2 className="text-2xl font-black text-white">Module content</h2>
           <div className="mt-4 text-sm leading-7 text-slate-300">
-            {children ?? <p>This canonical screen is ready for live bindings to OSCC, OCP, OEG, identity, registry, and audit APIs.</p>}
+            {children ?? <p>This module is ready for live app content, WordPress plugin bridge references, and ecosystem links.</p>}
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Link href="/dashboard" className="rounded-full border border-amber-200/50 px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-amber-100">Dashboard</Link>
+            <Link href="/ecosystem" className="rounded-full border border-purple-300/40 px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-purple-100">Ecosystem</Link>
           </div>
         </article>
       </section>
-      <AuthorityGrid />
+      <section className="rounded-3xl border border-purple-300/25 bg-purple-400/10 p-5">
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-purple-100">WordPress plugin bridge</p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {pluginShortcodes.map((shortcode) => <code key={shortcode} className="rounded-full border border-white/10 bg-slate-950/40 px-3 py-2 text-xs text-slate-200">{shortcode}</code>)}
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -1,18 +1,20 @@
 import Link from 'next/link';
 import { StatusBadge } from '@/components/StatusBadge';
-import type { consoleModules } from '@/lib/acc-content';
+import type { dashboardModules } from '@/lib/acc-content';
 
-type Module = (typeof consoleModules)[number];
+type Module = (typeof dashboardModules)[number];
 
 export function ModuleCard({ module }: { module: Module }) {
   return (
-    <Link href={module.href} className="group block rounded-3xl border border-white/10 bg-white/[0.055] p-5 shadow-2xl shadow-black/20 transition hover:-translate-y-1 hover:border-cyan-300/45 hover:bg-white/[0.08]">
+    <article className="group flex h-full flex-col rounded-3xl border border-white/10 bg-white/[0.055] p-5 shadow-2xl shadow-black/20 backdrop-blur transition hover:-translate-y-1 hover:border-amber-300/45 hover:bg-white/[0.08]">
       <div className="flex items-start justify-between gap-3">
         <h3 className="text-xl font-black tracking-tight text-white">{module.title}</h3>
         <StatusBadge status={module.status} />
       </div>
-      <p className="mt-4 text-sm leading-6 text-slate-300">{module.description}</p>
-      <p className="mt-5 text-xs font-black uppercase tracking-[0.18em] text-cyan-200 group-hover:text-cyan-100">Open module →</p>
-    </Link>
+      <p className="mt-4 flex-1 text-sm leading-6 text-slate-300">{module.description}</p>
+      <Link href={module.href} className="mt-5 inline-flex w-fit rounded-full border border-amber-200/50 bg-amber-200 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-slate-950 transition hover:-translate-y-0.5 hover:bg-amber-100">
+        Open
+      </Link>
+    </article>
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,8 +1,8 @@
 export function PageHeader({ eyebrow, title, description }: { eyebrow: string; title: string; description: string }) {
   return (
-    <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 shadow-2xl shadow-black/20 sm:p-8">
-      <p className="text-xs font-black uppercase tracking-[0.24em] text-cyan-200">{eyebrow}</p>
-      <h1 className="mt-3 text-4xl font-black tracking-[-0.05em] text-white sm:text-5xl">{title}</h1>
+    <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 shadow-2xl shadow-black/20 backdrop-blur sm:p-8">
+      <p className="text-xs font-black uppercase tracking-[0.24em] text-amber-200">{eyebrow}</p>
+      <h1 className="mt-3 break-words text-4xl font-black tracking-[-0.05em] text-white sm:text-5xl">{title}</h1>
       <p className="mt-4 max-w-4xl text-base leading-8 text-slate-300 sm:text-lg">{description}</p>
     </section>
   );

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,19 +1,19 @@
-import type { AccStatus } from '@/lib/acc-content';
+import type { AppStatus } from '@/lib/acc-content';
 
-const labels: Record<AccStatus, string> = {
+const labels: Record<AppStatus, string> = {
   live: 'Live',
-  'external-authority': 'External Authority',
-  watch: 'Watch',
-  planned: 'Planned'
+  available: 'Available',
+  'plugin-bridge': 'Plugin Bridge',
+  'coming-soon': 'Coming Soon'
 };
 
-const classes: Record<AccStatus, string> = {
+const classes: Record<AppStatus, string> = {
   live: 'border-emerald-300/40 bg-emerald-300/10 text-emerald-100',
-  'external-authority': 'border-cyan-300/40 bg-cyan-300/10 text-cyan-100',
-  watch: 'border-amber-300/40 bg-amber-300/10 text-amber-100',
-  planned: 'border-slate-300/30 bg-slate-300/10 text-slate-200'
+  available: 'border-amber-300/50 bg-amber-300/10 text-amber-100',
+  'plugin-bridge': 'border-purple-300/45 bg-purple-400/10 text-purple-100',
+  'coming-soon': 'border-slate-300/30 bg-slate-300/10 text-slate-200'
 };
 
-export function StatusBadge({ status }: { status: AccStatus }) {
-  return <span className={`rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] ${classes[status]}`}>{labels[status]}</span>;
+export function StatusBadge({ status }: { status: AppStatus }) {
+  return <span className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] ${classes[status]}`}>{labels[status]}</span>;
 }

--- a/src/lib/acc-content.ts
+++ b/src/lib/acc-content.ts
@@ -1,130 +1,126 @@
-export type AccStatus = 'live' | 'external-authority' | 'watch' | 'planned';
+export type AppStatus = 'live' | 'available' | 'plugin-bridge' | 'coming-soon';
+export type AccStatus = AppStatus;
 
-export const accRepository = {
+export const appRepository = {
   owner: 'ohi-stack',
-  name: 'acc',
-  url: 'https://github.com/ohi-stack/acc',
-  deployTarget: 'https://acc.onegodian.com',
-  canonicalHost: 'acc.onegodian.com'
+  name: 'onegodian-app-deploy',
+  url: 'https://github.com/ohi-stack/onegodian-app-deploy',
+  deployTarget: 'https://app.onegodian.com',
+  canonicalHost: 'app.onegodian.com'
 };
 
-export const accPositioning = {
-  name: 'ACC™ Agent Command Console',
-  shortName: 'ACC™',
-  eyebrow: 'OPERATOR-FACING COMMAND CONSOLE',
+export const domainStructure = [
+  { host: 'app.onegodian.com', role: 'Public/member-facing gateway for identity, education, membership, tools, certificates, products, media, and ecosystem access.' },
+  { host: 'console.onegodian.com', role: 'Operator/admin runtime surface.' },
+  { host: 'capital.onegodian.com', role: 'Capital operations.' },
+  { host: 'onegodian.org', role: 'Identity, education, community, and documentation.' },
+  { host: 'onegodian.com', role: 'Commerce, products, services, and payments.' }
+];
+
+export const appPositioning = {
+  name: 'OneGodian App',
+  shortName: 'OneGodian App™',
+  version: '1.1.0',
+  eyebrow: 'PUBLIC & MEMBER-FACING GATEWAY',
   summary:
-    'ACC™ is the dedicated operator interface for observing agents, coordinating workflows, opening approvals, and viewing operational telemetry across OneGodian systems.',
+    'The OneGodian App™ — the public and member-facing gateway for OneGodian identity, education, membership, tools, certificates, products, media, and ecosystem access.',
   boundary:
-    'ACC is an interface only. Authority remains with OSCC, OCP, OEG, identity, registry, and audit services. ACC does not self-authorize agents, mint identity, write registry truth, or replace audit systems.'
+    'The app presents public and member-facing experiences. It links to OneGodian.org for identity, education, community, and documentation, and to OneGodian.com for commerce, products, services, and payments. Contributions are not processed directly in this app unless a payment backend is connected.'
 };
 
-export const authorityServices = [
-  {
-    key: 'oscc',
-    name: 'OSCC',
-    role: 'Source-of-control coordination and command authority.',
-    ownership: 'external-authority' as AccStatus
-  },
-  {
-    key: 'ocp',
-    name: 'OCP',
-    role: 'Policy authorization, privileged-action decisions, and approval gates.',
-    ownership: 'external-authority' as AccStatus
-  },
-  {
-    key: 'oeg',
-    name: 'OEG',
-    role: 'Execution gateway for authorized operational tasks and routes.',
-    ownership: 'external-authority' as AccStatus
-  },
-  {
-    key: 'identity',
-    name: 'Identity Service',
-    role: 'Operator identity, roles, sessions, and access claims.',
-    ownership: 'external-authority' as AccStatus
-  },
-  {
-    key: 'registry',
-    name: 'Registry Service',
-    role: 'Canonical records, entity references, agent registrations, and route metadata.',
-    ownership: 'external-authority' as AccStatus
-  },
-  {
-    key: 'audit',
-    name: 'Audit Service',
-    role: 'Immutable evidence, event trails, decision logs, and compliance records.',
-    ownership: 'external-authority' as AccStatus
-  }
+export const pluginShortcodes = [
+  '[onegodian_membership_cta]',
+  '[onegodian_members_pricing]',
+  '[onegodian_membership_resources]',
+  '[onegodian_member_certificates]',
+  '[onegodian_member_dashboard]',
+  '[onegodian_member_support]',
+  '[onegodian_contributors_page]',
+  '[onegodian_contributor_tiers]',
+  '[onegodian_creator_network]',
+  '[onegodian_affiliate_dashboard]',
+  '[onegodian_referral_link]',
+  '[onegodian_contributor_wall]',
+  '[onegodian_contributor_disclaimer]'
 ];
 
-export const consoleModules = [
-  {
-    title: 'Operator Dashboard',
-    href: '/dashboard',
-    status: 'live' as AccStatus,
-    description: 'At-a-glance operational posture, pending approvals, agent health, route readiness, and external authority status.'
-  },
-  {
-    title: 'Agents',
-    href: '/agents',
-    status: 'live' as AccStatus,
-    description: 'Operator registry view for agent records, health states, assigned capabilities, and control-plane bindings.'
-  },
-  {
-    title: 'Tasks',
-    href: '/tasks',
-    status: 'live' as AccStatus,
-    description: 'Queue-facing task triage for work items awaiting authorization, assignment, execution, verification, or audit closeout.'
-  },
-  {
-    title: 'Workflows',
-    href: '/workflows',
-    status: 'watch' as AccStatus,
-    description: 'Workflow run visibility, policy checkpoints, delegated steps, and handoffs between OSCC, OCP, and OEG.'
-  },
-  {
-    title: 'OCP Decisions',
-    href: '/ocp',
-    status: 'external-authority' as AccStatus,
-    description: 'Read-only policy and decision surface. OCP remains the authoritative system for approvals.'
-  },
-  {
-    title: 'OEG Routes',
-    href: '/oeg',
-    status: 'external-authority' as AccStatus,
-    description: 'Execution gateway route state, enabled tools, and authorized command paths. OEG remains the execution authority.'
-  },
-  {
-    title: 'Adapters',
-    href: '/adapters',
-    status: 'watch' as AccStatus,
-    description: 'Connector readiness for supported services without merging ACC into any downstream application or plugin repository.'
-  },
-  {
-    title: 'Approvals',
-    href: '/approvals',
-    status: 'live' as AccStatus,
-    description: 'Human operator review queues for privileged actions, policy exceptions, and deployment gates.'
-  },
-  {
-    title: 'Audit',
-    href: '/audit',
-    status: 'external-authority' as AccStatus,
-    description: 'Evidence and event viewer backed by the external audit service; ACC never becomes the audit source of truth.'
-  },
-  {
-    title: 'Deployments',
-    href: '/deployments',
-    status: 'live' as AccStatus,
-    description: 'Deployment posture for acc.onegodian.com, release markers, environment checks, and repository separation.'
-  }
+export const homepageSections = [
+  { title: 'OneGodian Identity', href: '/members', description: 'Member identity entry points, certificates, resources, and ecosystem access aligned with OneGodian.org.' },
+  { title: 'Membership', href: '/members', description: 'Membership calls to action, pricing references, member resources, dashboard access, certificates, and support.' },
+  { title: 'Contributors', href: '/contributors', description: 'Voluntary public support for products, education, media, technology, membership, and community infrastructure.' },
+  { title: 'Creator Network', href: '/creator-network', description: 'A home for creators, affiliates, educators, and community voices who share OneGodian resources and campaigns.' },
+  { title: 'Affiliate Program', href: '/affiliate-dashboard', description: 'Application-aware affiliate structure with referral links, campaign assets, updates, and compliance notices.' },
+  { title: 'Certificates', href: '/certificates', description: 'Member certificate references and recognition pathways connected to the plugin bridge.' },
+  { title: 'Products', href: '/products', description: 'Product discovery and commerce pathways that keep purchases on OneGodian.com.' },
+  { title: 'Media', href: '/media', description: 'Public videos, updates, education media, campaigns, and creator-ready materials.' },
+  { title: 'Tools', href: '/tools', description: 'Member and public utilities, resource links, and operational helpers exposed through the app surface.' },
+  { title: 'Education', href: '/learning', description: 'Learning paths, community education, resources, and documentation linked to OneGodian.org.' },
+  { title: 'Ecosystem', href: '/ecosystem', description: 'A domain-aware map of OneGodian public, commerce, operator, capital, and community surfaces.' }
 ];
 
+export const dashboardModules = [
+  { title: 'Members', href: '/members', status: 'plugin-bridge' as AppStatus, description: 'Membership CTA, pricing references, resources, certificates, member dashboard, and support entry points.' },
+  { title: 'Contributors', href: '/contributors', status: 'available' as AppStatus, description: 'Voluntary support tiers and contributor information for public-facing OneGodian infrastructure.' },
+  { title: 'Creator Network', href: '/creator-network', status: 'available' as AppStatus, description: 'Application gateway for creators, affiliates, educators, and community voices.' },
+  { title: 'Affiliate Dashboard', href: '/affiliate-dashboard', status: 'coming-soon' as AppStatus, description: 'Structured affiliate workspace for referral links, campaign assets, updates, notices, and application status.' },
+  { title: 'Referral Links', href: '/referral-links', status: 'coming-soon' as AppStatus, description: 'Reserved referral-link workspace connected to the WordPress plugin bridge; no earnings logic is active here.' },
+  { title: 'Contributor Wall', href: '/contributor-wall', status: 'plugin-bridge' as AppStatus, description: 'Recognition surface for contributor acknowledgements when published by the plugin bridge.' },
+  { title: 'Certificates', href: '/certificates', status: 'plugin-bridge' as AppStatus, description: 'Member certificate access and verification references powered by current membership shortcode work.' },
+  { title: 'Products', href: '/products', status: 'available' as AppStatus, description: 'Product discovery with commerce and payment paths kept on OneGodian.com.' },
+  { title: 'Media', href: '/media', status: 'available' as AppStatus, description: 'Media hub for education, campaigns, creator updates, community stories, and ecosystem announcements.' },
+  { title: 'Learning', href: '/learning', status: 'available' as AppStatus, description: 'Education resources, learning paths, documentation, and community links aligned with OneGodian.org.' },
+  { title: 'Registry', href: '/registry', status: 'available' as AppStatus, description: 'Public registry references for identity, certificates, modules, tools, and ecosystem records.' },
+  { title: 'Tools', href: '/tools', status: 'live' as AppStatus, description: 'Member and public utility catalog returned by the app tools API and exposed through this gateway.' },
+  { title: 'Settings', href: '/settings', status: 'live' as AppStatus, description: 'Member-facing app preferences, account links, domain guidance, and support routing.' }
+];
+
+export const contributorTiers = [
+  { name: 'Supporter', amount: '$11' },
+  { name: 'Builder', amount: '$33' },
+  { name: 'Sustainer', amount: '$77' },
+  { name: 'Founder Circle', amount: '$111' },
+  { name: 'Infrastructure Partner', amount: '$333+' },
+  { name: 'Custom Contribution', amount: 'Any amount' }
+];
+
+export const contributorNotice = 'Contributions are voluntary support payments. They are not equity, securities, loans, bonds, investment contracts, or promises of financial return.';
+
+export const membershipShortcodeMap = [
+  { label: 'Membership CTA', shortcode: '[onegodian_membership_cta]' },
+  { label: 'Membership Pricing', shortcode: '[onegodian_members_pricing]' },
+  { label: 'Membership Resources', shortcode: '[onegodian_membership_resources]' },
+  { label: 'Member Certificates', shortcode: '[onegodian_member_certificates]' },
+  { label: 'Member Dashboard', shortcode: '[onegodian_member_dashboard]' },
+  { label: 'Member Support', shortcode: '[onegodian_member_support]' }
+];
+
+export const affiliateDashboardItems = [
+  'Referral Link',
+  'Campaign Assets',
+  'Contributor Products',
+  'Creator Updates',
+  'Compliance Notice',
+  'Application Status'
+];
+
+export const tools = [
+  { name: 'Membership Bridge', href: '/members', description: 'Connects app visitors to membership CTA, pricing, resources, certificates, dashboard, and support.' },
+  { name: 'Contributor Tiers', href: '/contributors', description: 'Displays voluntary support tiers and the required non-investment contributor notice.' },
+  { name: 'Creator Network Application', href: '/creator-network', description: 'Routes creators, affiliates, educators, and community voices toward the Creator Network application.' },
+  { name: 'Affiliate Structure', href: '/affiliate-dashboard', description: 'Shows referral, campaign, product, update, compliance, and application-status sections without payment logic.' },
+  { name: 'Ecosystem Map', href: '/ecosystem', description: 'Clarifies the production roles for app, console, capital, .org, and .com domains.' }
+];
+
+// Backwards-compatible names used by existing components/pages during the app transition.
+export const accRepository = appRepository;
+export const accPositioning = appPositioning;
+export const consoleModules = dashboardModules;
+export const authorityServices = domainStructure.map((item) => ({ key: item.host, name: item.host, role: item.role, ownership: 'available' as AppStatus }));
 export const separationRules = [
-  'Do not merge ACC into QRV repositories.',
-  'Do not merge ACC into the OneGodian App repository.',
-  'Do not merge ACC into Capital repositories.',
-  'Do not merge ACC into OMOS repositories.',
-  'Do not merge ACC into WordPress plugin repositories.',
-  'Keep ACC operator-facing, noindex, and separate from public/member-facing products.'
+  'Use app.onegodian.com for public and member-facing access.',
+  'Use console.onegodian.com for operator and admin runtime work.',
+  'Use capital.onegodian.com for capital operations.',
+  'Use OneGodian.org for identity, education, community, and documentation.',
+  'Use OneGodian.com for commerce, products, services, and payments.',
+  'Keep contributor language voluntary, non-investment, and non-securities.'
 ];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,32 +1,40 @@
 import { NextResponse } from 'next/server';
-import { accPositioning, accRepository, authorityServices, consoleModules } from '@/lib/acc-content';
+import { appPositioning, appRepository, dashboardModules, domainStructure, pluginShortcodes, tools } from '@/lib/acc-content';
 
-export function accJson(body: Record<string, unknown>, init?: ResponseInit) {
+export function appJson(body: Record<string, unknown>, init?: ResponseInit) {
   const response = NextResponse.json(
     {
-      service: accPositioning.name,
-      repository: `${accRepository.owner}/${accRepository.name}`,
-      deployTarget: accRepository.deployTarget,
-      authorityBoundary: accPositioning.boundary,
+      service: appPositioning.name,
+      repository: `${appRepository.owner}/${appRepository.name}`,
+      deployTarget: appRepository.deployTarget,
+      domainRole: 'public/member-facing app gateway',
       ...body
     },
     init
   );
   response.headers.set('Cache-Control', 'no-store');
-  response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
-  response.headers.set('x-onegodian-surface', 'acc');
+  response.headers.set('x-onegodian-surface', 'app');
   return response;
 }
 
+export const accJson = appJson;
+
 export function manifestPayload() {
   return {
-    name: accPositioning.name,
-    shortName: accPositioning.shortName,
-    url: accRepository.deployTarget,
-    repository: accRepository.url,
-    interfaceOnly: true,
-    noPublicSignup: true,
-    modules: consoleModules,
-    authorities: authorityServices
+    name: appPositioning.name,
+    appName: 'OneGodian App',
+    shortName: appPositioning.shortName,
+    version: appPositioning.version,
+    url: appRepository.deployTarget,
+    repository: appRepository.url,
+    domainRole: 'public/member-facing app gateway',
+    modules: dashboardModules,
+    routes: ['/', ...dashboardModules.map((module) => module.href), '/ecosystem'],
+    wordpressPluginBridgeShortcodes: pluginShortcodes,
+    domains: domainStructure
   };
+}
+
+export function toolsPayload() {
+  return { tools };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,34 +1,22 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const PUBLIC_API_PATHS = new Set(['/api/health', '/api/manifest', '/api/readiness', '/api/version']);
+const PUBLIC_API_PATHS = new Set(['/api/health', '/api/manifest', '/api/readiness', '/api/version', '/api/tools', '/api/stats']);
 
-function roleForRequest(req: NextRequest): 'member' | 'operator' | 'admin' {
-  const role = req.headers.get('x-onegodian-role') || req.cookies.get('onegodian_role')?.value || 'member';
-  return role === 'admin' || role === 'operator' ? role : 'member';
-}
-
-function withAccHeaders(response: NextResponse) {
-  response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
-  response.headers.set('x-onegodian-surface', 'acc');
-  response.headers.set('x-acc-authority', 'interface-only');
+function withAppHeaders(response: NextResponse) {
+  response.headers.set('x-onegodian-surface', 'app');
+  response.headers.set('x-onegodian-domain-role', 'public-member-facing-gateway');
   return response;
 }
 
 export function middleware(req: NextRequest) {
   const path = req.nextUrl.pathname;
-  const role = roleForRequest(req);
 
-  if (PUBLIC_API_PATHS.has(path)) {
-    return withAccHeaders(NextResponse.next());
+  if (PUBLIC_API_PATHS.has(path) || !path.startsWith('/api/')) {
+    return withAppHeaders(NextResponse.next());
   }
 
-  if (path.startsWith('/api/') && role !== 'operator' && role !== 'admin') {
-    return withAccHeaders(NextResponse.json({ error: 'operator_or_admin_required' }, { status: 403 }));
-  }
-
-  const response = NextResponse.next();
-  return withAccHeaders(response);
+  return withAppHeaders(NextResponse.json({ error: 'api_route_not_public', surface: 'app.onegodian.com' }, { status: 404 }));
 }
 
 export const config = { matcher: ['/((?!_next|favicon.ico).*)'] };


### PR DESCRIPTION
### Motivation
- Replace placeholder/operator-facing ACC content with a production-facing OneGodian App surface for `app.onegodian.com` that reflects the real ecosystem and domain separation rules.
- Surface membership, contributors, creator network, affiliate, certificates, products, media, tools, learning, registry, and settings pages and provide WordPress plugin bridge shortcodes for the plugin integration work.
- Expose simple public JSON endpoints for health, manifest, tools, and stats so the app can be discovered and integrated programmatically.
- Apply production OneGodian styling (dark navy, gold accents, purple highlights, rounded glass cards) and mobile-first layout adjustments for the public/member surface.

### Description
- Reworked application positioning and content in `src/lib/acc-content.ts` by introducing `appPositioning`, `dashboardModules`, `homepageSections`, `pluginShortcodes`, contributor tiers, membership shortcode map, tool registry, and domain structure used across the app.
- Reworked UI components and shell to the OneGodian App branding via `src/components/AppShell.tsx`, `src/components/PageHeader.tsx`, `src/components/ModuleCard.tsx`, `src/components/ConsolePage.tsx`, and `src/components/StatusBadge.tsx` with updated visuals and module card controls (title, description, status badge, and `Open` route links).
- Added member/public pages and routes under `src/app/` for `/`, `/dashboard`, `/members`, `/contributors`, `/creator-network`, `/affiliate-dashboard`, `/referral-links`, `/contributor-wall`, `/certificates`, `/products`, `/media`, `/learning`, `/registry`, `/tools`, `/settings`, and `/ecosystem` with the requested content and CTAs.
- Implemented public JSON endpoints and payloads: `/api/health`, `/api/manifest`, `/api/tools`, and `/api/stats` (server helpers in `src/lib/api.ts` produce the manifest including `wordpressPluginBridgeShortcodes`, `modules`, `routes`, and `domains`).
- Updated middleware `src/middleware.ts` to mark the site as the app surface and expose public API paths, and updated metadata/robots/PWA manifest/sitemap and `package.json` to target `onegodian-app-deploy` / `https://app.onegodian.com`.

### Testing
- Ran `npm install` successfully to ensure dependencies are present. (success)
- Ran `npm run lint` with `next lint` and observed no ESLint warnings or errors. (success)
- Ran `npm run build` with `next build` and observed a successful optimized production build and static page generation. (success)
- Started the server with `npm run start` and validated the public endpoints with `curl` against `/api/health`, `/api/manifest`, `/api/tools`, and `/api/stats`, each returning JSON that included the expected keys such as `service`, `domainRole`/`domainRole`, and `manifest`/`tools`/`stats`. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29b495400c832db976d717cf5141cf)