### PR TITLE
Fix OTS day-order alignment and add OneGodian calendar UI

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { OneGodianCalendar } from '@/components/OneGodianCalendar';
+
+export const metadata: Metadata = {
+  title: 'OneGodian Calendar',
+  description: 'OTS-V5 calendar reference with epoch-based day order labels.'
+};
+
+export default function Page() {
+  return (
+    <main className="space-y-8">
+      <h1 className="text-5xl font-black text-white">OneGodian Calendar</h1>
+      <OneGodianCalendar />
+    </main>
+  );
+}

--- a/src/components/OneGodianCalendar.tsx
+++ b/src/components/OneGodianCalendar.tsx
@@ -1,0 +1,50 @@
+import { getCivilMonthDates, getOTDate } from '@/lib/ots-calendar';
+
+const civilWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export function OneGodianCalendar() {
+  const today = new Date();
+  const year = today.getUTCFullYear();
+  const monthIndex = today.getUTCMonth();
+  const monthLabel = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(today);
+  const dates = getCivilMonthDates(year, monthIndex);
+
+  return (
+    <section className="rounded-[2rem] border border-[#D8B35A]/30 bg-white/[0.055] p-6 shadow-gold">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.24em] text-[#F0D98A]">OTS-V5 Calendar</p>
+          <h2 className="mt-2 text-3xl font-black text-white">{monthLabel}</h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          Gregorian civil layout is preserved for public date reference; each cell is labeled with its OTS date and epoch-based day order.
+        </p>
+      </div>
+
+      <div className="mt-6 grid grid-cols-7 gap-2 text-center text-xs font-black uppercase tracking-[0.16em] text-slate-400">
+        {civilWeekdays.map((weekday) => <div key={weekday}>{weekday}</div>)}
+      </div>
+
+      <div className="mt-2 grid grid-cols-7 gap-2">
+        {dates.map((date, index) => {
+          if (!date) return <div key={`empty-${index}`} className="min-h-28 rounded-2xl border border-white/5 bg-black/20" />;
+
+          const ot = getOTDate(date);
+
+          return (
+            <article key={date.toISOString()} className="min-h-28 rounded-2xl border border-white/10 bg-slate-950/45 p-3 text-left">
+              <p className="text-sm font-black text-white">{date.getUTCDate()}</p>
+              <p className="mt-2 text-xs font-black text-[#F0D98A]">{ot.dayOrder}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-300">{ot.otDate}</p>
+              <p className="mt-2 text-[0.65rem] uppercase tracking-[0.16em] text-slate-500">{ot.monthTheme}</p>
+            </article>
+          );
+        })}
+      </div>
+
+      <p className="mt-4 text-xs leading-5 text-slate-400">
+        Civil week headers remain Gregorian Sunday–Saturday for alignment with standard monthly grids. OTS day order does not use Date.getDay(); it advances from the OTS epoch with deltaDays % 7 so Skénra is Epoch Day 1.
+      </p>
+    </section>
+  );
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -7,6 +7,7 @@ export const navigation = [
   { label: 'Belief Mapper', href: '/belief-mapper' },
   { label: 'System Prompt', href: '/system-prompt' },
   { label: 'Docs', href: '/docs' },
+  { label: 'Calendar', href: '/calendar' },
   { label: 'Status', href: '/status' }
 ];
 export const openAppUrl = 'https://app.onegodian.com/omos';

--- a/src/lib/ots-calendar.ts
+++ b/src/lib/ots-calendar.ts
@@ -1,0 +1,72 @@
+export const OG_DAYS = [
+  'Skénra',
+  'Auren',
+  'Veyra',
+  'Thalen',
+  'Omira',
+  'Kael',
+  'Solun'
+] as const;
+
+export const OG_MONTHS = [
+  { name: 'Auralis', theme: 'Alignment' },
+  { name: 'Brennar', theme: 'Foundation' },
+  { name: 'Caelora', theme: 'Clarity' },
+  { name: 'Deymar', theme: 'Discipline' },
+  { name: 'Elyth', theme: 'Growth' },
+  { name: 'Faelion', theme: 'Service' },
+  { name: 'Galdra', theme: 'Wisdom' },
+  { name: 'Hesper', theme: 'Stewardship' },
+  { name: 'Ilyra', theme: 'Renewal' },
+  { name: 'Jorren', theme: 'Creation' },
+  { name: 'Kaelith', theme: 'Community' },
+  { name: 'Lumora', theme: 'Completion' }
+] as const;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const OTS_EPOCH_UTC = Date.UTC(2026, 0, 1);
+const DAYS_PER_OT_MONTH = 30;
+const DAYS_PER_OT_YEAR = OG_MONTHS.length * DAYS_PER_OT_MONTH;
+
+export type OTDate = {
+  valid: boolean;
+  otYear: number;
+  otMonth: string;
+  otDay: number;
+  otDate: string;
+  dayOrder: (typeof OG_DAYS)[number];
+  monthTheme: string;
+};
+
+export function getOTDate(input = new Date()): OTDate {
+  const utcDateOnly = Date.UTC(input.getUTCFullYear(), input.getUTCMonth(), input.getUTCDate());
+  const deltaDays = Math.floor((utcDateOnly - OTS_EPOCH_UTC) / DAY_MS);
+  const normalizedDays = ((deltaDays % DAYS_PER_OT_YEAR) + DAYS_PER_OT_YEAR) % DAYS_PER_OT_YEAR;
+  const otYear = Math.floor(deltaDays / DAYS_PER_OT_YEAR) + 1;
+  const monthIndex = Math.floor(normalizedDays / DAYS_PER_OT_MONTH);
+  const otDay = (normalizedDays % DAYS_PER_OT_MONTH) + 1;
+  // OTS day order is an internal epoch sequence: Epoch Day 1 is Skénra,
+  // then the names continue on a fixed 7-day cycle independent of Gregorian weekdays.
+  const dayIndex = ((deltaDays % 7) + 7) % 7;
+
+  return {
+    valid: true,
+    otYear,
+    otMonth: OG_MONTHS[monthIndex].name,
+    otDay,
+    otDate: `${OG_MONTHS[monthIndex].name} ${String(otDay).padStart(2, '0')}, ${String(otYear).padStart(4, '0')} OT`,
+    dayOrder: OG_DAYS[dayIndex],
+    monthTheme: OG_MONTHS[monthIndex].theme
+  };
+}
+
+export function getCivilMonthDates(year: number, monthIndex: number) {
+  const firstDay = new Date(Date.UTC(year, monthIndex, 1));
+  const startOffset = firstDay.getUTCDay();
+  const daysInMonth = new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+
+  return Array.from({ length: startOffset + daysInMonth }, (_, index) => {
+    if (index < startOffset) return null;
+    return new Date(Date.UTC(year, monthIndex, index - startOffset + 1));
+  });
+}


### PR DESCRIPTION
### Motivation
- Correct the OTS weekday assignment so the OTS week advances from the OTS epoch (Skénra = Epoch Day 1) instead of using Gregorian `Date.getDay()` which made Skénra align to Gregorian Sunday.
- Provide a calendar UI that keeps the familiar Gregorian monthly grid for civil reference while showing the correct epoch-based OTS day labels.

### Description
- Add `src/lib/ots-calendar.ts` implementing `getOTDate()` which computes `deltaDays` from a defined OTS epoch and selects the OTS weekday with `deltaDays % 7`, plus `getCivilMonthDates()` for generating a Gregorian-aligned month grid.
- Add `src/components/OneGodianCalendar.tsx` which preserves Gregorian Sunday–Saturday headers but labels each cell with the epoch-based OTS day (`ot.dayOrder`) and OTS date, and includes comments explaining the separation between civil layout and OTS sequence.
- Add a calendar route page at `src/app/calendar/page.tsx` and wire the `Calendar` entry into top-level navigation in `src/data/navigation.ts`.
- Use type-safe shapes and formatted `otDate` strings so the component can render OTS year/month/day and month themes per cell.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors, and it succeeded.
- Ran `npm run lint` (Next.js ESLint) with no warnings or errors, and it succeeded.
- Ran `npm run build` (Next.js production build) and the site compiled and statically generated pages including the new `/calendar` route successfully.
- Ran `npm test` (project `check` which runs typecheck + lint) and it completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9d881c64832dbf163b2d884a4e85)