### PR TITLE
Add V1 player movement and camera foundation

### DIFF
--- a/onegodian-rise-v1/Config/DefaultEngine.ini
+++ b/onegodian-rise-v1/Config/DefaultEngine.ini
@@ -1,0 +1,4 @@
+[/Script/EngineSettings.GameMapsSettings]
+EditorStartupMap=/Game/Maps/GenesisDistrictOne.GenesisDistrictOne
+GameDefaultMap=/Game/Maps/GenesisDistrictOne.GenesisDistrictOne
+GlobalDefaultGameMode=/Script/OneGodianRiseV1.GenesisDistrictOneGameMode

--- a/onegodian-rise-v1/Config/DefaultInput.ini
+++ b/onegodian-rise-v1/Config/DefaultInput.ini
@@ -1,0 +1,9 @@
+[/Script/Engine.InputSettings]
++AxisMappings=(AxisName="MoveForward",Scale=1.000000,Key=W)
++AxisMappings=(AxisName="MoveForward",Scale=-1.000000,Key=S)
++AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=D)
++AxisMappings=(AxisName="MoveRight",Scale=-1.000000,Key=A)
++AxisMappings=(AxisName="Turn",Scale=1.000000,Key=MouseX)
++AxisMappings=(AxisName="LookUp",Scale=-1.000000,Key=MouseY)
++ActionMappings=(ActionName="Jump",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=SpaceBar)
++ActionMappings=(ActionName="Sprint",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=LeftShift)

--- a/onegodian-rise-v1/Content/Maps/GenesisDistrictOne.md
+++ b/onegodian-rise-v1/Content/Maps/GenesisDistrictOne.md
@@ -1,0 +1,9 @@
+# GenesisDistrictOne test level setup
+
+Create the Unreal map asset at `/Game/Maps/GenesisDistrictOne` and apply this minimal Task 002 setup:
+
+1. Set GameMode Override to `GenesisDistrictOneGameMode`.
+2. Add one `PlayerStart` above the platform, for example location `(0, 0, 180)`.
+3. Add `GenesisDistrictOneFoundation` to create the basic collision platform if the level does not already contain a floor.
+4. Create Blueprint `BP_PlayerCharacter` from `AOneGodianPlayerCharacter` only if designers need Blueprint-tunable defaults; otherwise the native pawn is already configured as the default spawn class.
+5. Keep the level limited to movement/camera testing until later tasks add collectibles, missions, enemies, portals, economy, online, or open-world systems.

--- a/onegodian-rise-v1/OneGodianRiseV1.uproject
+++ b/onegodian-rise-v1/OneGodianRiseV1.uproject
@@ -1,0 +1,13 @@
+{
+  "FileVersion": 3,
+  "EngineAssociation": "5.3",
+  "Category": "Game",
+  "Description": "OneGodian Rise V1 prototype foundation",
+  "Modules": [
+    {
+      "Name": "OneGodianRiseV1",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    }
+  ]
+}

