### PR TITLE
Package OneGodian Members v1.7.1 WooCommerce sync ZIP

### DIFF
--- a/scripts/build-onegodian-members.sh
+++ b/scripts/build-onegodian-members.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SLUG="onegodian-members"
+PLUGIN_DIR="plugins/${PLUGIN_SLUG}"
+OUTPUT_ZIP="onegodian-members-v1.7.1-woocommerce-sync.zip"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -d "$PLUGIN_DIR" ]; then
+  echo "ERROR: Plugin directory not found: $PLUGIN_DIR" >&2
+  exit 1
+fi
+
+if [ ! -f "$PLUGIN_DIR/onegodian-members.php" ]; then
+  echo "ERROR: Main plugin file not found: $PLUGIN_DIR/onegodian-members.php" >&2
+  exit 1
+fi
+
+rm -f "$OUTPUT_ZIP"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/$PLUGIN_SLUG"
+cp -R "$PLUGIN_DIR/." "$TMP_DIR/$PLUGIN_SLUG/"
+
+find "$TMP_DIR/$PLUGIN_SLUG" \
+  -name '.git' -o \
+  -name '.github' -o \
+  -name 'node_modules' -o \
+  -name 'vendor' -o \
+  -name '.DS_Store' -o \
+  -name '*.zip' -o \
+  -name '__MACOSX' \
+  | while read -r item; do rm -rf "$item"; done
+
+(
+  cd "$TMP_DIR"
+  zip -rq "$ROOT_DIR/$OUTPUT_ZIP" "$PLUGIN_SLUG"
+)
+
+unzip -t "$OUTPUT_ZIP"
+echo "Built $OUTPUT_ZIP"

--- a/scripts/verify-onegodian-members.sh
+++ b/scripts/verify-onegodian-members.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SLUG="onegodian-members"
+PLUGIN_DIR="plugins/${PLUGIN_SLUG}"
+MAIN_FILE="$PLUGIN_DIR/onegodian-members.php"
+OUTPUT_ZIP="onegodian-members-v1.7.1-woocommerce-sync.zip"
+REQUIRED_SHORTCODES=(
+  onegodian_membership_cta
+  onegodian_members_pricing
+  onegodian_membership_resources
+  onegodian_member_certificates
+  onegodian_member_dashboard
+  onegodian_member_support
+  onegodian_contributors_page
+  onegodian_contributor_tiers
+  onegodian_creator_network
+  onegodian_affiliate_dashboard
+  onegodian_referral_link
+  onegodian_contributor_wall
+  onegodian_contributor_disclaimer
+)
+REQUIRED_PRODUCT_KEYS=(
+  woo_basic_member_product_id
+  woo_premium_member_product_id
+  woo_contributor_product_id
+  woo_creator_application_product_id
+  woo_affiliate_application_product_id
+)
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+[ -d "$PLUGIN_DIR" ] || fail "Plugin directory missing: $PLUGIN_DIR"
+[ -f "$MAIN_FILE" ] || fail "Main plugin file missing: $MAIN_FILE"
+
+grep -q "Plugin Name: OneGodian Members" "$MAIN_FILE" || fail "Plugin Name header missing or incorrect"
+grep -q "Version: 1.7.1" "$MAIN_FILE" || fail "Plugin header version is not 1.7.1"
+if ! grep -Eq "(OGM_VERSION|const VERSION)[[:space:]=']+.*1\.7\.1" "$MAIN_FILE"; then
+  fail "Runtime version constant/equivalent is not 1.7.1"
+fi
+
+if command -v php >/dev/null 2>&1; then
+  find "$PLUGIN_DIR" -type f -name '*.php' -print0 | xargs -0 -n 1 php -l >/dev/null
+  echo "PHP syntax check passed."
+else
+  echo "php not available; skipping PHP syntax check."
+fi
+
+if grep -R "Stripe is not configured" "$PLUGIN_DIR" >/dev/null 2>&1; then
+  fail "Public Stripe not-configured error still exists"
+fi
+
+for shortcode in "${REQUIRED_SHORTCODES[@]}"; do
+  grep -R "$shortcode" "$PLUGIN_DIR" >/dev/null 2>&1 || fail "Missing shortcode: $shortcode"
+done
+
+for key in "${REQUIRED_PRODUCT_KEYS[@]}"; do
+  grep -R "$key" "$PLUGIN_DIR" >/dev/null 2>&1 || fail "Missing WooCommerce product mapping key: $key"
+done
+
+grep -R "add-to-cart" "$PLUGIN_DIR" >/dev/null 2>&1 || fail "WooCommerce add-to-cart routing not found"
+grep -R "Payments are handled through WooCommerce checkout" "$PLUGIN_DIR" >/dev/null 2>&1 || fail "WooCommerce admin notice not found"
+
+if [ -f "$OUTPUT_ZIP" ]; then
+  unzip -t "$OUTPUT_ZIP" >/dev/null
+  TOP_LEVELS="$(zipinfo -1 "$OUTPUT_ZIP" | awk -F/ 'NF {print $1}' | sort -u)"
+  [ "$TOP_LEVELS" = "$PLUGIN_SLUG" ] || fail "ZIP must contain exactly one top-level folder: $PLUGIN_SLUG/; found: $TOP_LEVELS"
+  zipinfo -1 "$OUTPUT_ZIP" | grep -q "^${PLUGIN_SLUG}/onegodian-members.php$" || fail "ZIP missing main plugin file"
+  echo "ZIP verification passed: $OUTPUT_ZIP"
+else
+  echo "ZIP not found yet; source verification passed."
+fi
+
+echo "OneGodian Members verification passed."


### PR DESCRIPTION
## Summary

Implements Issue #336 packaging support for OneGodian Members v1.7.1.

Added:
- `scripts/build-onegodian-members.sh`
- `scripts/verify-onegodian-members.sh`

The build script packages `plugins/onegodian-members/` into:

`onegodian-members-v1.7.1-woocommerce-sync.zip`

The verification script checks:
- plugin directory and main file
- `Plugin Name: OneGodian Members`
- `Version: 1.7.1`
- runtime version constant/equivalent is `1.7.1`
- PHP syntax on all plugin PHP files when PHP is available
- no public `Stripe is not configured` message remains
- all required member and contributor/affiliate shortcodes exist
- WooCommerce product mapping keys exist
- WooCommerce add-to-cart routing exists
- ZIP has one top-level folder: `onegodian-members/`
- `unzip -t` passes when ZIP is present

## Notes

I attempted to add a GitHub Actions artifact workflow as part of this packaging task, but that write was blocked by the connector safety policy for workflow-file creation. The build and verify scripts are committed so the ZIP can be generated locally or by Codex with:

```bash
chmod +x scripts/build-onegodian-members.sh scripts/verify-onegodian-members.sh
./scripts/verify-onegodian-members.sh
./scripts/build-onegodian-members.sh
./scripts/verify-onegodian-members.sh
```

Closes #336.