### PR TITLE
Add /learning Learning Academy pages and redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,20 @@ const securityHeaders = [
 
 const nextConfig = {
   poweredByHeader: false,
+  async redirects() {
+    return [
+      {
+        source: '/academy',
+        destination: '/learning',
+        permanent: true
+      },
+      {
+        source: '/university',
+        destination: '/learning',
+        permanent: true
+      }
+    ];
+  },
   async headers() {
     return [
       { source: '/:path*', headers: securityHeaders },

--- a/src/app/learning/certificates/page.tsx
+++ b/src/app/learning/certificates/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
+
+export const metadata = { title: 'Learning Certificates | OneGodian App' };
+
+export default function Page() {
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Learning Academy" title="Certificate summary" description="Review certificate pathway summaries in the app, with canonical certificate records and academic completion flows maintained by the University LMS." />
+      <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6">
+        <Link href="https://u.onegodian.org/my-certificates" className="inline-flex rounded-full border border-amber-200/50 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950">Open LMS certificates</Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/learning/courses/page.tsx
+++ b/src/app/learning/courses/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
+
+export const metadata = { title: 'Learning Courses | OneGodian App' };
+
+export default function Page() {
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Learning Academy" title="App-facing course directory" description="Browse course discovery inside the OneGodian App, then continue to the canonical University LMS catalog for enrollment and academic delivery." />
+      <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6">
+        <Link href="https://u.onegodian.org/courses" className="inline-flex rounded-full border border-amber-200/50 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950">Open canonical LMS catalog</Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/learning/my-courses/page.tsx
+++ b/src/app/learning/my-courses/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
+
+export const metadata = { title: 'My Learning Courses | OneGodian App' };
+
+export default function Page() {
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Learning Academy" title="My courses" description="Authenticated learners can review active course access here and continue into the LMS dashboard for lessons, cohorts, live classes, and assessments." />
+      <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6">
+        <Link href="https://u.onegodian.org/dashboard" className="inline-flex rounded-full border border-amber-200/50 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950">Open LMS dashboard</Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -1,6 +1,136 @@
 import Link from 'next/link';
-import { ConsolePage } from '@/components/ConsolePage';
+import { PageHeader } from '@/components/PageHeader';
+
+const lmsBaseUrl = 'https://u.onegodian.org';
+
+const schools = [
+  'School of OneGodian Foundations',
+  'School of Metaphysical Operating Systems',
+  'School of Creator, Contributor, and Affiliate Development',
+  'School of Certificates, Protocols, and Applied Practice'
+];
+
+const featuredCourses = [
+  { title: 'OneGodian Foundations', status: 'Open enrollment', href: `${lmsBaseUrl}/courses` },
+  { title: 'OMOS Protocol Orientation', status: 'Current cohort', href: `${lmsBaseUrl}/courses` },
+  { title: 'Contributor Readiness Pathway', status: 'Featured pathway', href: `${lmsBaseUrl}/courses` }
+];
+
+const appLinks = [
+  { label: 'Course directory', href: '/learning/courses' },
+  { label: 'My courses', href: '/learning/my-courses' },
+  { label: 'Progress', href: '/learning/progress' },
+  { label: 'Certificates', href: '/learning/certificates' }
+];
+
+const lmsLinks = [
+  { label: 'Canonical course catalog', href: `${lmsBaseUrl}/courses` },
+  { label: 'Student dashboard', href: `${lmsBaseUrl}/dashboard` },
+  { label: 'Live classes', href: `${lmsBaseUrl}/live-classes` },
+  { label: 'Register for the LMS', href: `${lmsBaseUrl}/register` }
+];
+
+export const metadata = {
+  title: 'Learning Academy | OneGodian App',
+  description: 'Learning Academy overview for University of OneGodian pathways, courses, certificates, enrollment status, and LMS access.'
+};
 
 export default function Page() {
-  return <ConsolePage href="/learning">Learning connects members and visitors to education, resources, documentation, and community pathways on <Link href="https://onegodian.org" className="font-black text-amber-100">OneGodian.org</Link>.</ConsolePage>;
+  return (
+    <main className="space-y-8">
+      <PageHeader
+        eyebrow="Learning Academy"
+        title="University of OneGodian learning hub"
+        description="Use this OneGodian App entry point to review schools, featured courses, progress, certificates, and enrollment status before continuing into the canonical University LMS."
+      />
+
+      <section className="grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
+        <article className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 shadow-2xl shadow-black/20 backdrop-blur">
+          <p className="text-xs font-black uppercase tracking-[0.22em] text-amber-200">University introduction</p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight text-white">One Academy. Canonical LMS delivery.</h2>
+          <p className="mt-4 leading-8 text-slate-300">
+            The Learning Academy organizes University of OneGodian discovery inside the OneGodian App, while academic delivery, course access,
+            live classes, certificates, login, and registration remain canonical on the University LMS domain.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            {lmsLinks.slice(0, 2).map((link) => (
+              <Link key={link.href} href={link.href} className="rounded-full border border-amber-200/50 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950 transition hover:-translate-y-0.5 hover:bg-amber-100">
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </article>
+
+        <aside className="rounded-[2rem] border border-emerald-300/20 bg-emerald-300/[0.08] p-6 shadow-2xl shadow-black/20">
+          <p className="text-xs font-black uppercase tracking-[0.22em] text-emerald-200">Signed-in status</p>
+          <h2 className="mt-3 text-2xl font-black text-white">Learner snapshot</h2>
+          <dl className="mt-5 space-y-4 text-sm text-slate-300">
+            <div className="flex justify-between gap-4"><dt>Session state</dt><dd className="font-black text-white">Guest preview / member-ready</dd></div>
+            <div className="flex justify-between gap-4"><dt>WooCommerce enrollment</dt><dd className="font-black text-amber-100">Connects after sign-in</dd></div>
+            <div className="flex justify-between gap-4"><dt>Active pathways</dt><dd className="font-black text-white">0 previewed</dd></div>
+            <div className="flex justify-between gap-4"><dt>Certificates</dt><dd className="font-black text-white">Summary available</dd></div>
+          </dl>
+          <Link href={`${lmsBaseUrl}/login`} className="mt-6 inline-flex rounded-full border border-white/15 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-white transition hover:border-amber-200/60 hover:text-amber-100">
+            Sign in to LMS
+          </Link>
+        </aside>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {appLinks.map((link) => (
+          <Link key={link.href} href={link.href} className="rounded-3xl border border-white/10 bg-white/[0.055] p-5 text-white shadow-2xl shadow-black/20 transition hover:-translate-y-1 hover:border-amber-300/45 hover:bg-white/[0.08]">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-amber-200">App route</span>
+            <span className="mt-3 block text-xl font-black">{link.label}</span>
+          </Link>
+        ))}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <article className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 lg:col-span-1">
+          <h2 className="text-2xl font-black text-white">School directory</h2>
+          <ul className="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+            {schools.map((school) => <li key={school} className="rounded-2xl border border-white/10 bg-black/15 p-4">{school}</li>)}
+          </ul>
+        </article>
+
+        <article className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 lg:col-span-2">
+          <h2 className="text-2xl font-black text-white">Featured and current courses</h2>
+          <div className="mt-5 grid gap-4 md:grid-cols-3">
+            {featuredCourses.map((course) => (
+              <Link key={course.title} href={course.href} className="rounded-2xl border border-white/10 bg-black/15 p-4 transition hover:border-amber-200/60">
+                <span className="text-xs font-black uppercase tracking-[0.16em] text-amber-200">{course.status}</span>
+                <span className="mt-3 block text-lg font-black text-white">{course.title}</span>
+              </Link>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-6">
+          <h2 className="text-xl font-black text-white">Continue Learning</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">Signed-in learners can resume active courses from the LMS dashboard and return here for app-level navigation.</p>
+        </article>
+        <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-6">
+          <h2 className="text-xl font-black text-white">Certificate pathways</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">Certificate summaries appear in the app, with official records and academic completion flows maintained by the LMS.</p>
+        </article>
+        <article className="rounded-3xl border border-white/10 bg-white/[0.055] p-6">
+          <h2 className="text-xl font-black text-white">Progress and achievements</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">Progress cards summarize learner movement across schools, enrollments, live classes, and certificate milestones.</p>
+        </article>
+      </section>
+
+      <section className="rounded-[2rem] border border-amber-200/20 bg-amber-200/[0.08] p-6">
+        <h2 className="text-2xl font-black text-white">Canonical University LMS routes</h2>
+        <div className="mt-5 flex flex-wrap gap-3">
+          {lmsLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="rounded-full border border-amber-200/40 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-amber-100 transition hover:bg-amber-200 hover:text-slate-950">
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/src/app/learning/progress/page.tsx
+++ b/src/app/learning/progress/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
+
+export const metadata = { title: 'Learning Progress | OneGodian App' };
+
+export default function Page() {
+  return (
+    <main className="space-y-6">
+      <PageHeader eyebrow="Learning Academy" title="Progress and achievements" description="Track learner progress summaries in the app while official academic progress remains managed by the University LMS." />
+      <section className="rounded-[2rem] border border-white/10 bg-white/[0.055] p-6">
+        <Link href="https://u.onegodian.org/dashboard" className="inline-flex rounded-full border border-amber-200/50 bg-amber-200 px-5 py-3 text-xs font-black uppercase tracking-[0.16em] text-slate-950">Review LMS progress</Link>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a proper `/learning` entry point in the OneGodian App to avoid Next.js 404s and surface app-level discovery while preserving canonical LMS delivery on `https://u.onegodian.org`.
- Ensure legacy links continue to work by mapping older routes to the new `/learning` location.

### Description
- Implemented a new App Router overview page at `src/app/learning/page.tsx` that includes University introduction, school directory, featured courses, continue-learning messaging, certificate pathways, learner snapshot (signed-in/signed-out state and WooCommerce enrollment note), and buttons linking to the canonical LMS.
- Added app-facing child routes `src/app/learning/courses/page.tsx`, `src/app/learning/my-courses/page.tsx`, `src/app/learning/progress/page.tsx`, and `src/app/learning/certificates/page.tsx` which surface app navigation and link into the LMS for enrollment and academic delivery.
- Added permanent redirects in `next.config.js` to route `/academy` and `/university` to `/learning` for compatibility with older links.
- Kept pages lightweight and focused on app-level discovery with clear calls-to-action to the canonical LMS for enrollment, dashboard, live classes, and certificates.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run lint` and there were no ESLint warnings or errors.
- Ran `npm run build` (Next.js production build) which completed successfully and shows the new `/learning` and child routes were generated as static app routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539c585228832dbfcca70009de8fc9)