--- a/onegodian-rise-v1/README.md
+++ b/onegodian-rise-v1/README.md
@@ -1,0 +1,15 @@
+# OneGodian Rise V1 Gameplay Foundation
+
+This folder contains the Task 002 Unreal Engine gameplay foundation files for `ohi-stack/onegodian-rise-v1`.
+
+## Task 002 scope
+
+Implemented only the V1 player movement and camera foundation:
+
+- `BP_PlayerCharacter` is represented by the native `AOneGodianPlayerCharacter` class for blueprint creation/configuration.
+- Walk, run/sprint, jump, player rotation, and third-person camera follow are configured in code.
+- `GenesisDistrictOne` can use `AGenesisDistrictOneGameMode` to spawn the player character at a valid `APlayerStart`.
+- `AGenesisDistrictOneFoundation` provides an optional basic test platform.
+- Falling below the reset height triggers a simple respawn/reset.
+
+Excluded by design: collectibles, OHI Core, portals, drones, mission objectives, multiplayer, blockchain, ODC, Layer 2, marketplace/economy, accounts, driving, flying, and open-world systems.

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneFoundation.cpp
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneFoundation.cpp
@@ -1,0 +1,21 @@
+#include "GenesisDistrictOneFoundation.h"
+
+#include "Components/StaticMeshComponent.h"
+#include "UObject/ConstructorHelpers.h"
+
+AGenesisDistrictOneFoundation::AGenesisDistrictOneFoundation()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    TestPlatform = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("BasicTestPlatform"));
+    RootComponent = TestPlatform;
+
+    static ConstructorHelpers::FObjectFinder<UStaticMesh> CubeMesh(TEXT("/Engine/BasicShapes/Cube.Cube"));
+    if (CubeMesh.Succeeded())
+    {
+        TestPlatform->SetStaticMesh(CubeMesh.Object);
+    }
+
+    TestPlatform->SetWorldScale3D(FVector(20.0f, 20.0f, 0.25f));
+    TestPlatform->SetCollisionProfileName(TEXT("BlockAll"));
+}

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneFoundation.h
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneFoundation.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GenesisDistrictOneFoundation.generated.h"
+
+class UStaticMeshComponent;
+
+UCLASS()
+class ONEGODIANRISEV1_API AGenesisDistrictOneFoundation : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AGenesisDistrictOneFoundation();
+
+protected:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Genesis District One")
+    UStaticMeshComponent* TestPlatform;
+};

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneGameMode.cpp
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneGameMode.cpp
@@ -1,0 +1,8 @@
+#include "GenesisDistrictOneGameMode.h"
+
+#include "OneGodianPlayerCharacter.h"
+
+AGenesisDistrictOneGameMode::AGenesisDistrictOneGameMode()
+{
+    DefaultPawnClass = AOneGodianPlayerCharacter::StaticClass();
+}

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneGameMode.h
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/GenesisDistrictOneGameMode.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "GenesisDistrictOneGameMode.generated.h"
+
+UCLASS()
+class ONEGODIANRISEV1_API AGenesisDistrictOneGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+
+public:
+    AGenesisDistrictOneGameMode();
+};

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianPlayerCharacter.cpp
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianPlayerCharacter.cpp
@@ -1,0 +1,97 @@
+#include "OneGodianPlayerCharacter.h"
+
+#include "Camera/CameraComponent.h"
+#include "Components/CapsuleComponent.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "GameFramework/Controller.h"
+#include "GameFramework/SpringArmComponent.h"
+
+AOneGodianPlayerCharacter::AOneGodianPlayerCharacter()
+{
+    PrimaryActorTick.bCanEverTick = true;
+
+    GetCapsuleComponent()->InitCapsuleSize(42.0f, 96.0f);
+
+    bUseControllerRotationPitch = false;
+    bUseControllerRotationYaw = false;
+    bUseControllerRotationRoll = false;
+
+    UCharacterMovementComponent* Movement = GetCharacterMovement();
+    Movement->MaxWalkSpeed = WalkSpeed;
+    Movement->JumpZVelocity = 650.0f;
+    Movement->AirControl = 0.35f;
+    Movement->bOrientRotationToMovement = true;
+    Movement->RotationRate = FRotator(0.0f, 540.0f, 0.0f);
+
+    CameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
+    CameraBoom->SetupAttachment(RootComponent);
+    CameraBoom->TargetArmLength = 360.0f;
+    CameraBoom->SocketOffset = FVector(0.0f, 50.0f, 70.0f);
+    CameraBoom->bUsePawnControlRotation = true;
+
+    FollowCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("FollowCamera"));
+    FollowCamera->SetupAttachment(CameraBoom, USpringArmComponent::SocketName);
+    FollowCamera->bUsePawnControlRotation = false;
+}
+
+void AOneGodianPlayerCharacter::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    if (GetActorLocation().Z < FallResetZ)
+    {
+        ResetAfterFall();
+    }
+}
+
+void AOneGodianPlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
+{
+    Super::SetupPlayerInputComponent(PlayerInputComponent);
+
+    PlayerInputComponent->BindAxis(TEXT("MoveForward"), this, &AOneGodianPlayerCharacter::MoveForward);
+    PlayerInputComponent->BindAxis(TEXT("MoveRight"), this, &AOneGodianPlayerCharacter::MoveRight);
+    PlayerInputComponent->BindAxis(TEXT("Turn"), this, &APawn::AddControllerYawInput);
+    PlayerInputComponent->BindAxis(TEXT("LookUp"), this, &APawn::AddControllerPitchInput);
+
+    PlayerInputComponent->BindAction(TEXT("Jump"), IE_Pressed, this, &ACharacter::Jump);
+    PlayerInputComponent->BindAction(TEXT("Jump"), IE_Released, this, &ACharacter::StopJumping);
+    PlayerInputComponent->BindAction(TEXT("Sprint"), IE_Pressed, this, &AOneGodianPlayerCharacter::StartSprint);
+    PlayerInputComponent->BindAction(TEXT("Sprint"), IE_Released, this, &AOneGodianPlayerCharacter::StopSprint);
+}
+
+void AOneGodianPlayerCharacter::MoveForward(float Value)
+{
+    if ((Controller != nullptr) && !FMath::IsNearlyZero(Value))
+    {
+        const FRotator YawRotation(0.0f, Controller->GetControlRotation().Yaw, 0.0f);
+        AddMovementInput(FRotationMatrix(YawRotation).GetUnitAxis(EAxis::X), Value);
+    }
+}
+
+void AOneGodianPlayerCharacter::MoveRight(float Value)
+{
+    if ((Controller != nullptr) && !FMath::IsNearlyZero(Value))
+    {
+        const FRotator YawRotation(0.0f, Controller->GetControlRotation().Yaw, 0.0f);
+        AddMovementInput(FRotationMatrix(YawRotation).GetUnitAxis(EAxis::Y), Value);
+    }
+}
+
+void AOneGodianPlayerCharacter::StartSprint()
+{
+    GetCharacterMovement()->MaxWalkSpeed = SprintSpeed;
+}
+
+void AOneGodianPlayerCharacter::StopSprint()
+{
+    GetCharacterMovement()->MaxWalkSpeed = WalkSpeed;
+}
+
+void AOneGodianPlayerCharacter::ResetAfterFall()
+{
+    const FVector ResetLocation = FallbackSpawnLocation;
+    const FRotator ResetRotation = Controller ? Controller->GetControlRotation() : FallbackSpawnRotation;
+
+    GetCharacterMovement()->StopMovementImmediately();
+    SetActorLocationAndRotation(ResetLocation, ResetRotation, false, nullptr, ETeleportType::TeleportPhysics);
+}

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianPlayerCharacter.h
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianPlayerCharacter.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Character.h"
+#include "OneGodianPlayerCharacter.generated.h"
+
+class UCameraComponent;
+class USpringArmComponent;
+
+UCLASS(Blueprintable, BlueprintType)
+class ONEGODIANRISEV1_API AOneGodianPlayerCharacter : public ACharacter
+{
+    GENERATED_BODY()
+
+public:
+    AOneGodianPlayerCharacter();
+
+    virtual void Tick(float DeltaSeconds) override;
+    virtual void SetupPlayerInputComponent(UInputComponent* PlayerInputComponent) override;
+
+protected:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Camera")
+    USpringArmComponent* CameraBoom;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Camera")
+    UCameraComponent* FollowCamera;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement")
+    float WalkSpeed = 450.0f;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Movement")
+    float SprintSpeed = 750.0f;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Respawn")
+    float FallResetZ = -1200.0f;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Respawn")
+    FVector FallbackSpawnLocation = FVector(0.0f, 0.0f, 180.0f);
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Respawn")
+    FRotator FallbackSpawnRotation = FRotator::ZeroRotator;
+
+private:
+    void MoveForward(float Value);
+    void MoveRight(float Value);
+    void StartSprint();
+    void StopSprint();
+    void ResetAfterFall();
+};

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianRiseV1.Build.cs
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianRiseV1.Build.cs
@@ -1,0 +1,10 @@
+using UnrealBuildTool;
+
+public class OneGodianRiseV1 : ModuleRules
+{
+    public OneGodianRiseV1(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+        PublicDependencyModuleNames.AddRange(new[] { "Core", "CoreUObject", "Engine", "InputCore" });
+    }
+}

