### PR TITLE
Build protocol docs engine

### DIFF
--- a/src/app/docs/[slug]/page.tsx
+++ b/src/app/docs/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { DocsEngine } from '@/components/docs/DocsEngine';
+import { docsBySlug, protocolDocs } from '@/data/protocol-docs';
+
+export function generateStaticParams() { return protocolDocs.map((doc) => ({ slug: doc.slug })); }
+
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
+  const doc = docsBySlug.get(params.slug);
+  if (!doc) return { title: 'Protocol Documentation' };
+  return { title: doc.title, description: doc.summary };
+}
+
+export default function Page({ params }: { params: { slug: string } }) {
+  const doc = docsBySlug.get(params.slug);
+  if (!doc) notFound();
+  return <DocsEngine doc={doc} />;
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,3 +1,28 @@
-import type { Metadata } from 'next'; import { tools } from '@/data/tools';
-export const metadata: Metadata = { title: 'Documentation Hub', description: 'OMOS route, API, module, and implementation documentation.' };
-export default function Page(){return <main className="space-y-8"><h1 className="text-5xl font-black text-white">Documentation Hub</h1><div className="grid gap-4 md:grid-cols-2">{tools.map(t=><article className="rounded-3xl border border-white/10 bg-white/[.055] p-5" key={t.href}><h2 className="font-black text-[#F0D98A]">{t.title}</h2><p className="mt-2 text-slate-300">{t.description}</p></article>)}</div></main>}
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { protocolDocs } from '@/data/protocol-docs';
+
+export const metadata: Metadata = {
+  title: 'Protocol Documentation Engine',
+  description: 'Unified OMOS protocol, algorithm, prompt, synthesis, and OTS-V5 documentation.'
+};
+
+export default function Page() {
+  return <main className="space-y-8">
+    <section className="rounded-[2rem] border border-white/10 bg-white/[.055] p-8">
+      <p className="text-xs font-black uppercase tracking-[0.24em] text-[#F0D98A]">Unified Docs Engine</p>
+      <h1 className="mt-3 text-5xl font-black text-white">Protocol Docs Engine</h1>
+      <p className="mt-4 max-w-4xl text-lg leading-8 text-slate-300">A single markdown-ready documentation system with sticky navigation, anchors, copy controls, version badges, and PDF calls to action.</p>
+    </section>
+    <div className="grid gap-4 md:grid-cols-2">
+      {protocolDocs.map((doc) => <Link className="rounded-3xl border border-white/10 bg-white/[.055] p-6 transition hover:border-[#D8B35A]/60 hover:bg-[#D8B35A]/10" href={`/docs/${doc.slug}`} key={doc.slug}>
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded-full bg-[#D8B35A]/15 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-[#F0D98A]">{doc.badge}</span>
+          <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-white">{doc.version}</span>
+        </div>
+        <h2 className="mt-4 text-2xl font-black text-white">{doc.title}</h2>
+        <p className="mt-3 text-slate-300">{doc.summary}</p>
+      </Link>)}
+    </div>
+  </main>;
+}

--- a/src/components/docs/CopyButton.tsx
+++ b/src/components/docs/CopyButton.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useState } from 'react';
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }
+
+  return <button type="button" onClick={copy} className="rounded-full border border-[#D8B35A]/40 bg-[#D8B35A]/10 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-[#F0D98A] transition hover:bg-[#D8B35A]/20">{copied ? 'Copied' : 'Copy'}</button>;
+}

