### PR TITLE
Add ARE plugin consolidation validation report

### DIFF
--- a/algonquian-real-estate/docs/PLUGIN-CONSOLIDATION-VALIDATION.md
+++ b/algonquian-real-estate/docs/PLUGIN-CONSOLIDATION-VALIDATION.md
@@ -1,0 +1,54 @@
+# ARE Plugin Consolidation Validation Report
+
+Task title: Consolidate ARE plugin packages into main platform repo
+
+## Result
+
+Plugin consolidation did not proceed because no required plugin source folders or plugin archives were available in the Codex workspace.
+
+Per task instructions, this report records the validation result and avoids fabricating missing plugin source code.
+
+## Workspace checks performed
+
+- Checked for existing plugin source folders under `algonquian-real-estate/plugins/`.
+- Checked the workspace for available archive files that could contain plugin source, including `.zip`, `.tar.gz`, and `.tgz` files.
+- Checked the workspace for paths matching the expected `algq-*` plugin package names.
+
+## Missing plugin packages
+
+The following 12 plugin packages are missing and were not created:
+
+1. `algq-command-center`
+2. `algq-automation-engine`
+3. `algq-buyer-portal`
+4. `algq-deal-intake`
+5. `algq-deal-marketplace`
+6. `algq-digital-products`
+7. `algq-digital-store`
+8. `algq-document-library`
+9. `algq-funding-tracker`
+10. `algq-mao-engine`
+11. `algq-pipeline-crm`
+12. `algq-woocommerce-bridge`
+
+## Expected destination after source is provided
+
+```text
+algonquian-real-estate/plugins/
+├── algq-command-center/
+├── algq-automation-engine/
+├── algq-buyer-portal/
+├── algq-deal-intake/
+├── algq-deal-marketplace/
+├── algq-digital-products/
+├── algq-digital-store/
+├── algq-document-library/
+├── algq-funding-tracker/
+├── algq-mao-engine/
+├── algq-pipeline-crm/
+└── algq-woocommerce-bridge/
+```
+
+## Next step
+
+Provide the actual plugin source folders or archives in the Codex workspace, then rerun consolidation. Existing source folders should be updated in place rather than duplicated.


### PR DESCRIPTION
### Motivation
- Record the outcome of an attempted consolidation of Algonquian Real Estate (ARE) WordPress plugin packages into the main platform repo when source artifacts are not present. 

### Description
- Add `algonquian-real-estate/docs/PLUGIN-CONSOLIDATION-VALIDATION.md` which documents workspace checks, lists the 12 missing `algq-*` plugin packages, preserves the expected destination tree, and instructs the next steps without fabricating source. 

### Testing
- Ran `npm test -- --runInBand` (which runs `tsc --noEmit` and `next lint`) and the test/lint step completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d71c47ba4832dbd1147fba9a98352)