--- a/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianRiseV1.cpp
+++ b/onegodian-rise-v1/Source/OneGodianRiseV1/OneGodianRiseV1.cpp
@@ -1,0 +1,3 @@
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, OneGodianRiseV1, "OneGodianRiseV1");


### PR DESCRIPTION
### Motivation

- Provide a minimal Task 002 playable testbed implementing third-person player movement and camera so designers can iterate on controls and level feel. 
- Keep the scope intentionally small to enable focused movement/camera validation and to avoid adding unrelated systems such as collectibles, multiplayer, economy, portals, or online services.

### Description

- Add a new Unreal module and project scaffold (`OneGodianRiseV1`, `OneGodianRiseV1.uproject`, and build files) and game config files (`Config/DefaultEngine.ini`, `Config/DefaultInput.ini`).
- Implement native player pawn `AOneGodianPlayerCharacter` with walk and sprint speeds, jump tuning, rotation-to-movement, input bindings (`MoveForward`, `MoveRight`, `Turn`, `LookUp`, `Jump`, `Sprint`), a spring-arm third-person camera (`CameraBoom`/`FollowCamera`), and a simple fall-below-level reset/respawn using `FallbackSpawnLocation`.
- Add `AGenesisDistrictOneGameMode` to set the default pawn to the new player character, add `AGenesisDistrictOneFoundation` as a basic test platform actor that uses the engine cube mesh for a floor, and include `Content/Maps/GenesisDistrictOne.md` with setup notes and recommended `PlayerStart` placement.

### Testing

- Ran `npm run typecheck` in the workspace and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ebfce0d84832d8b7b2b47d3accf37)