--- a/src/components/docs/DocsEngine.tsx
+++ b/src/components/docs/DocsEngine.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { protocolDocs, type ProtocolDoc } from '@/data/protocol-docs';
+import { getHeadings, MarkdownRenderer } from './MarkdownRenderer';
+import { CopyButton } from './CopyButton';
+
+export function DocsEngine({ doc }: { doc: ProtocolDoc }) {
+  const headings = getHeadings(doc.markdown);
+  return <main className="grid gap-8 lg:grid-cols-[18rem_minmax(0,1fr)]">
+    <aside className="lg:sticky lg:top-28 lg:self-start">
+      <div className="rounded-[2rem] border border-white/10 bg-[#070607]/75 p-4 shadow-2xl backdrop-blur-xl">
+        <p className="px-3 text-xs font-black uppercase tracking-[0.22em] text-[#F0D98A]">Protocol Docs</p>
+        <nav className="mt-4 space-y-2">{protocolDocs.map((item) => <Link key={item.slug} href={`/docs/${item.slug}`} className={`block rounded-2xl px-3 py-3 text-sm font-bold transition ${item.slug === doc.slug ? 'bg-[#D8B35A] text-black' : 'text-slate-300 hover:bg-white/10 hover:text-white'}`}>{item.title}<span className="mt-1 block text-xs opacity-70">{item.version}</span></Link>)}</nav>
+        <div className="mt-6 border-t border-white/10 pt-4">
+          <p className="px-3 text-xs font-black uppercase tracking-[0.18em] text-slate-400">On this page</p>
+          <div className="mt-3 space-y-2">{headings.map((heading) => <a key={heading.id} href={`#${heading.id}`} className="block rounded-xl px-3 py-2 text-sm text-slate-300 hover:bg-white/10 hover:text-[#F0D98A]">{heading.text}</a>)}</div>
+        </div>
+      </div>
+    </aside>
+    <article className="min-w-0 overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 shadow-2xl md:p-10">
+      <header className="mb-8 rounded-[1.5rem] border border-[#D8B35A]/30 bg-gradient-to-br from-[#D8B35A]/15 to-white/[0.03] p-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="rounded-full border border-[#D8B35A]/50 bg-[#D8B35A]/10 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-[#F0D98A]">{doc.badge}</span>
+          <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-white">{doc.version}</span>
+        </div>
+        <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">{doc.summary}</p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <a href={doc.pdfHref} className="rounded-full bg-[#D8B35A] px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-black shadow-gold">Download PDF</a>
+          <CopyButton text={doc.markdown} />
+        </div>
+      </header>
+      <MarkdownRenderer markdown={doc.markdown} />
+    </article>
+  </main>;
+}

--- a/src/components/docs/MarkdownRenderer.tsx
+++ b/src/components/docs/MarkdownRenderer.tsx
@@ -1,0 +1,64 @@
+import { CopyButton } from './CopyButton';
+
+type Block = { type: 'heading'; depth: number; text: string } | { type: 'paragraph'; text: string } | { type: 'list'; items: string[]; ordered: boolean } | { type: 'code'; code: string; language: string };
+
+export function slugify(value: string) { return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''); }
+
+export function getHeadings(markdown: string) {
+  return markdown.split('\n').filter((line) => /^#{2,3}\s/.test(line)).map((line) => {
+    const text = line.replace(/^#{2,3}\s/, '').trim();
+    return { id: slugify(text), text };
+  });
+}
+
+function parseMarkdown(markdown: string): Block[] {
+  const lines = markdown.split('\n');
+  const blocks: Block[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    if (line.startsWith('```')) {
+      const language = line.replace('```', '').trim();
+      const code: string[] = [];
+      index += 1;
+      while (index < lines.length && !lines[index].startsWith('```')) { code.push(lines[index]); index += 1; }
+      blocks.push({ type: 'code', code: code.join('\n'), language });
+    } else if (/^#{1,3}\s/.test(line)) {
+      const depth = line.match(/^#+/)?.[0].length ?? 1;
+      blocks.push({ type: 'heading', depth, text: line.replace(/^#{1,3}\s/, '').trim() });
+    } else if (/^[-*]\s/.test(line) || /^\d+\.\s/.test(line)) {
+      const ordered = /^\d+\.\s/.test(line);
+      const items = [line.replace(/^([-*]|\d+\.)\s/, '')];
+      while (index + 1 < lines.length && (ordered ? /^\d+\.\s/.test(lines[index + 1]) : /^[-*]\s/.test(lines[index + 1]))) {
+        index += 1;
+        items.push(lines[index].replace(/^([-*]|\d+\.)\s/, ''));
+      }
+      blocks.push({ type: 'list', ordered, items });
+    } else {
+      const text = [line.trim()];
+      while (index + 1 < lines.length && lines[index + 1].trim() && !/^#{1,3}\s/.test(lines[index + 1]) && !/^[-*]\s/.test(lines[index + 1]) && !/^\d+\.\s/.test(lines[index + 1]) && !lines[index + 1].startsWith('```')) {
+        index += 1;
+        text.push(lines[index].trim());
+      }
+      blocks.push({ type: 'paragraph', text: text.join(' ') });
+    }
+  }
+  return blocks;
+}
+
+export function MarkdownRenderer({ markdown }: { markdown: string }) {
+  return <div className="space-y-6">{parseMarkdown(markdown).map((block, index) => {
+    if (block.type === 'heading') {
+      const Tag = block.depth === 1 ? 'h1' : block.depth === 2 ? 'h2' : 'h3';
+      const id = slugify(block.text);
+      const classes = block.depth === 1 ? 'text-4xl font-black text-white md:text-6xl' : block.depth === 2 ? 'scroll-mt-28 border-t border-white/10 pt-8 text-3xl font-black text-white' : 'scroll-mt-28 text-2xl font-black text-[#F0D98A]';
+      return <Tag id={id} key={`${id}-${index}`} className={classes}><a href={`#${id}`} className="hover:text-[#F0D98A]">{block.text}</a></Tag>;
+    }
+    if (block.type === 'list') {
+      const List = block.ordered ? 'ol' : 'ul';
+      return <List key={index} className={`space-y-3 text-slate-300 ${block.ordered ? 'list-decimal' : 'list-disc'} pl-6`}>{block.items.map((item) => <li key={item} className="pl-2 leading-7">{item}</li>)}</List>;
+    }
+    if (block.type === 'code') return <div key={index} className="overflow-hidden rounded-3xl border border-[#D8B35A]/30 bg-black/50"><div className="flex items-center justify-between border-b border-white/10 px-4 py-3 text-xs uppercase tracking-[0.18em] text-slate-400"><span>{block.language || 'code'}</span><CopyButton text={block.code} /></div><pre className="overflow-x-auto p-5 text-sm leading-7 text-[#F0D98A]"><code>{block.code}</code></pre></div>;
+    return <p key={index} className="text-lg leading-8 text-slate-300">{block.text}</p>;
+  })}</div>;
+}

--- a/src/data/protocol-docs.ts
+++ b/src/data/protocol-docs.ts
@@ -1,0 +1,171 @@
+export type ProtocolDoc = {
+  slug: string;
+  title: string;
+  badge: string;
+  version: string;
+  summary: string;
+  pdfHref: string;
+  markdown: string;
+};
+
+export const protocolDocs: ProtocolDoc[] = [
+  {
+    slug: 'protocol',
+    title: 'The OneGodian Protocol™',
+    badge: 'Protocol Canon',
+    version: 'v1.0',
+    summary: 'A neutral interaction standard for human, semantic, agent, and interface layers.',
+    pdfHref: '/docs/protocol?format=pdf',
+    markdown: `# The OneGodian Protocol™
+
+The OneGodian Protocol™ defines a recognition and interaction framework for identity, semantic systems, AI agents, interfaces, and implementation environments.
+
+## Operating purpose
+
+The protocol establishes shared boundaries for safe system participation without asserting universal authority, denominational control, or exclusive religious interpretation.
+
+## Layer model
+
+- Human Layer: protects user dignity, agency, and consent.
+- Semantic Layer: keeps labels, meanings, and definitions traceable.
+- Agent Layer: instructs AI and automation systems to preserve safety and clarity.
+- Interface Layer: turns protocol rules into visible user experience patterns.
+
+## Implementation boundaries
+
+Every implementation must support non-denominational neutrality, respectful interaction, compliance-first behavior, and clear disclosure of scope.
+
+## System rule
+
+If protocol language is ambiguous, choose the interpretation that maximizes human safety, consent, transparency, and auditability.`
+  },
+  {
+    slug: 'algorithm',
+    title: 'The OneGodian Algorithm™',
+    badge: 'Alignment Logic',
+    version: 'v1.0',
+    summary: 'A repeatable Observe → Distill → Align → Select → Execute → Verify decision cycle.',
+    pdfHref: '/docs/algorithm?format=pdf',
+    markdown: `# The OneGodian Algorithm™
+
+The OneGodian Algorithm™ is an alignment method for turning observations into verified action.
+
+## Decision cycle
+
+1. Observe: collect context without premature judgment.
+2. Distill: reduce noise into the essential signal.
+3. Align: compare the signal to protocol, purpose, and constraints.
+4. Select: choose the safest viable path.
+5. Execute: perform the action with traceable intent.
+6. Verify: review outcome, evidence, and residual risk.
+
+## Alignment layers
+
+- Protocol Layer
+- Experience Layer
+- Community Layer
+- Orientation Layer
+
+## Decision rule
+
+Prefer the path that preserves dignity, increases coherence, reduces avoidable harm, and remains verifiable by future operators.
+
+## Future imports
+
+Markdown source can be replaced with file-backed content while retaining the same rendering engine, navigation shell, and metadata contract.`
+  },
+  {
+    slug: 'system-prompt',
+    title: 'System Prompt Architecture',
+    badge: 'Prompt Standard',
+    version: 'v1.0',
+    summary: 'A prompt composition guide for OMOS-aligned assistants, agents, and interfaces.',
+    pdfHref: '/docs/system-prompt?format=pdf',
+    markdown: `# System Prompt Architecture
+
+The OMOS system prompt standard converts protocol and algorithm rules into operational instructions for AI agents.
+
+## Prompt hierarchy
+
+- Identity: state the role and operating scope.
+- Protocol: declare safety, neutrality, and compliance constraints.
+- Algorithm: define the reasoning cycle used to transform inputs into outputs.
+- Interface: specify response shape, citations, and user-facing behaviors.
+
+## Required behaviors
+
+Agents must avoid universal authority claims, preserve user autonomy, disclose uncertainty, and escalate sensitive decisions to appropriate human or institutional review.
+
+## Copy-ready scaffold
+
+\`\`\`text
+You are an OMOS-aligned assistant. Preserve dignity, clarify scope, follow compliance constraints, and use Observe → Distill → Align → Select → Execute → Verify before producing consequential output.
+\`\`\`
+
+## Auditability
+
+Prompts should be versioned, reviewed, and mapped to the protocol documents that authorize them.`
+  },
+  {
+    slug: 'gcd-synthesis',
+    title: 'The Architecture of Algorithmic GCD Model Synthesis',
+    badge: 'Synthesis Method',
+    version: 'v1.0',
+    summary: 'A synthesis architecture for finding greatest common denominators across models and belief systems.',
+    pdfHref: '/docs/gcd-synthesis?format=pdf',
+    markdown: `# The Architecture of Algorithmic GCD Model Synthesis
+
+Algorithmic GCD Model Synthesis identifies the greatest common denominator across multiple models, belief structures, taxonomies, or institutional frameworks.
+
+## Core idea
+
+Rather than forcing total agreement, GCD synthesis extracts shared primitives that can support cooperation, translation, and interoperable reasoning.
+
+## Pipeline
+
+1. Ingest source models.
+2. Normalize terminology.
+3. Map equivalent concepts.
+4. Isolate shared primitives.
+5. Preserve meaningful differences.
+6. Synthesize an interoperable model.
+7. Validate with stakeholders and evidence.
+
+## Output qualities
+
+A valid synthesis is minimal, explainable, reversible, and useful for future decisions.
+
+## OMOS use
+
+Within OMOS, GCD synthesis supports belief mapping, institutional classification, agent alignment, and cross-framework implementation.`
+  },
+  {
+    slug: 'ots-v5',
+    title: 'OTS-V5',
+    badge: 'Time Standard',
+    version: 'v5.0',
+    summary: 'The epoch-based OTS calendar reference used by OMOS interface and calendar views.',
+    pdfHref: '/docs/ots-v5?format=pdf',
+    markdown: `# OTS-V5
+
+OTS-V5 is the OneGodian time-system reference used to label calendar views with an epoch-based day order.
+
+## Epoch
+
+The OTS epoch begins on January 1, 2026 UTC. Day order advances from the epoch rather than from the Gregorian weekday function.
+
+## Interface rule
+
+Public calendars may preserve Gregorian civil month grids for recognition while adding OTS labels for internal sequence, epoch day, and system context.
+
+## Day-order behavior
+
+OTS day order is calculated from the epoch delta. This keeps the system stable across interface implementations and avoids dependency on local weekday assumptions.
+
+## Implementation note
+
+OTS-V5 documentation should remain importable as markdown so calendar, API, and agent references can share one canonical source.`
+  }
+];
+
+export const docsBySlug = new Map(protocolDocs.map((doc) => [doc.slug, doc]));


### PR DESCRIPTION
### Motivation
- Provide a unified, markdown-driven documentation system for The OneGodian Protocol™, The OneGodian Algorithm™, System Prompt Architecture, Algorithmic GCD Model Synthesis, and OTS-V5 under `/docs`.
- Deliver a reusable docs engine with a sticky sidebar, section anchors, copy controls, dark OMOS theme styling, PDF download CTA, and version badges.
- Make future file-backed markdown imports and static routing straightforward via a single structured data source and rendering engine.

### Description
- Added `src/data/protocol-docs.ts` which defines the `ProtocolDoc` type, the `protocolDocs` array with inlined markdown, and a `docsBySlug` map for fast lookup.
- Implemented a lightweight markdown pipeline and UI components: `src/components/docs/MarkdownRenderer.tsx` (parser + renderer with anchors and code-block copy), `src/components/docs/CopyButton.tsx`, and `src/components/docs/DocsEngine.tsx` (sticky navigation, headings list, version badges, and PDF/Copy CTAs).
- Added a dynamic route `src/app/docs/[slug]/page.tsx` that exposes `generateStaticParams` and `generateMetadata` and renders pages via the shared `DocsEngine`, and replaced `src/app/docs/page.tsx` with a docs-engine index linking to each slug.
- Preserved OMOS visual language and accessibility considerations while supporting headings, paragraphs, ordered/unordered lists, fenced code blocks, anchorable headings, and copy actions for full document and code snippets.

### Testing
- Ran `npm run check` which executes `tsc --noEmit` and `next lint`, and it completed successfully with no ESLint warnings.
- Type checking passed for the new files and the project build-time checks returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d62115fc832d8a2573048955a00c)